### PR TITLE
Dataclasses implementation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - [x] Add traits
 - [x] Add string interpolation
 - [x] Add multiple value return without having to make structs
+- [x] Dataclasses (implicit constructors)
 - [ ] Add optional types
 - [x] Add dictionaries
 - [ ] Add lambda functions

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -89,6 +89,8 @@ class Codegen final : public ASTVisitor {
   std::unordered_map<std::string, std::string> importAliasToModulePath;
   std::unordered_map<std::string, llvm::StructType*> listStructTypes;
   std::vector<std::tuple<lesma::Value*, const FuncDecl*, Value*>> prototypes;
+  /** Class AST + constructor symbol for default `new` bodies (no FuncDecl). */
+  std::vector<std::pair<lesma::Value*, const Class*>> syntheticConstructorBodies;
   std::unordered_map<std::string, const FuncDecl*> genericFunctions;
   std::unordered_map<std::string, std::unordered_map<std::string, const FuncDecl*>> genericMethods;
   std::unordered_map<std::string, const Class*> genericClasses;
@@ -271,6 +273,9 @@ protected:
                         const std::vector<lesma::Type*>& explicitTypeArgs = {})
       -> std::unique_ptr<lesma::Value>;
   auto defineFunction(lesma::Value* value, const FuncDecl* node, Value* clsSymbol) -> void;
+  auto declareSynthesizedClassConstructor(const Class* astNode, lesma::Type* classType,
+                                          lesma::Value* classStructSym) -> lesma::Value*;
+  auto defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Class* astNode) -> void;
   auto computeGenericFunctionBindingEnv(const FuncDecl* node,
                                         const std::vector<lesma::Type*>& paramTypes,
                                         const std::vector<std::string>& genericNames,

--- a/src/liblesma/Backend/CodegenPipeline.cpp
+++ b/src/liblesma/Backend/CodegenPipeline.cpp
@@ -650,6 +650,27 @@ auto Codegen::run() -> void {
     currentGenericTypes = std::move(savedGenerics);
   }
 
+  for (size_t si = 0; si < syntheticConstructorBodies.size(); ++si) {
+    lesma::Value* ctorSym = syntheticConstructorBodies[si].first;
+    const Class* cls = syntheticConstructorBodies[si].second;
+    auto savedGenerics = currentGenericTypes;
+    if (auto env = specializationEnvs.find(ctorSym); env != specializationEnvs.end()) {
+      currentGenericTypes = env->second;
+    } else {
+      auto fields = ctorSym->getType()->getFields();
+      if (!fields.empty() && fields.front()->type != nullptr &&
+          fields.front()->type->is(BaseType::TY_PTR) &&
+          fields.front()->type->getElementType() != nullptr) {
+        if (auto clsEnv = specializedClassTypeEnvs.find(fields.front()->type->getElementType());
+            clsEnv != specializedClassTypeEnvs.end()) {
+          currentGenericTypes = clsEnv->second;
+        }
+      }
+    }
+    defineSynthesizedClassConstructor(ctorSym, cls);
+    currentGenericTypes = std::move(savedGenerics);
+  }
+
   // Return 0 for top-level function (location must match topLevelFunc's DISubprogram)
   if (parser->getAst() != nullptr) {
     setDebugLoc(parser->getAst()->getSpan());

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -325,6 +325,27 @@ auto Codegen::specializeClass(const Class* node,
       }
     }
   }
+  if (!constructorEnvResolved && needsConstructorInference && constructorDecl == nullptr) {
+    std::vector<VarDecl*> requiredFields;
+    for (VarDecl* fd : node->getFields()) {
+      if (fd->getValue() == nullptr) {
+        requiredFields.push_back(fd);
+      }
+    }
+    if (constructorArgTypes.size() != requiredFields.size()) {
+      throw CodegenError(node->getSpan(),
+                         "Generic class {}: expected {} constructor argument(s) for synthesized "
+                         "constructor, got {}",
+                         node->getIdentifier(), requiredFields.size(), constructorArgTypes.size());
+    }
+    for (size_t i = 0; i < requiredFields.size(); ++i) {
+      TypeExpr* declType = requiredFields[i]->getType();
+      if (declType != nullptr) {
+        bindGenericsFromTypePair(declType, constructorArgTypes[i], genericNameSet, env);
+      }
+    }
+    constructorEnvResolved = true;
+  }
 
   for (const auto& gn : genericNames) {
     if (!env.contains(gn)) {
@@ -439,8 +460,10 @@ auto Codegen::specializeClass(const Class* node,
   selfSymbol = nullptr;
 
   if (!hasConstructor) {
-    throw CodegenError(node->getSpan(), "Generic class {} has no constructors",
-                       node->getIdentifier());
+    selfSymbol = structSymbolPtr;
+    lesma::Value* synthCtor = declareSynthesizedClassConstructor(node, typePtr, structSymbolPtr);
+    structSymbolPtr->setConstructor(synthCtor);
+    selfSymbol = nullptr;
   }
   selfSymbol = savedSelfSymbol;
   currentGenericTypes = std::move(saved);

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -68,6 +68,20 @@ LLD_HAS_DRIVER(elf)
 #include "liblesma/Token/TokenType.h"
 #include "liblesma/Typecheck/Typechecker.h"
 
+namespace {
+
+[[nodiscard]] auto makeCallableSignatureKey(const std::string& name,
+                                            const std::vector<lesma::Type*>& types)
+    -> std::string {
+  std::string key = name;
+  for (lesma::Type* type : types) {
+    key += "|" + (type != nullptr ? type->toString() : "?");
+  }
+  return key;
+}
+
+} // namespace
+
 using namespace lesma;
 
 Codegen::Codegen(std::shared_ptr<Parser> parser, std::shared_ptr<SourceMgr> srcMgr,
@@ -832,15 +846,6 @@ auto Codegen::declareSynthesizedClassConstructor(const Class* astNode, lesma::Ty
   Value* savedSelfSym = selfSymbol;
   selfSymbol = classStructSym;
 
-  auto makeCallableSignatureKey = [](const std::string& name,
-                                     const std::vector<lesma::Type*>& types) -> std::string {
-    std::string key = name;
-    for (auto* type : types) {
-      key += "|" + (type != nullptr ? type->toString() : "?");
-    }
-    return key;
-  };
-
   auto mangledName = getMangledName(astNode->getSpan(), "new", paramTypes, selfSymbol != nullptr);
   std::string signatureKey = makeCallableSignatureKey("new", paramTypes);
   if (!currentGenericTypes.empty()) {
@@ -1218,14 +1223,6 @@ auto Codegen::visit(const FuncDecl* node) -> void {
 
   auto mangledName =
       getMangledName(node->getSpan(), node->getName(), paramTypes, selfSymbol != nullptr);
-  auto makeCallableSignatureKey = [](const std::string& name,
-                                     const std::vector<lesma::Type*>& types) -> std::string {
-    std::string key = name;
-    for (auto* type : types) {
-      key += "|" + (type != nullptr ? type->toString() : "?");
-    }
-    return key;
-  };
   std::string signatureKey = makeCallableSignatureKey(node->getName(), paramTypes);
   if (!currentGenericTypes.empty()) {
     std::vector<std::string> bindingOrder;
@@ -3315,14 +3312,6 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
     -> std::unique_ptr<lesma::Value> {
   std::vector<lesma::Type*> localParamTypes = paramTypes;
   std::vector<llvm::Value*> localParamsLLVM = paramsLLVM;
-  auto makeCallableSignatureKey = [](const std::string& name,
-                                     const std::vector<lesma::Type*>& types) -> std::string {
-    std::string key = name;
-    for (auto* type : types) {
-      key += "|" + (type != nullptr ? type->toString() : "?");
-    }
-    return key;
-  };
   for (auto* explicitTypeArg : explicitTypeArgs) {
     if (explicitTypeArg != nullptr) {
       getOrCreateLlvmType(explicitTypeArg);

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -799,6 +799,300 @@ auto Codegen::buildClassMethodParamTypesForLookup(const FuncDecl* node)
   return paramTypes;
 }
 
+auto Codegen::declareSynthesizedClassConstructor(const Class* astNode, lesma::Type* classType,
+                                                 lesma::Value* classStructSym) -> lesma::Value* {
+  Type* selfPtrType =
+      cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), classType));
+  std::vector<lesma::Type*> paramTypes = {selfPtrType};
+  std::vector<std::unique_ptr<Field>> fields;
+  fields.push_back(std::make_unique<Field>("self", selfPtrType));
+  std::vector<Field*> const typeFields = classType->getFields();
+  size_t ti = 0;
+  for (VarDecl* v : astNode->getFields()) {
+    if (ti >= typeFields.size()) {
+      break;
+    }
+    Type* storageTy = typeFields[ti]->type;
+    ti++;
+    if (v->getValue() != nullptr) {
+      continue;
+    }
+    Type* paramType = storageTy;
+    if (paramType->is(BaseType::TY_CLASS)) {
+      paramType =
+          cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), paramType));
+    }
+    getOrCreateLlvmType(paramType);
+    paramTypes.push_back(paramType);
+    fields.push_back(std::make_unique<Field>(v->getIdentifier()->getValue(), paramType));
+  }
+  Type* returnType = cacheType(std::make_unique<Type>(BaseType::TY_VOID, builder->getVoidTy()));
+  getOrCreateLlvmType(returnType);
+
+  Value* savedSelfSym = selfSymbol;
+  selfSymbol = classStructSym;
+
+  auto makeCallableSignatureKey = [](const std::string& name,
+                                     const std::vector<lesma::Type*>& types) -> std::string {
+    std::string key = name;
+    for (auto* type : types) {
+      key += "|" + (type != nullptr ? type->toString() : "?");
+    }
+    return key;
+  };
+
+  auto mangledName = getMangledName(astNode->getSpan(), "new", paramTypes, selfSymbol != nullptr);
+  std::string signatureKey = makeCallableSignatureKey("new", paramTypes);
+  if (!currentGenericTypes.empty()) {
+    std::vector<std::string> bindingOrder;
+    if (selfSymbol != nullptr && selfSymbol->getType() != nullptr &&
+        selfSymbol->getType()->getElementType() != nullptr) {
+      bindingOrder = selfSymbol->getType()->getElementType()->getGenericParams();
+    }
+    if (bindingOrder.empty()) {
+      bindingOrder.reserve(currentGenericTypes.size());
+      for (const auto& kv : currentGenericTypes) {
+        bindingOrder.push_back(kv.first);
+      }
+      std::sort(bindingOrder.begin(), bindingOrder.end());
+    }
+    appendGenericBindingSuffix(astNode->getSpan(), mangledName, bindingOrder, currentGenericTypes);
+    appendGenericBindingSuffix(astNode->getSpan(), signatureKey, bindingOrder, currentGenericTypes);
+  }
+  const bool shouldExport = classStructSym->isExported();
+  auto linkage = shouldExport ? Function::ExternalLinkage : Function::PrivateLinkage;
+
+  std::vector<llvm::Type*> paramLLVMTypes;
+  for (auto* pt : paramTypes) {
+    paramLLVMTypes.push_back(pt->getLlvmType());
+  }
+  llvm::FunctionType* llvmFnTy = FunctionType::get(builder->getVoidTy(), paramLLVMTypes, false);
+  Function* f = Function::Create(llvmFnTy, linkage, mangledName, *theModule);
+  attachFunctionDebugInfo(f, "new", mangledName, astNode->getNameSpan(), linkage, false);
+  auto loweredType = std::make_unique<Type>(BaseType::TY_FUNCTION, llvmFnTy, std::move(fields));
+  loweredType->setReturnType(returnType);
+  loweredType->setVarArgs(false);
+  Type* loweredTypePtr = cacheType(std::move(loweredType));
+
+  const bool isSpecializedInstance = specializedClassSymbolsByType.contains(classType);
+
+  if (isSpecializedInstance) {
+    SymbolTable* bodyScope = scope->createChildBlock("synthetic_ctor");
+    auto selfPs = std::make_unique<Value>("self", paramTypes[0]);
+    selfPs->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+    selfPs->setDeclarationKind(ValueDeclarationKind::PARAMETER);
+    bodyScope->insertSymbol(std::move(selfPs));
+    unsigned reqIdx = 0;
+    for (VarDecl* v : astNode->getFields()) {
+      if (v->getValue() != nullptr) {
+        continue;
+      }
+      auto ps = std::make_unique<Value>(v->getIdentifier()->getValue(), paramTypes[1U + reqIdx]);
+      ps->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+      ps->setDeclarationKind(ValueDeclarationKind::PARAMETER);
+      bodyScope->insertSymbol(std::move(ps));
+      reqIdx++;
+    }
+    auto funcSymbol = std::make_unique<Value>("new", loweredTypePtr, f);
+    funcSymbol->setCategory(ValueCategory::CALLABLE_SYMBOL);
+    funcSymbol->setDeclarationKind(ValueDeclarationKind::METHOD);
+    funcSymbol->setExported(shouldExport);
+    funcSymbol->setMangledName(mangledName);
+    funcSymbol->setBodyScope(bodyScope);
+    auto* funcSymbolPtr = funcSymbol.get();
+    scope->insertSymbol(std::move(funcSymbol));
+    specializedFunctions[mangledName] = funcSymbolPtr;
+    specializedFunctions[signatureKey] = funcSymbolPtr;
+    specializationEnvs[funcSymbolPtr] = currentGenericTypes;
+    syntheticConstructorBodies.emplace_back(funcSymbolPtr, astNode);
+    selfSymbol = savedSelfSym;
+    return funcSymbolPtr;
+  }
+
+  lesma::Value* existingFunc = scope->lookupFunction("new", paramTypes);
+  if (existingFunc == nullptr) {
+    auto normalizeFunctionParamType = [](lesma::Type* type) -> lesma::Type* {
+      if (type != nullptr && type->is(BaseType::TY_PTR) && type->getElementType() != nullptr &&
+          type->getElementType()->is(BaseType::TY_CLASS)) {
+        return type->getElementType();
+      }
+      return type;
+    };
+    for (auto* candidate : scope->getSymbols()) {
+      if (candidate == nullptr || candidate->getName() != "new" ||
+          !candidate->getType()->is(BaseType::TY_FUNCTION) ||
+          candidate->getLlvmValue() != nullptr) {
+        continue;
+      }
+      auto candidateFields = candidate->getType()->getFields();
+      if (candidateFields.size() != paramTypes.size()) {
+        continue;
+      }
+      bool compatible = true;
+      for (size_t i = 0; i < candidateFields.size(); ++i) {
+        lesma::Type* formalType = normalizeFunctionParamType(candidateFields[i]->type);
+        lesma::Type* actualType = normalizeFunctionParamType(paramTypes[i]);
+        if ((formalType == nullptr) != (actualType == nullptr) ||
+            (formalType != nullptr && !formalType->isEqual(actualType))) {
+          compatible = false;
+          break;
+        }
+      }
+      if (compatible) {
+        existingFunc = candidate;
+        break;
+      }
+    }
+  }
+
+  if (existingFunc == nullptr) {
+    throw CodegenError(astNode->getSpan(),
+                       "Missing typechecked symbol for synthesized constructor");
+  }
+  existingFunc->setType(loweredTypePtr);
+  existingFunc->setLlvmValue(f);
+  existingFunc->setCategory(ValueCategory::CALLABLE_SYMBOL);
+  existingFunc->setMangledName(mangledName);
+  specializedFunctions[mangledName] = existingFunc;
+  specializedFunctions[signatureKey] = existingFunc;
+  syntheticConstructorBodies.emplace_back(existingFunc, astNode);
+  selfSymbol = savedSelfSym;
+  return existingFunc;
+}
+
+auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Class* astNode)
+    -> void {
+  SymbolTable* savedScope = scope;
+  scope = ctorSym->getBodyScope();
+  if (scope == nullptr) {
+    throw CodegenError(astNode->getSpan(), "Synthesized constructor has no body scope");
+  }
+  currentFunction = ctorSym;
+  deferStack.emplace();
+
+  if (ctorSym->getLlvmValue() == nullptr) {
+    throw CodegenError(astNode->getSpan(), "Synthesized constructor has no LLVM function");
+  }
+  auto* f = llvm::cast<Function>(ctorSym->getLlvmValue());
+
+  BasicBlock* entry = BasicBlock::Create(theModule->getContext(), "entry", f);
+  builder->SetInsertPoint(entry);
+  setDebugLoc(astNode->getSpan());
+
+  llvm::DIFile* declFile = moduleDiFile;
+  unsigned declLine = 1U;
+  if (astNode->getNameSpan().isValid() && astNode->getNameSpan().Start.isValid()) {
+    unsigned const bid = sourceManager->FindBufferContainingLoc(astNode->getNameSpan().Start);
+    if (bid != 0U) {
+      declFile = getOrCreateDiFileForBuffer(bid);
+    }
+    declLine = sourceManager->getLineAndColumn(astNode->getNameSpan().Start).first;
+  }
+
+  auto lookupInCurrentScope = [this](const std::string& name) -> Value* {
+    for (auto* symbol : scope->getSymbols()) {
+      if (symbol->getName() == name) {
+        return symbol;
+      }
+    }
+    return nullptr;
+  };
+
+  int fieldIndex = 0;
+  for (const auto& field : ctorSym->getType()->getFields()) {
+    auto* param = f->getArg(fieldIndex);
+    std::string const paramName = field->name;
+
+    param->setName(paramName);
+
+    llvm::Value* ptr = builder->CreateAlloca(param->getType(), nullptr, param->getName() + "_ptr");
+    llvm::Instruction* storeParam = builder->CreateStore(param, ptr);
+    emitParameterDebugDeclare(f, ptr, paramName, static_cast<unsigned>(fieldIndex + 1), declFile,
+                              declLine, param->getType(), storeParam);
+
+    if (auto* existingParam = lookupInCurrentScope(paramName);
+        existingParam != nullptr && existingParam->getLlvmValue() == nullptr) {
+      existingParam->setLlvmValue(ptr);
+      existingParam->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+    } else {
+      auto symbol = std::make_unique<Value>(field->name, field->type, ptr);
+      symbol->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+      scope->insertSymbol(std::move(symbol));
+    }
+
+    fieldIndex++;
+  }
+
+  Type* classType = ctorSym->getType()->getFields()[0]->type->getElementType();
+  getOrCreateLlvmType(classType);
+  auto* structTy = llvm::cast<llvm::StructType>(getOrCreateLlvmType(classType));
+  Value* selfSym = scope->lookup("self");
+  if (selfSym == nullptr) {
+    throw CodegenError(astNode->getSpan(), "Synthesized constructor missing self parameter");
+  }
+  llvm::Value* selfAlloca = selfSym->getLlvmValue();
+  llvm::Value* selfPtr = builder->CreateLoad(builder->getPtrTy(), selfAlloca, "self.ptr");
+
+  std::vector<Field*> const layoutFields = classType->getFields();
+  size_t layoutIdx = 0;
+  for (VarDecl* v : astNode->getFields()) {
+    if (layoutIdx >= layoutFields.size()) {
+      break;
+    }
+    Type* storageTy = layoutFields[layoutIdx]->type;
+    llvm::Value* slotPtr =
+        builder->CreateStructGEP(structTy, selfPtr, static_cast<unsigned>(layoutIdx),
+                                 v->getIdentifier()->getValue() + ".ptr");
+    layoutIdx++;
+    if (v->getValue() != nullptr) {
+      v->getValue()->accept(*this);
+      auto rhs = cast(v->getValue()->getSpan(), result.get(), storageTy);
+      builder->CreateStore(rhs->getLlvmValue(), slotPtr);
+    } else {
+      Value* ps = scope->lookup(v->getIdentifier()->getValue());
+      if (ps == nullptr) {
+        throw CodegenError(astNode->getSpan(), "Missing parameter for field {}",
+                           v->getIdentifier()->getValue());
+      }
+      getOrCreateLlvmType(storageTy);
+      llvm::Value* loaded =
+          builder->CreateLoad(storageTy->getLlvmType(), ps->getLlvmValue(),
+                              llvm::Twine(v->getIdentifier()->getValue()).concat(".arg"));
+      builder->CreateStore(loaded, slotPtr);
+    }
+  }
+
+  builder->CreateRetVoid();
+
+  auto instrs = deferStack.top();
+  deferStack.pop();
+
+  for (auto* inst : instrs) {
+    inst->accept(*this);
+  }
+
+  for (BasicBlock& bb : *f) {
+    Instruction* terminator = bb.getTerminator();
+    if (terminator != nullptr) {
+      continue;
+    }
+    builder->SetInsertPoint(&bb);
+    builder->CreateRetVoid();
+  }
+
+  isReturn = false;
+  std::string verifyOutput;
+  llvm::raw_string_ostream oss(verifyOutput);
+  if (llvm::verifyFunction(*f, &oss)) {
+    throw CodegenError(astNode->getSpan(), "Invalid synthesized constructor\n{}", verifyOutput);
+  }
+
+  scope = savedScope;
+  currentFunction = nullptr;
+  builder->SetInsertPoint(&topLevelFunc->back());
+  builder->SetCurrentDebugLocation(llvm::DebugLoc());
+}
+
 auto Codegen::visit(const FuncDecl* node) -> void {
   setDebugLoc(node->getSpan());
   if (!node->getGenericParams().empty()) {
@@ -1379,7 +1673,8 @@ auto Codegen::visit(const Class* node) -> void {
   }
 
   if (!hasConstructor) {
-    throw CodegenError(node->getSpan(), "Class {} has no constructors", node->getIdentifier());
+    lesma::Value* synthCtor = declareSynthesizedClassConstructor(node, type, existingStruct);
+    existingStruct->setConstructor(synthCtor);
   }
 
   selfSymbol = nullptr;
@@ -2458,14 +2753,14 @@ auto Codegen::visit(const DictLiteral* node) -> void {
 
   auto* keysListStructTy = getOrCreateListStructType(keysBufferType);
   auto* valsListStructTy = getOrCreateListStructType(valsBufferType);
-  auto* keysHeader = emitMalloc(
-      builder->getInt64(
-          theModule->getDataLayout().getTypeAllocSize(keysListStructTy).getFixedValue()),
-      "dict.keys.header");
-  auto* valsHeader = emitMalloc(
-      builder->getInt64(
-          theModule->getDataLayout().getTypeAllocSize(valsListStructTy).getFixedValue()),
-      "dict.vals.header");
+  auto* keysHeader =
+      emitMalloc(builder->getInt64(
+                     theModule->getDataLayout().getTypeAllocSize(keysListStructTy).getFixedValue()),
+                 "dict.keys.header");
+  auto* valsHeader =
+      emitMalloc(builder->getInt64(
+                     theModule->getDataLayout().getTypeAllocSize(valsListStructTy).getFixedValue()),
+                 "dict.vals.header");
 
   llvm::Value* keysDataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
   llvm::Value* valsDataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
@@ -2488,8 +2783,8 @@ auto Codegen::visit(const DictLiteral* node) -> void {
       setDebugLoc(node->getSpan());
       auto* keyPtr = builder->CreateGEP(keysElementLlvmType, keysDataPtr, builder->getInt64(i),
                                         "dict.key.elem.ptr");
-      builder->CreateStore(
-          getListStoredElementValue(keys[i]->getSpan(), result.get(), keyElemType), keyPtr);
+      builder->CreateStore(getListStoredElementValue(keys[i]->getSpan(), result.get(), keyElemType),
+                           keyPtr);
 
       values[i]->accept(*this);
       setDebugLoc(node->getSpan());
@@ -3428,19 +3723,19 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
   auto* savedSelfSymbol = selfSymbol;
   std::vector<lesma::Type*> paramTypes;
   std::vector<llvm::Value*> paramsLLVM;
-  // Typechecker Type* for a generic instance may differ from specializeClass's Type*; method symbols
-  // use the latter. Same LLVM pointer, canonical class type for signature lookup.
+  // Typechecker Type* for a generic instance may differ from specializeClass's Type*; method
+  // symbols use the latter. Same LLVM pointer, canonical class type for signature lookup.
   lesma::Value* receiverForCall = receiver;
   std::unique_ptr<lesma::Value> receiverAdapter;
-  if (receiver->getType()->is(BaseType::TY_PTR) && receiver->getType()->getElementType() != nullptr) {
+  if (receiver->getType()->is(BaseType::TY_PTR) &&
+      receiver->getType()->getElementType() != nullptr) {
     lesma::Type* elemTy = receiver->getType()->getElementType();
     if (auto it = specializedClassSymbolsByType.find(elemTy);
         it != specializedClassSymbolsByType.end()) {
       lesma::Type* specClassTy = it->second->getType();
-      lesma::Type* ptrToSpec = cacheType(
-          std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), specClassTy));
-      receiverAdapter =
-          std::make_unique<lesma::Value>("", ptrToSpec, receiver->getLlvmValue());
+      lesma::Type* ptrToSpec =
+          cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), specClassTy));
+      receiverAdapter = std::make_unique<lesma::Value>("", ptrToSpec, receiver->getLlvmValue());
       receiverForCall = receiverAdapter.get();
     }
   }

--- a/src/liblesma/Frontend/Parser.cpp
+++ b/src/liblesma/Frontend/Parser.cpp
@@ -723,9 +723,13 @@ auto Parser::parseVarDecl() -> std::unique_ptr<Statement> {
   }
 
   if (!expr && !isMutable) {
-    throw ParserError(
-        llvm::SMRange{startTok->getStart(), type != nullptr ? type->getEnd() : nameEnd->getEnd()},
-        "Cannot declare an immutable variable without an initial expression");
+    // In a class, `let x: T` without `=` is allowed: initialized by `new` (explicit or
+    // synthesized from required fields).
+    if (!(inClass && type != nullptr)) {
+      throw ParserError(
+          llvm::SMRange{startTok->getStart(), type != nullptr ? type->getEnd() : nameEnd->getEnd()},
+          "Cannot declare an immutable variable without an initial expression");
+    }
   }
 
   consumeNewline();
@@ -1287,7 +1291,8 @@ auto Parser::parseClass() -> std::unique_ptr<Statement> {
           fields.push_back(std::unique_ptr<VarDecl>(varDecl));
         }
       } else if (checkAny<TokenType::DEF>()) {
-        // Class methods reuse parseFunctionDeclaration; do not inherit `export` from `export class …`.
+        // Class methods reuse parseFunctionDeclaration; do not inherit `export` from `export class
+        // …`.
         bool const savedExported = isExported;
         isExported = false;
         auto stmt = parseFunctionDeclaration();

--- a/src/liblesma/Symbol/SymbolTable.cpp
+++ b/src/liblesma/Symbol/SymbolTable.cpp
@@ -374,6 +374,16 @@ auto SymbolTable::lookupFunction(const std::string& name, std::vector<lesma::Typ
     }
 
     bool candidateWins = bestCandidate == nullptr || rankVectorBetter(candidateRanks, bestRanks);
+    if (!candidateWins && bestCandidate != nullptr && candidateRanks.size() == bestRanks.size()) {
+      bool const ranksEqual =
+          std::equal(candidateRanks.begin(), candidateRanks.end(), bestRanks.begin());
+      if (ranksEqual) {
+        Value* candSym = it->second.get();
+        if (candSym->getLlvmValue() != nullptr && bestCandidate->getLlvmValue() == nullptr) {
+          candidateWins = true;
+        }
+      }
+    }
     if (candidateWins) {
       bestRanks = std::move(candidateRanks);
       bestCandidate = it->second.get();

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -2553,7 +2553,7 @@ void Typechecker::registerSynthesizedClassConstructor(const Class* node, Type* c
   selfParam->setDeclarationSpan(node->getNameSpan());
   selfParam->setDeclarationFilePath(mainFilePath);
   body->insertSymbol(std::move(selfParam));
-  unsigned reqIdx = 0;
+  unsigned reqIdx = 0U;
   for (VarDecl* field : node->getFields()) {
     if (field->getValue() != nullptr) {
       continue;

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -4582,6 +4582,9 @@ auto Typechecker::visit(const TraitDecl* node) -> void {
   traitMethodSignatures[node->getIdentifier()].clear();
   Type* traitTy = scope->lookupType(node->getIdentifier());
   for (FuncDecl* req : node->getRequirements()) {
+    if (req->getName() == "new") {
+      throw TypeCheckError(req->getNameSpan(), "Traits cannot declare constructor 'new'");
+    }
     if (traitTy != nullptr) {
       traitMethodSignatures[node->getIdentifier()][req->getName()].push_back(
           buildMethodFunctionType(req, traitTy));

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -2496,6 +2496,79 @@ auto Typechecker::visit(const Enum* node) -> void {
   node->setResolvedSymbol(scope->lookupStruct(node->getIdentifier()));
 }
 
+void Typechecker::registerSynthesizedClassConstructor(const Class* node, Type* classTypePtr,
+                                                      SymbolTable* outerScope) {
+  Type* selfPtrType = cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, classTypePtr));
+  std::vector<std::unique_ptr<Field>> paramFields;
+  paramFields.push_back(std::make_unique<Field>("self", selfPtrType));
+  std::vector<Type*> lookupTypes = {selfPtrType};
+  std::vector<Field*> const& typeFields = classTypePtr->getFields();
+  size_t typeIdx = 0;
+  for (VarDecl* field : node->getFields()) {
+    if (typeIdx >= typeFields.size()) {
+      break;
+    }
+    Type* storageTy = typeFields[typeIdx]->type;
+    typeIdx++;
+    if (field->getValue() != nullptr) {
+      continue;
+    }
+    Type* paramType = storageTy;
+    if (paramType != nullptr && paramType->is(BaseType::TY_CLASS)) {
+      paramType = cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, paramType));
+    }
+    if (paramType == nullptr) {
+      throw TypeCheckError(field->getSpan(),
+                           "Synthesized constructor cannot infer type for field '{}'",
+                           field->getIdentifier()->getValue());
+    }
+    lookupTypes.push_back(paramType);
+    paramFields.push_back(std::make_unique<Field>(field->getIdentifier()->getValue(), paramType));
+  }
+  Type* voidRet = cacheType(std::make_unique<Type>(BaseType::TY_VOID));
+  auto funcType = std::make_unique<Type>(BaseType::TY_FUNCTION, nullptr, std::move(paramFields));
+  funcType->setReturnType(voidRet);
+  Type* funcTypePtr = cacheType(std::move(funcType));
+
+  if (outerScope->lookupFunction("new", lookupTypes) != nullptr) {
+    throw TypeCheckError(node->getNameSpan(), "Constructor 'new' already registered for class {}",
+                         node->getIdentifier());
+  }
+  auto ctorSym = std::make_unique<Value>("new", funcTypePtr);
+  ctorSym->setCategory(ValueCategory::CALLABLE_SYMBOL);
+  ctorSym->setDeclarationKind(ValueDeclarationKind::METHOD);
+  ctorSym->setExported(node->isExported());
+  ctorSym->setDeclarationSpan(node->getNameSpan());
+  ctorSym->setDeclarationFilePath(mainFilePath);
+  outerScope->insertSymbol(std::move(ctorSym));
+  Value* ctorFunc = outerScope->lookupFunction("new", lookupTypes);
+  if (ctorFunc == nullptr) {
+    throw TypeCheckError(node->getNameSpan(), "Internal error registering synthesized constructor");
+  }
+  SymbolTable* body = outerScope->createChildBlock("function");
+  ctorFunc->setBodyScope(body);
+  auto selfParam = std::make_unique<Value>("self", selfPtrType);
+  selfParam->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+  selfParam->setDeclarationKind(ValueDeclarationKind::PARAMETER);
+  selfParam->setDeclarationSpan(node->getNameSpan());
+  selfParam->setDeclarationFilePath(mainFilePath);
+  body->insertSymbol(std::move(selfParam));
+  unsigned reqIdx = 0;
+  for (VarDecl* field : node->getFields()) {
+    if (field->getValue() != nullptr) {
+      continue;
+    }
+    Type* paramType = lookupTypes[1U + reqIdx];
+    auto ps = std::make_unique<Value>(field->getIdentifier()->getValue(), paramType);
+    ps->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+    ps->setDeclarationKind(ValueDeclarationKind::PARAMETER);
+    ps->setDeclarationSpan(field->getIdentifier()->getSpan());
+    ps->setDeclarationFilePath(mainFilePath);
+    body->insertSymbol(std::move(ps));
+    reqIdx++;
+  }
+}
+
 auto Typechecker::visit(const Class* node) -> void {
   auto savedGenerics = currentGenericTypes;
   SymbolTable* outerScope = scope;
@@ -2604,6 +2677,19 @@ auto Typechecker::visit(const Class* node) -> void {
   }
   currentClassExported = savedClassExportedFlag;
   currentMethodInsertScope = savedMethodInsertScope;
+
+  if (declarationPass) {
+    bool hasExplicitNew = false;
+    for (FuncDecl* m : node->getMethods()) {
+      if (m->getName() == "new") {
+        hasExplicitNew = true;
+        break;
+      }
+    }
+    if (!hasExplicitNew) {
+      registerSynthesizedClassConstructor(node, classTypePtr, outerScope);
+    }
+  }
 
   if (!declarationPass) {
     classesPendingUnusedMemberDiagnosis.push_back(node);

--- a/src/liblesma/Typecheck/Typechecker.h
+++ b/src/liblesma/Typecheck/Typechecker.h
@@ -101,8 +101,8 @@ class Typechecker final : public ASTVisitor {
   ImportedNameSourceMap importedNameToSource;
   /** Cache of fully analyzed imported modules for import-aware symbol resolution. */
   std::unordered_map<std::string, std::shared_ptr<ImportedModuleAnalysis>> importedModuleCache;
-  /** Filled during the second pass; diagnosed after the full unit so calls like `Foo()` see `new` as
-   *  used first (see \c run). */
+  /** Filled during the second pass; diagnosed after the full unit so calls like `Foo()` see `new`
+   * as used first (see \c run). */
   std::vector<const Class*> classesPendingUnusedMemberDiagnosis;
 
   /** When non-null, unreachable-code and other warnings are appended here (severity Warning).
@@ -219,6 +219,10 @@ class Typechecker final : public ASTVisitor {
   /** True when \p sym is the nominal type name binding (not a value, function,
    *  or enum member), for CUSTOM_TYPE resolution after lookupStruct / lookup. */
   [[nodiscard]] auto isTypeSymbolForCustomTypeName(Value const* sym) -> bool;
+
+  /** When a class has no `def new`, register a constructor taking each field without a default. */
+  void registerSynthesizedClassConstructor(const Class* node, Type* classTypePtr,
+                                           SymbolTable* outerScope);
 
 public:
   /** Typecheck with no import * resolution. */

--- a/tests/lesma/failure/trait_declares_new.les
+++ b/tests/lesma/failure/trait_declares_new.les
@@ -1,0 +1,3 @@
+# Constructors belong on classes; trait requirements may not use `new`.
+trait Bad
+    def new()

--- a/tests/lesma/success/class_synthesized_constructor.les
+++ b/tests/lesma/success/class_synthesized_constructor.les
@@ -1,0 +1,14 @@
+# Default `new` from fields: required parameters are fields without initializers (in order).
+
+class Animal
+    let type: str
+    let name: str
+    var age: int = 1
+
+var dog = Animal("dog", "frankie")
+if dog.type != "dog"
+    exit(1)
+if dog.name != "frankie"
+    exit(1)
+if dog.age != 1
+    exit(1)

--- a/tests/lesma/success/class_synthesized_constructor_generic.les
+++ b/tests/lesma/success/class_synthesized_constructor_generic.les
@@ -1,0 +1,24 @@
+# Generic class without explicit `def new`: synthesized ctor + inference.
+
+class GBox<T>
+    var val: T
+    def getVal() -> T
+        return self.val
+
+var ib = GBox(100)
+if ib.getVal() != 100
+    exit(1)
+
+class GPair<T, U>
+    var a: T
+    var b: U
+    def getA() -> T
+        return self.a
+    def getB() -> U
+        return self.b
+
+var pr = GPair(7, 2.5)
+if pr.getA() != 7
+    exit(1)
+if pr.getB() != 2.5
+    exit(1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Classes now auto-generate implicit `new` constructors from fields without defaults, including generic classes.

* **Bug Fixes / Behavior**
  * Parser accepts immutable class fields declared without an `=` initializer.
  * Traits can no longer declare `new` (treated as an error).

* **Tests**
  * Added tests covering synthesized constructors for standard and generic classes.

* **Documentation**
  * ROADMAP updated to mark "Dataclasses (implicit constructors)" as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->