### PR TITLE
Type Unions and Type narrowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ expressiveness, elegance, and simplicity without sacrificing performance.
 
 - [Official Documentation](https://lesma-lang.com/)
 - [Examples](https://github.com/alinalihassan/Lesma/blob/main/tests/lesma)
+- In-repo docs source: `tools/docs/content/docs/` (e.g. [language/types.mdx](tools/docs/content/docs/language/types.mdx))
 
 ## Installation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,8 @@
 - [ ] Add multithreading using pthread for now (async/await? ala Spice)
 - [x] Add comments above classes and functions as documentation in LSP
 - [x] Check dictionaries for multiline support
+- [x] Type unions
+- [x] Type narrowing
 
 ## LSP
 - [ ] rename + prepareRename

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,16 +16,17 @@
 - [x] Add string interpolation
 - [x] Add multiple value return without having to make structs
 - [x] Dataclasses (implicit constructors)
-- [ ] Add optional types
 - [x] Add dictionaries
 - [x] Add lambda functions
-- [ ] Add try catch
-- [ ] Add multithreading using pthread for now (async/await? ala Spice)
 - [x] Add comments above classes and functions as documentation in LSP
 - [x] Check dictionaries for multiline support
 - [x] Type unions
 - [x] Type narrowing
-- [ ] Enums v2 (in type unions, enums with methods, and associated values)
+- [ ] Add optional types
+- [ ] Enums v2 (in type unions, enums with methods, traits and associated values)
+- [ ] Multithreading with LLVM coroutines (async await)
+- [ ] Try catch and Errors
+- [ ] Formatter
 
 ## LSP
 - [ ] rename + prepareRename

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,7 @@
 - [x] Check dictionaries for multiline support
 - [x] Type unions
 - [x] Type narrowing
+- [ ] Enums v2 (in type unions, enums with methods, and associated values)
 
 ## LSP
 - [ ] rename + prepareRename

--- a/docs/lsp_utf8_positions.md
+++ b/docs/lsp_utf8_positions.md
@@ -1,5 +1,0 @@
-# LSP and UTF-8 positions
-
-Lesma LSP advertises `PositionEncodingKind::UTF8`. Clients must send `Position.character` as **UTF-8 code units (bytes)** from the start of the line, not Unicode code points or UTF-16 code units.
-
-Regression coverage: run `tests/lesma/success/utf8_string_literal.les` and ensure diagnostics (if any) align with byte offsets in editors that use UTF-8 columns.

--- a/docs/unsupported_syntax.md
+++ b/docs/unsupported_syntax.md
@@ -1,8 +1,0 @@
-# Syntax not in Lesma (edge-case catalog)
-
-The following are intentionally unsupported today; do not expect parse or typecheck errors to suggest otherwise.
-
-- **Chained comparisons** such as `a < b < c` (Python-style). Use `a < b && b < c` (with possible duplication of `b` evaluation).
-- **Bitwise and shift operators** such as `&`, `|`, `^`, `<<`, `>>`, `~`. Use arithmetic or intrinsics where available.
-
-If these are added later, specify evaluation order, short-circuiting (for chains), and LLVM poison rules for shifts.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -22,8 +22,10 @@ case "${LESMA_TEST_TIMEOUT}" in
 '' | *[!0-9]*) LESMA_TEST_TIMEOUT=2 ;;
 esac
 
-# Distinct exit status when the per-invocation watchdog stops the compiler (GNU timeout uses 124).
-LESMA_TEST_TIMEOUT_EXIT=124
+# Watchdog timeout must not reuse a process exit code. The old LESMA_TEST_TIMEOUT_EXIT=124 matched
+# GNU timeout but collided with forwarded codes: Driver returns LesmaError::getExitCode() (uint8_t,
+# LesmaError.h) from Driver.cpp; src/cli/main.cpp forwards that to std::_Exit. Any 0–255 can be a
+# real JIT/compiler exit. Timeouts are indicated only by LESMA_WATCHDOG_TIMED_OUT=1 (see test_compiler).
 
 test_compiler() {
   local file="$1"
@@ -31,6 +33,8 @@ test_compiler() {
   local compiler_path="$3"
   local quiet="${4:-}"
   local cpid kpid hard_pid ret timeout_flag
+
+  LESMA_WATCHDOG_TIMED_OUT=0
 
   if [ "${LESMA_TEST_TIMEOUT}" -eq 0 ]; then
     case "${quiet}" in
@@ -47,6 +51,8 @@ test_compiler() {
     return $?
   fi
 
+  timeout_flag=$(mktemp "${TMPDIR:-/tmp}/lesma-test-timeout.XXXXXX") || return 1
+
   case "${quiet}" in
   all)
     "${compiler_path}" "${mode}" --no-warnings "${file}" >/dev/null 2>&1 &
@@ -59,8 +65,6 @@ test_compiler() {
     ;;
   esac
   cpid=$!
-
-  timeout_flag=$(mktemp "${TMPDIR:-/tmp}/lesma-test-timeout.XXXXXX") || return 1
 
   # Watchdog: after LESMA_TEST_TIMEOUT, SIGTERM then SIGKILL after ~1s if still alive.
   (
@@ -99,7 +103,7 @@ test_compiler() {
   wait "${hard_pid}" 2>/dev/null || true
 
   if [ -s "${timeout_flag}" ]; then
-    ret="${LESMA_TEST_TIMEOUT_EXIT}"
+    LESMA_WATCHDOG_TIMED_OUT=1
   fi
   rm -f "${timeout_flag}"
 
@@ -129,7 +133,7 @@ run_single_test() {
     test_jit_ret_value=$?
   fi
 
-  if [ "${test_jit_ret_value}" -eq "${LESMA_TEST_TIMEOUT_EXIT}" ]; then
+  if [ "${LESMA_WATCHDOG_TIMED_OUT}" -eq 1 ]; then
     printf 'fail-timeout %s\n' "${name}" >"${result_file}"
   elif [ "${test_jit_ret_value}" -ne "${test_expected_ret_value}" ] && [ "${expected_to_fail}" -eq 0 ]; then
     printf 'fail-run %s %s %s\n' "${name}" "${test_expected_ret_value}" "${test_jit_ret_value}" >"${result_file}"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -82,8 +82,6 @@ test_compiler() {
       fi
     fi
   ) &
-    fi
-  ) &
   kpid=$!
 
   # Hard ceiling so wait on cpid cannot block without bound if signal delivery misbehaves.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -16,6 +16,8 @@ success_count=0
 
 # Wall-clock limit per compiler invocation (seconds). Use 0 to disable. Override with LESMA_TEST_TIMEOUT.
 LESMA_TEST_TIMEOUT="${LESMA_TEST_TIMEOUT:-2}"
+# Success tests hide JIT program stdout by default. Set LESMA_TEST_VERBOSE=1 to print it.
+LESMA_TEST_VERBOSE="${LESMA_TEST_VERBOSE:-0}"
 case "${LESMA_TEST_TIMEOUT}" in
 '' | *[!0-9]*) LESMA_TEST_TIMEOUT=2 ;;
 esac
@@ -28,19 +30,31 @@ test_compiler() {
   local cpid kpid ret
 
   if [ "${LESMA_TEST_TIMEOUT}" -eq 0 ]; then
-    if [ -n "${quiet}" ]; then
+    case "${quiet}" in
+    all)
       "${compiler_path}" "${mode}" --no-warnings "${file}" >/dev/null 2>&1
-    else
+      ;;
+    out)
+      "${compiler_path}" "${mode}" --no-warnings "${file}" >/dev/null
+      ;;
+    *)
       "${compiler_path}" "${mode}" --no-warnings "${file}"
-    fi
+      ;;
+    esac
     return $?
   fi
 
-  if [ -n "${quiet}" ]; then
+  case "${quiet}" in
+  all)
     "${compiler_path}" "${mode}" --no-warnings "${file}" >/dev/null 2>&1 &
-  else
+    ;;
+  out)
+    "${compiler_path}" "${mode}" --no-warnings "${file}" >/dev/null &
+    ;;
+  *)
     "${compiler_path}" "${mode}" --no-warnings "${file}" &
-  fi
+    ;;
+  esac
   cpid=$!
   (
     sleep "${LESMA_TEST_TIMEOUT}"
@@ -54,7 +68,8 @@ test_compiler() {
   return "${ret}"
 }
 
-# Writes one status line to result_file only (stdout stays free for compiler output).
+# Writes one status line to result_file only.
+# quiet modes: "out" = drop subprocess stdout (JIT program output); "all" = drop stdout+stderr.
 # Lines: pass NAME EXPECT_FAIL | fail-run NAME EXPECT GOT | fail-expect NAME
 run_single_test() {
   local file="$1"
@@ -66,10 +81,13 @@ run_single_test() {
   name=$(basename -s .les "${file}")
 
   if [ "${expected_to_fail}" -eq 1 ]; then
-    test_compiler "${file}" "run" "${compiler_path}" quiet
+    test_compiler "${file}" "run" "${compiler_path}" all
+    test_jit_ret_value=$?
+  elif [ "${LESMA_TEST_VERBOSE}" -eq 1 ]; then
+    test_compiler "${file}" "run" "${compiler_path}"
     test_jit_ret_value=$?
   else
-    test_compiler "${file}" "run" "${compiler_path}"
+    test_compiler "${file}" "run" "${compiler_path}" out
     test_jit_ret_value=$?
   fi
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -70,6 +70,7 @@ test_compiler() {
   (
     sleep "${LESMA_TEST_TIMEOUT}"
     if kill -0 "${cpid}" 2>/dev/null; then
+      printf '1' >"${timeout_flag}"
       kill -TERM "${cpid}" 2>/dev/null || true
       i=0
       while [ "${i}" -lt 10 ] && kill -0 "${cpid}" 2>/dev/null; do
@@ -79,7 +80,8 @@ test_compiler() {
       if kill -0 "${cpid}" 2>/dev/null; then
         kill -KILL "${cpid}" 2>/dev/null || true
       fi
-      printf '1' >"${timeout_flag}"
+    fi
+  ) &
     fi
   ) &
   kpid=$!

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -21,6 +21,11 @@ LESMA_TEST_VERBOSE="${LESMA_TEST_VERBOSE:-0}"
 case "${LESMA_TEST_TIMEOUT}" in
 '' | *[!0-9]*) LESMA_TEST_TIMEOUT=2 ;;
 esac
+case "${LESMA_TEST_VERBOSE}" in
+'' | *[!0-9]*) LESMA_TEST_VERBOSE=0 ;;
+esac
+LESMA_TEST_TIMEOUT=$((10#${LESMA_TEST_TIMEOUT}))
+LESMA_TEST_VERBOSE=$((10#${LESMA_TEST_VERBOSE}))
 
 # Watchdog timeout must not reuse a process exit code. The old LESMA_TEST_TIMEOUT_EXIT=124 matched
 # GNU timeout but collided with forwarded codes: Driver returns LesmaError::getExitCode() (uint8_t,

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -14,17 +14,44 @@ fi
 fail_count=0
 success_count=0
 
+# Wall-clock limit per compiler invocation (seconds). Use 0 to disable. Override with LESMA_TEST_TIMEOUT.
+LESMA_TEST_TIMEOUT="${LESMA_TEST_TIMEOUT:-2}"
+case "${LESMA_TEST_TIMEOUT}" in
+'' | *[!0-9]*) LESMA_TEST_TIMEOUT=2 ;;
+esac
+
 test_compiler() {
   local file="$1"
   local mode="$2"
   local compiler_path="$3"
   local quiet="${4:-}"
-  if [ -n "${quiet}" ]; then
-    "${compiler_path}" "${mode}" --no-warnings "${file}" >/dev/null 2>&1
-  else
-    "${compiler_path}" "${mode}" --no-warnings "${file}"
+  local cpid kpid ret
+
+  if [ "${LESMA_TEST_TIMEOUT}" -eq 0 ]; then
+    if [ -n "${quiet}" ]; then
+      "${compiler_path}" "${mode}" --no-warnings "${file}" >/dev/null 2>&1
+    else
+      "${compiler_path}" "${mode}" --no-warnings "${file}"
+    fi
+    return $?
   fi
-  return $?
+
+  if [ -n "${quiet}" ]; then
+    "${compiler_path}" "${mode}" --no-warnings "${file}" >/dev/null 2>&1 &
+  else
+    "${compiler_path}" "${mode}" --no-warnings "${file}" &
+  fi
+  cpid=$!
+  (
+    sleep "${LESMA_TEST_TIMEOUT}"
+    kill "${cpid}" 2>/dev/null || true
+  ) &
+  kpid=$!
+  wait "${cpid}"
+  ret=$?
+  kill "${kpid}" 2>/dev/null || true
+  wait "${kpid}" 2>/dev/null || true
+  return "${ret}"
 }
 
 # Writes one status line to result_file only (stdout stays free for compiler output).

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -22,12 +22,15 @@ case "${LESMA_TEST_TIMEOUT}" in
 '' | *[!0-9]*) LESMA_TEST_TIMEOUT=2 ;;
 esac
 
+# Distinct exit status when the per-invocation watchdog stops the compiler (GNU timeout uses 124).
+LESMA_TEST_TIMEOUT_EXIT=124
+
 test_compiler() {
   local file="$1"
   local mode="$2"
   local compiler_path="$3"
   local quiet="${4:-}"
-  local cpid kpid ret
+  local cpid kpid hard_pid ret timeout_flag
 
   if [ "${LESMA_TEST_TIMEOUT}" -eq 0 ]; then
     case "${quiet}" in
@@ -56,15 +59,50 @@ test_compiler() {
     ;;
   esac
   cpid=$!
+
+  timeout_flag=$(mktemp "${TMPDIR:-/tmp}/lesma-test-timeout.XXXXXX") || return 1
+
+  # Watchdog: after LESMA_TEST_TIMEOUT, SIGTERM then SIGKILL after ~1s if still alive.
   (
     sleep "${LESMA_TEST_TIMEOUT}"
-    kill "${cpid}" 2>/dev/null || true
+    if kill -0 "${cpid}" 2>/dev/null; then
+      kill -TERM "${cpid}" 2>/dev/null || true
+      i=0
+      while [ "${i}" -lt 10 ] && kill -0 "${cpid}" 2>/dev/null; do
+        sleep 0.1
+        i=$((i + 1))
+      done
+      if kill -0 "${cpid}" 2>/dev/null; then
+        kill -KILL "${cpid}" 2>/dev/null || true
+      fi
+      printf '1' >"${timeout_flag}"
+    fi
   ) &
   kpid=$!
+
+  # Hard ceiling so wait on cpid cannot block without bound if signal delivery misbehaves.
+  (
+    sleep $((LESMA_TEST_TIMEOUT + 5))
+    if kill -0 "${cpid}" 2>/dev/null; then
+      kill -KILL "${cpid}" 2>/dev/null || true
+      printf '1' >"${timeout_flag}"
+    fi
+  ) &
+  hard_pid=$!
+
   wait "${cpid}"
   ret=$?
+
   kill "${kpid}" 2>/dev/null || true
   wait "${kpid}" 2>/dev/null || true
+  kill "${hard_pid}" 2>/dev/null || true
+  wait "${hard_pid}" 2>/dev/null || true
+
+  if [ -s "${timeout_flag}" ]; then
+    ret="${LESMA_TEST_TIMEOUT_EXIT}"
+  fi
+  rm -f "${timeout_flag}"
+
   return "${ret}"
 }
 
@@ -91,7 +129,9 @@ run_single_test() {
     test_jit_ret_value=$?
   fi
 
-  if [ "${test_jit_ret_value}" -ne "${test_expected_ret_value}" ] && [ "${expected_to_fail}" -eq 0 ]; then
+  if [ "${test_jit_ret_value}" -eq "${LESMA_TEST_TIMEOUT_EXIT}" ]; then
+    printf 'fail-timeout %s\n' "${name}" >"${result_file}"
+  elif [ "${test_jit_ret_value}" -ne "${test_expected_ret_value}" ] && [ "${expected_to_fail}" -eq 0 ]; then
     printf 'fail-run %s %s %s\n' "${name}" "${test_expected_ret_value}" "${test_jit_ret_value}" >"${result_file}"
   elif [ "${expected_to_fail}" -eq 1 ] && [ "${test_jit_ret_value}" -eq "${test_expected_ret_value}" ]; then
     printf 'fail-expect %s\n' "${name}" >"${result_file}"
@@ -130,6 +170,11 @@ process_result_line() {
     fail_count=$((fail_count + 1))
     printf 'Testing %s\n' "$2"
     printf '  Run succeeded but was expected to fail\n'
+    ;;
+  fail-timeout)
+    fail_count=$((fail_count + 1))
+    printf 'Testing %s\n' "$2"
+    printf '  Timed out after %ss (LESMA_TEST_TIMEOUT)\n' "${LESMA_TEST_TIMEOUT}"
     ;;
   *)
     printf 'Internal error: bad result line: %s\n' "${line}" >&2

--- a/src/liblesma/AST/AST.h
+++ b/src/liblesma/AST/AST.h
@@ -219,6 +219,13 @@ public:
     return std::make_unique<TypeExpr>(loc, std::move(displayName), TokenType::TUPLE_TYPE,
                                       std::move(elements), std::unique_ptr<TypeExpr>(nullptr));
   }
+  /** Union type `T1 | T2 | ...`: `params` are arms, `ret` is null. */
+  static auto makeUnionType(llvm::SMRange loc, std::string displayName,
+                            std::vector<std::unique_ptr<TypeExpr>> arms)
+      -> std::unique_ptr<TypeExpr> {
+    return std::make_unique<TypeExpr>(loc, std::move(displayName), TokenType::UNION_TYPE,
+                                      std::move(arms), std::unique_ptr<TypeExpr>(nullptr));
+  }
   void accept(ASTVisitor& visitor) const override { visitor.visit(this); }
 
   [[nodiscard]] [[maybe_unused]] auto getName() const -> std::string { return name; }

--- a/src/liblesma/AST/AST.h
+++ b/src/liblesma/AST/AST.h
@@ -68,6 +68,8 @@ class Literal : public Expression {
   mutable Value* resolvedSymbol = nullptr;
   /** If non-null for STRING literals, codegen emits a boxed stdlib str instance. */
   mutable Type* resolvedStrClassType = nullptr;
+  /** Flow-narrowed type for IDENTIFIER (e.g. `int` inside `else` after `x is float`); LSP hover. */
+  mutable Type* lspFlowSensitiveType = nullptr;
 
 public:
   Literal(llvm::SMRange loc, std::string value, TokenType type)
@@ -80,6 +82,8 @@ public:
   auto setResolvedSymbol(Value* v) const -> void { resolvedSymbol = v; }
   [[nodiscard]] auto getResolvedStrClassType() const -> Type* { return resolvedStrClassType; }
   auto setResolvedStrClassType(Type* t) const -> void { resolvedStrClassType = t; }
+  [[nodiscard]] auto getLspFlowSensitiveType() const -> Type* { return lspFlowSensitiveType; }
+  auto setLspFlowSensitiveType(Type* t) const -> void { lspFlowSensitiveType = t; }
 
   auto toString(llvm::SourceMgr* /*srcMgr*/, const std::string& /*prefix*/, bool /*isTail*/) const
       -> std::string override {

--- a/src/liblesma/AST/AST.h
+++ b/src/liblesma/AST/AST.h
@@ -1063,6 +1063,8 @@ class IsOp : public Expression {
   std::unique_ptr<Expression> left;
   TokenType op;
   std::unique_ptr<TypeExpr> right;
+  /** Filled by typechecker; used by codegen without re-visiting the RHS `TypeExpr`. */
+  mutable Type* resolvedRhsType = nullptr;
 
 public:
   IsOp(llvm::SMRange loc, std::unique_ptr<Expression> left, TokenType op,
@@ -1073,6 +1075,8 @@ public:
   [[nodiscard]] [[maybe_unused]] auto getLeft() const -> Expression* { return left.get(); }
   [[nodiscard]] [[maybe_unused]] auto getOperator() const -> TokenType { return op; }
   [[nodiscard]] [[maybe_unused]] auto getRight() const -> TypeExpr* { return right.get(); }
+  [[nodiscard]] auto getResolvedRhsType() const -> Type* { return resolvedRhsType; }
+  auto setResolvedRhsType(Type* t) const -> void { resolvedRhsType = t; }
 
   auto toString(llvm::SourceMgr* srcMgr, const std::string& prefix, bool isTail) const
       -> std::string override {

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <deque>
 #include <memory>
 #include <optional>
@@ -509,6 +510,11 @@ protected:
       lesma::Type* t, const std::unordered_map<std::string, lesma::Type*>& env) -> lesma::Type*;
 
 private:
+  /** Minimum tag bits: ceil(log2(memberCount)), at least 1 (memberCount must be > 0). */
+  [[nodiscard]] static auto unionDiscriminantMinBits(std::size_t memberCount) -> unsigned;
+  /** Round up to a whole number of bytes (8, 16, 32, 64); 0 if \p minBits > 64. */
+  [[nodiscard]] static auto roundUnionTagToSupportedBitWidth(unsigned minBits) -> unsigned;
+
   [[nodiscard]] auto cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> lesma::Value*;
   [[nodiscard]] auto cgUnionComplementMemberIndex(lesma::Type* unionTy, lesma::Type* excluded)
       -> std::optional<unsigned>;

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -227,6 +227,10 @@ protected:
                                         std::unordered_map<lesma::Value*, unsigned>& out) -> void;
   auto emitUnionWrapValue(llvm::SMRange span, lesma::Value* val, lesma::Type* unionTy,
                           unsigned variantIndex) -> std::unique_ptr<lesma::Value>;
+  /** Wrap \p val into \p unionTy at \p variantIndex using existing alloca \p destSlot (union struct). */
+  auto emitUnionWrapValueToSlot(llvm::SMRange span, lesma::Value* val, lesma::Type* unionTy,
+                                unsigned variantIndex, llvm::Value* destSlot)
+      -> std::unique_ptr<lesma::Value>;
   [[nodiscard]] auto unionVariantIndexOf(lesma::Type* unionTy, lesma::Type* memberTy) const
       -> std::optional<unsigned>;
   auto emitUnionPayloadLoadFromSlot(llvm::Value* unionAllocaPtr, lesma::Type* unionTy,
@@ -503,5 +507,10 @@ protected:
    * or superclass type. */
   auto substituteTypeForSpecializationEnv(
       lesma::Type* t, const std::unordered_map<std::string, lesma::Type*>& env) -> lesma::Type*;
+
+private:
+  [[nodiscard]] auto cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> lesma::Value*;
+  [[nodiscard]] auto cgUnionComplementMemberIndex(lesma::Type* unionTy, lesma::Type* excluded)
+      -> std::optional<unsigned>;
 };
 } // namespace lesma

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -543,6 +543,10 @@ protected:
   auto substituteTypeForSpecializationEnv(lesma::Type* t,
                                           const std::unordered_map<std::string, lesma::Type*>& env)
       -> lesma::Type*;
+  /** Peel singleton TY_UNION chains and rebuild ptr/array when the element changes (types from
+   *  Typechecker::substituteInType before singleton collapse, or imports) so emitClassMonomorph
+   *  matches substituteTypeForSpecializationEnv lowering. */
+  auto typeWithSingletonUnionsCollapsed(lesma::Type* t) -> lesma::Type*;
 
 private:
   /** Minimum tag bits: ceil(log2(memberCount)), at least 1 (memberCount must be > 0). */

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -38,12 +38,13 @@ class AllocaInst;
 #include <sysexits.h>
 
 #include "liblesma/AST/ASTVisitor.h"
-#include "liblesma/Common/ExportDiscovery.h"
 #include "liblesma/Backend/MangleUtils.h"
+#include "liblesma/Common/ExportDiscovery.h"
 #include "liblesma/Frontend/Parser.h"
 #include "liblesma/Symbol/SymbolTable.h"
 #include "liblesma/Symbol/Type.h"
 #include "liblesma/Symbol/TypeUtils.h"
+#include "liblesma/Symbol/UnionNarrowingStableKey.h"
 #include "liblesma/Symbol/Value.h"
 
 using namespace llvm;
@@ -152,7 +153,9 @@ class Codegen final : public ASTVisitor {
   std::size_t lambdaCounter = 0U;
   llvm::OptimizationLevel optimizationLevelForDebug = llvm::OptimizationLevel::O3;
   /** `if x is T` / else: maps parameter/local symbol → union variant index for narrowed loads. */
-  std::vector<std::unordered_map<lesma::Value*, unsigned>> unionNarrowVariantStack;
+  std::vector<std::unordered_map<UnionNarrowingStableKey, unsigned, UnionNarrowingStableKeyHash,
+                                 UnionNarrowingStableKeyEq>>
+      unionNarrowVariantStack;
 
   std::unique_ptr<llvm::DIBuilder> diBuilder;
   llvm::DICompileUnit* diCompileUnit = nullptr;
@@ -224,11 +227,14 @@ protected:
       -> llvm::AllocaInst*;
 
   [[nodiscard]] auto lookupUnionNarrowVariant(lesma::Value* sym) const -> std::optional<unsigned>;
-  auto fillCodegenUnionNarrowVariantMap(const If* node, unsigned blockIndex,
-                                        std::unordered_map<lesma::Value*, unsigned>& out) -> void;
+  auto fillCodegenUnionNarrowVariantMap(
+      const If* node, unsigned blockIndex,
+      std::unordered_map<UnionNarrowingStableKey, unsigned, UnionNarrowingStableKeyHash,
+                         UnionNarrowingStableKeyEq>& out) -> void;
   auto emitUnionWrapValue(llvm::SMRange span, lesma::Value* val, lesma::Type* unionTy,
                           unsigned variantIndex) -> std::unique_ptr<lesma::Value>;
-  /** Wrap \p val into \p unionTy at \p variantIndex using existing alloca \p destSlot (union struct). */
+  /** Wrap \p val into \p unionTy at \p variantIndex using existing alloca \p destSlot (union
+   * struct). */
   auto emitUnionWrapValueToSlot(llvm::SMRange span, lesma::Value* val, lesma::Type* unionTy,
                                 unsigned variantIndex, llvm::Value* destSlot)
       -> std::unique_ptr<lesma::Value>;
@@ -318,14 +324,12 @@ protected:
       -> std::unique_ptr<lesma::Value>;
   auto appendCallableArgument(lesma::Value* arg, std::vector<lesma::Type*>& paramTypes,
                               std::vector<llvm::Value*>& paramsLLVM) -> void;
-  auto callNamedFunction(llvm::SMRange span, const std::string& functionName,
-                         const std::vector<lesma::Type*>& paramTypes,
-                         const std::vector<llvm::Value*>& paramsLLVM,
-                         const std::vector<lesma::Type*>& explicitTypeArgs = {},
-                         Value* typecheckCalleeFallback = nullptr,
-                         lesma::Type* allocatedClassMonomorph = nullptr,
-                         const std::vector<std::pair<std::string, lesma::Type*>>*
-                             genericBindingHint = nullptr)
+  auto callNamedFunction(
+      llvm::SMRange span, const std::string& functionName,
+      const std::vector<lesma::Type*>& paramTypes, const std::vector<llvm::Value*>& paramsLLVM,
+      const std::vector<lesma::Type*>& explicitTypeArgs = {},
+      Value* typecheckCalleeFallback = nullptr, lesma::Type* allocatedClassMonomorph = nullptr,
+      const std::vector<std::pair<std::string, lesma::Type*>>* genericBindingHint = nullptr)
       -> std::unique_ptr<lesma::Value>;
   auto callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
                             const std::string& methodName,
@@ -366,15 +370,17 @@ protected:
   auto appendGenericBindingSuffix(llvm::SMRange span, std::string& base,
                                   const std::vector<std::string>& genericNames,
                                   const std::unordered_map<std::string, lesma::Type*>& env) -> void;
-  auto specializeFunction(const FuncDecl* node, const std::vector<lesma::Type*>& paramTypes,
-                          const std::vector<std::string>& genericNames,
-                          const std::vector<lesma::Type*>& explicitTypeArgs = {},
-                          const std::unordered_map<std::string, lesma::Type*>* bindingEnvHint = nullptr)
+  auto
+  specializeFunction(const FuncDecl* node, const std::vector<lesma::Type*>& paramTypes,
+                     const std::vector<std::string>& genericNames,
+                     const std::vector<lesma::Type*>& explicitTypeArgs = {},
+                     const std::unordered_map<std::string, lesma::Type*>* bindingEnvHint = nullptr)
       -> lesma::Value*;
-  auto specializeLambda(const LambdaExpr* node, const std::vector<lesma::Type*>& paramTypes,
-                        const std::vector<std::string>& genericNames,
-                        const std::vector<lesma::Type*>& explicitTypeArgs = {},
-                        const std::unordered_map<std::string, lesma::Type*>* bindingEnvHint = nullptr)
+  auto
+  specializeLambda(const LambdaExpr* node, const std::vector<lesma::Type*>& paramTypes,
+                   const std::vector<std::string>& genericNames,
+                   const std::vector<lesma::Type*>& explicitTypeArgs = {},
+                   const std::unordered_map<std::string, lesma::Type*>* bindingEnvHint = nullptr)
       -> lesma::Value*;
   auto defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) -> void;
   [[nodiscard]] auto getFuncValuePairLlvmType() -> llvm::StructType*;
@@ -452,7 +458,8 @@ protected:
 
   /** Ensure \p type has an LLVM type (fill in when from typechecker). */
   auto getOrCreateLlvmType(lesma::Type* type) -> llvm::Type*;
-  /** LLVM integer tag type for \c TY_UNION (first struct field); requires \p unionTy to be a union. */
+  /** LLVM integer tag type for \c TY_UNION (first struct field); requires \p unionTy to be a union.
+   */
   [[nodiscard]] auto getOrCreateUnionTagLlvmType(lesma::Type* unionTy) -> llvm::Type*;
   /** LLVM storage type for aggregate fields/slots after ABI lowering. */
   [[nodiscard]] auto getStoredAggregateFieldLlvmType(lesma::Type* fieldType) -> llvm::Type*;
@@ -506,8 +513,9 @@ protected:
   [[nodiscard]] auto isTypeFullyConcrete(lesma::Type* t) const -> bool;
   /** Substitute generic parameters (and nested specialized classes) for lowering a template field
    * or superclass type. */
-  auto substituteTypeForSpecializationEnv(
-      lesma::Type* t, const std::unordered_map<std::string, lesma::Type*>& env) -> lesma::Type*;
+  auto substituteTypeForSpecializationEnv(lesma::Type* t,
+                                          const std::unordered_map<std::string, lesma::Type*>& env)
+      -> lesma::Type*;
 
 private:
   /** Minimum tag bits: ceil(log2(memberCount)), at least 1 (memberCount must be > 0). */
@@ -515,7 +523,8 @@ private:
   /** Round up to a whole number of bytes (8, 16, 32, 64); 0 if \p minBits > 64. */
   [[nodiscard]] static auto roundUnionTagToSupportedBitWidth(unsigned minBits) -> unsigned;
 
-  [[nodiscard]] auto cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> lesma::Value*;
+  [[nodiscard]] auto cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope)
+      -> lesma::Value*;
   [[nodiscard]] auto cgUnionComplementMemberIndex(lesma::Type* unionTy, lesma::Type* excluded)
       -> std::optional<unsigned>;
 };

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -175,7 +175,7 @@ class Codegen final : public ASTVisitor {
       }
     }
     UnionNarrowingScope(const UnionNarrowingScope&) = delete;
-    auto operator=(const UnionNarrowingScope&) = delete;
+    auto operator=(const UnionNarrowingScope&) -> UnionNarrowingScope& = delete;
     UnionNarrowingScope(UnionNarrowingScope&&) = delete;
     auto operator=(UnionNarrowingScope&&) -> UnionNarrowingScope& = delete;
 

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -157,6 +157,33 @@ class Codegen final : public ASTVisitor {
                                  UnionNarrowingStableKeyEq>>
       unionNarrowVariantStack;
 
+  /** Pushes a non-empty narrow map onto \c unionNarrowVariantStack in the ctor and pops in the
+   * dtor so the stack stays balanced if nested codegen throws (e.g. \c CodegenError). */
+  struct UnionNarrowingScope {
+    using MapTy =
+        std::unordered_map<UnionNarrowingStableKey, unsigned, UnionNarrowingStableKeyHash,
+                           UnionNarrowingStableKeyEq>;
+    UnionNarrowingScope(std::vector<MapTy>& stackRef, MapTy&& map)
+        : stack(stackRef), pushed(!map.empty()) {
+      if (pushed) {
+        stack.push_back(std::move(map));
+      }
+    }
+    ~UnionNarrowingScope() {
+      if (pushed) {
+        stack.pop_back();
+      }
+    }
+    UnionNarrowingScope(const UnionNarrowingScope&) = delete;
+    auto operator=(const UnionNarrowingScope&) = delete;
+    UnionNarrowingScope(UnionNarrowingScope&&) = delete;
+    auto operator=(UnionNarrowingScope&&) -> UnionNarrowingScope& = delete;
+
+  private:
+    std::vector<MapTy>& stack;
+    bool pushed;
+  };
+
   std::unique_ptr<llvm::DIBuilder> diBuilder;
   llvm::DICompileUnit* diCompileUnit = nullptr;
   llvm::DIFile* moduleDiFile = nullptr;

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -447,6 +447,8 @@ protected:
 
   /** Ensure \p type has an LLVM type (fill in when from typechecker). */
   auto getOrCreateLlvmType(lesma::Type* type) -> llvm::Type*;
+  /** LLVM integer tag type for \c TY_UNION (first struct field); requires \p unionTy to be a union. */
+  [[nodiscard]] auto getOrCreateUnionTagLlvmType(lesma::Type* unionTy) -> llvm::Type*;
   /** LLVM storage type for aggregate fields/slots after ABI lowering. */
   [[nodiscard]] auto getStoredAggregateFieldLlvmType(lesma::Type* fieldType) -> llvm::Type*;
   /** Load an aggregate field/slot value using the ABI-lowered storage type. */

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -2,6 +2,7 @@
 
 #include <deque>
 #include <memory>
+#include <optional>
 #include <stack>
 #include <string>
 #include <tuple>
@@ -149,6 +150,8 @@ class Codegen final : public ASTVisitor {
   bool emitDebugInfo = false;
   std::size_t lambdaCounter = 0U;
   llvm::OptimizationLevel optimizationLevelForDebug = llvm::OptimizationLevel::O3;
+  /** `if x is T` / else: maps parameter/local symbol → union variant index for narrowed loads. */
+  std::vector<std::unordered_map<lesma::Value*, unsigned>> unionNarrowVariantStack;
 
   std::unique_ptr<llvm::DIBuilder> diBuilder;
   llvm::DICompileUnit* diCompileUnit = nullptr;
@@ -218,6 +221,16 @@ protected:
   /** Alloca in \p fn's entry block (after PHIs) so LLVM mem2reg can promote loop/stack slots. */
   auto createAllocaInEntry(llvm::Function* fn, llvm::Type* elemTy, const std::string& name)
       -> llvm::AllocaInst*;
+
+  [[nodiscard]] auto lookupUnionNarrowVariant(lesma::Value* sym) const -> std::optional<unsigned>;
+  auto fillCodegenUnionNarrowVariantMap(const If* node, unsigned blockIndex,
+                                        std::unordered_map<lesma::Value*, unsigned>& out) -> void;
+  auto emitUnionWrapValue(llvm::SMRange span, lesma::Value* val, lesma::Type* unionTy,
+                          unsigned variantIndex) -> std::unique_ptr<lesma::Value>;
+  [[nodiscard]] auto unionVariantIndexOf(lesma::Type* unionTy, lesma::Type* memberTy) const
+      -> std::optional<unsigned>;
+  auto emitUnionPayloadLoadFromSlot(llvm::Value* unionAllocaPtr, lesma::Type* unionTy,
+                                    lesma::Type* memberTy) -> llvm::Value*;
 
   auto linkObjectFileWithLld(const std::string& objFilename) -> void;
 
@@ -318,6 +331,12 @@ protected:
   [[nodiscard]] auto isBuiltinListBuiltinMethodName(const std::string& methodName) const -> bool;
   /** True when class layout matches stdlib list (single __buffer field; not dict keys+vals). */
   [[nodiscard]] auto classHasSingleBufferStorageField(lesma::Type* classTy) const -> bool;
+  /** `unionValue.method(...)` when every union member is a class with a compatible method. */
+  auto emitUnionClassMethodDispatch(llvm::SMRange span, lesma::Value* unionValue,
+                                    const std::string& methodName,
+                                    const std::vector<lesma::Value*>& args,
+                                    const std::vector<lesma::Type*>& explicitTypeArgs)
+      -> std::unique_ptr<lesma::Value>;
   auto callMethodByName(llvm::SMRange span, lesma::Value* receiver, const std::string& methodName,
                         const std::vector<lesma::Value*>& args = {},
                         const std::vector<lesma::Type*>& explicitTypeArgs = {})

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -283,10 +283,31 @@ auto Codegen::substituteTypeForSpecializationEnv(
     return cacheType(std::move(tupleType));
   }
   if (t->is(BaseType::TY_UNION)) {
-    std::vector<Type*> members;
-    members.reserve(t->getUnionMembers().size());
+    std::vector<Type*> flat;
+    flat.reserve(t->getUnionMembers().size());
+    auto appendFlattened = [&](Type* cur, auto&& self) -> void {
+      if (cur == nullptr) {
+        return;
+      }
+      if (cur->is(BaseType::TY_UNION)) {
+        for (Type* inner : cur->getUnionMembers()) {
+          self(inner, self);
+        }
+      } else {
+        flat.push_back(cur);
+      }
+    };
     for (Type* m : t->getUnionMembers()) {
-      members.push_back(substituteTypeForSpecializationEnv(m, env));
+      Type* substituted = substituteTypeForSpecializationEnv(m, env);
+      appendFlattened(substituted, appendFlattened);
+    }
+    std::unordered_set<Type*> seen;
+    std::vector<Type*> members;
+    members.reserve(flat.size());
+    for (Type* m : flat) {
+      if (seen.insert(m).second) {
+        members.push_back(m);
+      }
     }
     std::ranges::sort(members, [](Type* a, Type* b) { return a->toString() < b->toString(); });
     std::string dn;

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -401,6 +401,56 @@ auto Codegen::bindGenericsFromTypePair(const TypeExpr* declared, lesma::Type* ac
       }
     }
     return;
+  case TokenType::INT8_TYPE:
+    if (!actual->is(BaseType::TY_INT) || actual->getIntWidth() != 8U || !actual->isSigned()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::INT16_TYPE:
+    if (!actual->is(BaseType::TY_INT) || actual->getIntWidth() != 16U || !actual->isSigned()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::INT32_TYPE:
+    if (!actual->is(BaseType::TY_INT) || actual->getIntWidth() != 32U || !actual->isSigned()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::UINT_TYPE:
+    // `uint` / `uint64`: 64-bit unsigned TY_INT in Codegen::visit(const TypeExpr*).
+    if (!actual->is(BaseType::TY_INT) || actual->getIntWidth() != 64U || actual->isSigned()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::UINT8_TYPE:
+    if (!actual->is(BaseType::TY_INT) || actual->getIntWidth() != 8U || actual->isSigned()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::UINT16_TYPE:
+    if (!actual->is(BaseType::TY_INT) || actual->getIntWidth() != 16U || actual->isSigned()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::UINT32_TYPE:
+    if (!actual->is(BaseType::TY_INT) || actual->getIntWidth() != 32U || actual->isSigned()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
   case TokenType::BOOL_TYPE:
     if (!actual->is(BaseType::TY_BOOL)) {
       if (bindingConflict != nullptr) {

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -27,8 +27,7 @@ auto Codegen::findGenericClassAstForTemplateType(Type* classTemplateTy) const ->
   }
   for (const auto& [id, ast] : genericClasses) {
     lesma::Value* sym = rootScope->lookupStruct(id);
-    if (sym != nullptr && sym->getType() != nullptr &&
-        sym->getType()->isEqual(classTemplateTy)) {
+    if (sym != nullptr && sym->getType() != nullptr && sym->getType()->isEqual(classTemplateTy)) {
       return ast;
     }
   }
@@ -83,7 +82,8 @@ auto Codegen::isTypeFullyConcrete(Type* t) const -> bool {
       }
       break;
     case BaseType::TY_CLASS:
-      if (auto envIt = specializedClassTypeEnvs.find(cur); envIt != specializedClassTypeEnvs.end()) {
+      if (auto envIt = specializedClassTypeEnvs.find(cur);
+          envIt != specializedClassTypeEnvs.end()) {
         for (const auto& [name, boundType] : envIt->second) {
           (void) name;
           if (!self(self, boundType)) {
@@ -127,8 +127,7 @@ auto Codegen::emitClassMonomorph(Type* specialized, const Class* templateAst) ->
 
   auto envIt = specializedClassTypeEnvs.find(specialized);
   if (envIt == specializedClassTypeEnvs.end()) {
-    throw CodegenError(templateAst->getSpan(),
-                       "Internal error: missing specialization env for {}",
+    throw CodegenError(templateAst->getSpan(), "Internal error: missing specialization env for {}",
                        specialized->getDisplayName());
   }
 
@@ -169,7 +168,8 @@ auto Codegen::emitClassMonomorph(Type* specialized, const Class* templateAst) ->
   std::string specializationKey =
       (alias.empty() ? "" : "&" + alias + "=>") + templateAst->getIdentifier();
   for (const auto& name : genericNames) {
-    specializationKey += "|" + MangleUtils::getTypeMangledName(templateAst->getSpan(), env.at(name));
+    specializationKey +=
+        "|" + MangleUtils::getTypeMangledName(templateAst->getSpan(), env.at(name));
   }
   specializedClasses[specializationKey] = structSymbolPtr;
 
@@ -194,7 +194,8 @@ auto Codegen::emitClassMonomorph(Type* specialized, const Class* templateAst) ->
   if (Type* superTy = specialized->getClassSuperclass();
       superTy != nullptr && superTy->is(BaseType::TY_CLASS)) {
     Type* superTemplate = superTy;
-    if (auto it = specializedClassTemplateOf.find(superTy); it != specializedClassTemplateOf.end()) {
+    if (auto it = specializedClassTemplateOf.find(superTy);
+        it != specializedClassTemplateOf.end()) {
       superTemplate = it->second;
     }
     if (const Class* superAst = findGenericClassAstForTemplateType(superTemplate);
@@ -236,8 +237,9 @@ auto Codegen::emitClassMonomorph(Type* specialized, const Class* templateAst) ->
   return structSymbolPtr;
 }
 
-auto Codegen::substituteTypeForSpecializationEnv(
-    Type* t, const std::unordered_map<std::string, Type*>& env) -> Type* {
+auto Codegen::substituteTypeForSpecializationEnv(Type* t,
+                                                 const std::unordered_map<std::string, Type*>& env)
+    -> Type* {
   if (t == nullptr) {
     return nullptr;
   }
@@ -371,7 +373,8 @@ auto Codegen::substituteTypeForSpecializationEnv(
     if (allBound) {
       const std::string registryKey =
           TypeUtils::makeSpecializedClassKey(classTemplate, genericParamNames, classEnv);
-      if (auto it = specializedClassTypesByKey.find(registryKey); it != specializedClassTypesByKey.end()) {
+      if (auto it = specializedClassTypesByKey.find(registryKey);
+          it != specializedClassTypesByKey.end()) {
         return it->second;
       }
     }
@@ -384,6 +387,80 @@ auto Codegen::bindGenericsFromTypePair(const TypeExpr* declared, lesma::Type* ac
                                        std::unordered_map<std::string, lesma::Type*>& env,
                                        bool* bindingConflict) -> void {
   if (declared == nullptr || actual == nullptr) {
+    return;
+  }
+  switch (declared->getType()) {
+  case TokenType::INT_TYPE:
+    if (!actual->is(BaseType::TY_INT)) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::BOOL_TYPE:
+    if (!actual->is(BaseType::TY_BOOL)) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::FLOAT_TYPE:
+  case TokenType::FLOAT32_TYPE:
+    if (!actual->isFloatingPoint()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  case TokenType::STRING_TYPE:
+    if (!actual->is(BaseType::TY_CLASS) || actual->getDisplayName() != "str") {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
+  default:
+    break;
+  }
+  if (declared->getType() == TokenType::UNION_TYPE && actual->is(BaseType::TY_UNION)) {
+    const auto declArms = declared->getParams();
+    const auto& actualMem = actual->getUnionMembers();
+    if (declArms.size() != actualMem.size()) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+      return;
+    }
+    std::vector<bool> used(actualMem.size(), false);
+    auto tryBind = [&](auto&& self, size_t fi,
+                       std::unordered_map<std::string, lesma::Type*> trial) -> bool {
+      if (fi == declArms.size()) {
+        env = std::move(trial);
+        return true;
+      }
+      for (size_t aj = 0; aj < actualMem.size(); ++aj) {
+        if (used[aj]) {
+          continue;
+        }
+        auto probe = trial;
+        bool c = false;
+        bindGenericsFromTypePair(declArms[fi], actualMem[aj], genericNameSet, probe, &c);
+        if (c) {
+          continue;
+        }
+        used[aj] = true;
+        if (self(self, fi + 1, std::move(probe))) {
+          return true;
+        }
+        used[aj] = false;
+      }
+      return false;
+    };
+    if (!tryBind(tryBind, 0, env)) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
     return;
   }
   if (declared->getType() == TokenType::CUSTOM_TYPE) {
@@ -524,16 +601,16 @@ auto Codegen::appendGenericBindingSuffix(llvm::SMRange span, std::string& base,
   }
 }
 
-auto Codegen::specializeFunction(const FuncDecl* node, const std::vector<lesma::Type*>& paramTypes,
-                                 const std::vector<std::string>& genericNames,
-                                 const std::vector<lesma::Type*>& explicitTypeArgs,
-                                 const std::unordered_map<std::string, lesma::Type*>* bindingEnvHint)
-    -> lesma::Value* {
+auto Codegen::specializeFunction(
+    const FuncDecl* node, const std::vector<lesma::Type*>& paramTypes,
+    const std::vector<std::string>& genericNames, const std::vector<lesma::Type*>& explicitTypeArgs,
+    const std::unordered_map<std::string, lesma::Type*>* bindingEnvHint) -> lesma::Value* {
   Value* templateSym = node->getResolvedSymbol();
   auto saved = currentGenericTypes;
-  auto env = bindingEnvHint != nullptr
-                 ? *bindingEnvHint
-                 : computeGenericFunctionBindingEnv(node, paramTypes, genericNames, explicitTypeArgs);
+  auto env =
+      bindingEnvHint != nullptr
+          ? *bindingEnvHint
+          : computeGenericFunctionBindingEnv(node, paramTypes, genericNames, explicitTypeArgs);
   currentGenericTypes = env;
 
   for (auto* paramType : paramTypes) {
@@ -847,9 +924,8 @@ auto Codegen::specializeClass(const Class* node,
     }
   }
 
-  auto envIsFullyConcrete = [this](
-                                const std::unordered_map<std::string, lesma::Type*>& bindings)
-      -> bool {
+  auto envIsFullyConcrete =
+      [this](const std::unordered_map<std::string, lesma::Type*>& bindings) -> bool {
     for (const auto& [name, ty] : bindings) {
       (void) name;
       if (!isTypeFullyConcrete(ty)) {
@@ -864,7 +940,8 @@ auto Codegen::specializeClass(const Class* node,
   std::string registryKey;
   if (templateType != nullptr && !genericNames.empty()) {
     registryKey = TypeUtils::makeSpecializedClassKey(templateType, genericNames, env);
-    if (auto it = specializedClassTypesByKey.find(registryKey); it != specializedClassTypesByKey.end()) {
+    if (auto it = specializedClassTypesByKey.find(registryKey);
+        it != specializedClassTypesByKey.end()) {
       if (envIsFullyConcrete(env)) {
         return emitClassMonomorph(it->second, node);
       }
@@ -942,8 +1019,7 @@ auto Codegen::specializeClass(const Class* node,
   std::vector<llvm::Type*> elementLLVMTypes;
   elementLLVMTypes.push_back(builder->getPtrTy());
   lesma::Value* tmplSymForFields = scope->lookupStruct(node->getIdentifier());
-  Type* tmplTyForFields =
-      tmplSymForFields != nullptr ? tmplSymForFields->getType() : nullptr;
+  Type* tmplTyForFields = tmplSymForFields != nullptr ? tmplSymForFields->getType() : nullptr;
 
   if (!node->getGenericParams().empty() && tmplTyForFields != nullptr) {
     for (Field* f : tmplTyForFields->getFields()) {
@@ -972,8 +1048,8 @@ auto Codegen::specializeClass(const Class* node,
           result = std::make_unique<Value>(*defaultVal);
         }
       }
-      typePtr->addField(std::make_unique<Field>(field->getIdentifier()->getValue(), result->getType(),
-                                                std::move(defaultVal)));
+      typePtr->addField(std::make_unique<Field>(field->getIdentifier()->getValue(),
+                                                result->getType(), std::move(defaultVal)));
     }
   }
 

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -116,6 +116,33 @@ auto Codegen::isTypeFullyConcrete(Type* t) const -> bool {
   return isTypeFullyConcreteImpl(isTypeFullyConcreteImpl, t);
 }
 
+auto Codegen::typeWithSingletonUnionsCollapsed(Type* t) -> Type* {
+  if (t == nullptr) {
+    return nullptr;
+  }
+  while (t->is(BaseType::TY_UNION) && t->getUnionMembers().size() == 1U) {
+    Type* inner = t->getUnionMembers()[0];
+    if (inner == nullptr) {
+      break;
+    }
+    t = inner;
+  }
+  if (t->is(BaseType::TY_PTR) && t->getElementType() != nullptr) {
+    Type* inner = typeWithSingletonUnionsCollapsed(t->getElementType());
+    if (inner != t->getElementType()) {
+      return cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, inner));
+    }
+  } else if (t->is(BaseType::TY_ARRAY) && t->getElementType() != nullptr) {
+    Type* inner = typeWithSingletonUnionsCollapsed(t->getElementType());
+    if (inner != t->getElementType()) {
+      auto* arr = cacheType(std::make_unique<Type>(BaseType::TY_ARRAY, nullptr, inner));
+      arr->setDisplayName(t->getDisplayName());
+      return arr;
+    }
+  }
+  return t;
+}
+
 auto Codegen::emitClassMonomorph(Type* specialized, const Class* templateAst) -> lesma::Value* {
   if (specialized == nullptr || templateAst == nullptr) {
     throw CodegenError({}, "Internal error: emitClassMonomorph requires specialized class input");
@@ -129,6 +156,15 @@ auto Codegen::emitClassMonomorph(Type* specialized, const Class* templateAst) ->
   if (envIt == specializedClassTypeEnvs.end()) {
     throw CodegenError(templateAst->getSpan(), "Internal error: missing specialization env for {}",
                        specialized->getDisplayName());
+  }
+
+  for (auto& nameAndTy : envIt->second) {
+    nameAndTy.second = typeWithSingletonUnionsCollapsed(nameAndTy.second);
+  }
+  for (Field* field : specialized->getFields()) {
+    if (field->type != nullptr) {
+      field->type = typeWithSingletonUnionsCollapsed(field->type);
+    }
   }
 
   const auto& env = envIt->second;
@@ -493,6 +529,10 @@ auto Codegen::bindGenericsFromTypePair(const TypeExpr* declared, lesma::Type* ac
       }
       return;
     }
+    std::unordered_map<std::string, lesma::Type*> genericPlaceholders;
+    for (const auto& name : genericNameSet) {
+      genericPlaceholders.emplace(name, cacheType(std::make_unique<lesma::Type>(name)));
+    }
     std::vector<bool> used(actualMem.size(), false);
     auto tryBind = [&](auto&& self, size_t fi,
                        std::unordered_map<std::string, lesma::Type*> trial) -> bool {
@@ -502,6 +542,40 @@ auto Codegen::bindGenericsFromTypePair(const TypeExpr* declared, lesma::Type* ac
       }
       for (size_t aj = 0; aj < actualMem.size(); ++aj) {
         if (used[aj]) {
+          continue;
+        }
+        // Match Typechecker::inferGenericBindings: only pair arms with pmem[fi]->isEqual(amem[aj])
+        // before inferring. Lower the declared arm under trial + TY_GENERIC placeholders for
+        // unbound params (same idea as resolveType with currentGenericTypes).
+        auto savedGenerics = currentGenericTypes;
+        auto savedResult = std::move(result);
+        std::unordered_map<std::string, lesma::Type*> merged = savedGenerics;
+        for (const auto& kv : trial) {
+          merged[kv.first] = kv.second;
+        }
+        for (const auto& name : genericNameSet) {
+          if (merged.find(name) == merged.end()) {
+            merged[name] = genericPlaceholders.at(name);
+          }
+        }
+        currentGenericTypes = std::move(merged);
+        lesma::Type* declArmTy = nullptr;
+        try {
+          declArms[fi]->accept(*this);
+          declArmTy = result != nullptr ? result->getType() : nullptr;
+        } catch (const CodegenError&) {
+          declArmTy = nullptr;
+        }
+        result = std::move(savedResult);
+        currentGenericTypes = std::move(savedGenerics);
+        if (declArmTy == nullptr) {
+          continue;
+        }
+        // Typechecker::inferGenericBindings tests pmem[fi]->isEqual(amem[aj]) before recursing; that
+        // is false for TY_GENERIC vs concrete, so viable pairings are discovered via infer, not
+        // structural equality on the open arm. Require isEqual only when the declared arm is already
+        // concrete so we do not pair e.g. `int` with `str` before bindGenericsFromTypePair runs.
+        if (!declArmTy->is(BaseType::TY_GENERIC) && !declArmTy->isEqual(actualMem[aj])) {
           continue;
         }
         auto probe = trial;

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -331,6 +331,7 @@ auto Codegen::substituteTypeForSpecializationEnv(
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
     u->setUnionMembers(std::move(members));
     u->setDisplayName(dn);
+    u->setDeclarationSpan(t->getDeclarationSpan());
     return cacheType(std::move(u));
   }
   if (t->is(BaseType::TY_CLASS)) {

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -301,11 +301,22 @@ auto Codegen::substituteTypeForSpecializationEnv(
       Type* substituted = substituteTypeForSpecializationEnv(m, env);
       appendFlattened(substituted, appendFlattened);
     }
-    std::unordered_set<Type*> seen;
     std::vector<Type*> members;
     members.reserve(flat.size());
     for (Type* m : flat) {
-      if (seen.insert(m).second) {
+      bool duplicate = false;
+      for (Type* existing : members) {
+        if (m == nullptr) {
+          if (existing == nullptr) {
+            duplicate = true;
+            break;
+          }
+        } else if (existing != nullptr && m->isEqual(existing)) {
+          duplicate = true;
+          break;
+        }
+      }
+      if (!duplicate) {
         members.push_back(m);
       }
     }

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -322,6 +322,9 @@ auto Codegen::substituteTypeForSpecializationEnv(Type* t,
         members.push_back(m);
       }
     }
+    if (members.size() == 1U) {
+      return members.front();
+    }
     std::ranges::sort(members, [](Type* a, Type* b) { return a->toString() < b->toString(); });
     std::string dn;
     for (size_t i = 0; i < members.size(); ++i) {

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -938,13 +938,9 @@ auto Codegen::specializeClass(const Class* node,
 
   auto envIsFullyConcrete =
       [this](const std::unordered_map<std::string, lesma::Type*>& bindings) -> bool {
-    for (const auto& [name, ty] : bindings) {
-      (void) name;
-      if (!isTypeFullyConcrete(ty)) {
-        return false;
-      }
-    }
-    return true;
+    return std::ranges::all_of(bindings, [this](const auto& nameAndTy) {
+      return isTypeFullyConcrete(nameAndTy.second);
+    });
   };
 
   Value* templateSymbol = scope->lookupStruct(node->getIdentifier());

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -68,6 +69,14 @@ auto Codegen::isTypeFullyConcrete(Type* t) const -> bool {
     case BaseType::TY_ENUM:
       for (Field* field : cur->getFields()) {
         if (!self(self, field->type)) {
+          isConcrete = false;
+          break;
+        }
+      }
+      break;
+    case BaseType::TY_UNION:
+      for (Type* m : cur->getUnionMembers()) {
+        if (!self(self, m)) {
           isConcrete = false;
           break;
         }
@@ -272,6 +281,25 @@ auto Codegen::substituteTypeForSpecializationEnv(
     auto tupleType = std::make_unique<Type>(BaseType::TY_TUPLE, nullptr, std::move(fields));
     tupleType->setDisplayName(t->getDisplayName());
     return cacheType(std::move(tupleType));
+  }
+  if (t->is(BaseType::TY_UNION)) {
+    std::vector<Type*> members;
+    members.reserve(t->getUnionMembers().size());
+    for (Type* m : t->getUnionMembers()) {
+      members.push_back(substituteTypeForSpecializationEnv(m, env));
+    }
+    std::ranges::sort(members, [](Type* a, Type* b) { return a->toString() < b->toString(); });
+    std::string dn;
+    for (size_t i = 0; i < members.size(); ++i) {
+      if (i > 0) {
+        dn += " | ";
+      }
+      dn += members[i]->toString();
+    }
+    auto u = std::make_unique<Type>(BaseType::TY_UNION);
+    u->setUnionMembers(std::move(members));
+    u->setDisplayName(dn);
+    return cacheType(std::move(u));
   }
   if (t->is(BaseType::TY_CLASS)) {
     Type* classTemplate = t;

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -321,53 +321,14 @@ auto Codegen::substituteTypeForSpecializationEnv(Type* t,
     return cacheType(std::move(tupleType));
   }
   if (t->is(BaseType::TY_UNION)) {
-    std::vector<Type*> flat;
-    flat.reserve(t->getUnionMembers().size());
-    auto appendFlattened = [&](Type* cur, auto&& self) -> void {
-      if (cur == nullptr) {
-        return;
-      }
-      if (cur->is(BaseType::TY_UNION)) {
-        for (Type* inner : cur->getUnionMembers()) {
-          self(inner, self);
-        }
-      } else {
-        flat.push_back(cur);
-      }
-    };
+    std::vector<Type*> arms;
+    arms.reserve(t->getUnionMembers().size());
     for (Type* m : t->getUnionMembers()) {
-      Type* substituted = substituteTypeForSpecializationEnv(m, env);
-      appendFlattened(substituted, appendFlattened);
+      arms.push_back(substituteTypeForSpecializationEnv(m, env));
     }
-    std::vector<Type*> members;
-    members.reserve(flat.size());
-    for (Type* m : flat) {
-      bool duplicate = false;
-      for (Type* existing : members) {
-        if (m == nullptr) {
-          if (existing == nullptr) {
-            duplicate = true;
-            break;
-          }
-        } else if (existing != nullptr && m->isEqual(existing)) {
-          duplicate = true;
-          break;
-        }
-      }
-      if (!duplicate) {
-        members.push_back(m);
-      }
-    }
+    auto [members, dn] = TypeUtils::canonicalizeUnionMembers(std::move(arms));
     if (members.size() == 1U) {
       return members.front();
-    }
-    std::ranges::sort(members, [](Type* a, Type* b) { return a->toString() < b->toString(); });
-    std::string dn;
-    for (size_t i = 0; i < members.size(); ++i) {
-      if (i > 0) {
-        dn += " | ";
-      }
-      dn += members[i]->toString();
     }
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
     u->setUnionMembers(std::move(members));

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -394,7 +394,8 @@ auto Codegen::bindGenericsFromTypePair(const TypeExpr* declared, lesma::Type* ac
   }
   switch (declared->getType()) {
   case TokenType::INT_TYPE:
-    if (!actual->is(BaseType::TY_INT)) {
+    // Plain `int` / `int64`: Codegen::visit(TypeExpr*) lowers to 64-bit signed TY_INT only.
+    if (!actual->is(BaseType::TY_INT) || actual->getIntWidth() != 64U || !actual->isSigned()) {
       if (bindingConflict != nullptr) {
         *bindingConflict = true;
       }
@@ -408,15 +409,23 @@ auto Codegen::bindGenericsFromTypePair(const TypeExpr* declared, lesma::Type* ac
     }
     return;
   case TokenType::FLOAT_TYPE:
+    if (!actual->is(BaseType::TY_FLOAT)) {
+      if (bindingConflict != nullptr) {
+        *bindingConflict = true;
+      }
+    }
+    return;
   case TokenType::FLOAT32_TYPE:
-    if (!actual->isFloatingPoint()) {
+    if (!actual->is(BaseType::TY_FLOAT32)) {
       if (bindingConflict != nullptr) {
         *bindingConflict = true;
       }
     }
     return;
   case TokenType::STRING_TYPE:
-    if (!actual->is(BaseType::TY_CLASS) || actual->getDisplayName() != "str") {
+    // `cstr` in type position is TY_STRING in Codegen::visit(const TypeExpr*), not the stdlib str
+    // class (that path uses CUSTOM_TYPE + lookup name "str").
+    if (!actual->is(BaseType::TY_STRING)) {
       if (bindingConflict != nullptr) {
         *bindingConflict = true;
       }

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -165,52 +165,17 @@ auto Codegen::visit(const TypeExpr* node) -> void {
     result = std::make_unique<Value>(cached);
   } else if (node->getType() == TokenType::UNION_TYPE) {
     std::vector<Type*> members;
-    std::string displayName;
+    members.reserve(node->getParams().size());
     for (TypeExpr* param : node->getParams()) {
       param->accept(*this);
-      Type* elemTy = result->getType();
-      if (!members.empty()) {
-        displayName += " | ";
-      }
-      displayName += elemTy->toString();
-      members.push_back(elemTy);
+      members.push_back(result->getType());
     }
-    std::vector<Type*> flat;
-    for (Type* t : members) {
-      if (t->is(BaseType::TY_UNION)) {
-        for (Type* inner : t->getUnionMembers()) {
-          flat.push_back(inner);
-        }
-      } else {
-        flat.push_back(t);
-      }
-    }
-    std::vector<Type*> unique;
-    for (Type* t : flat) {
-      bool dup = false;
-      for (Type* u : unique) {
-        if (t->isEqual(u)) {
-          dup = true;
-          break;
-        }
-      }
-      if (!dup) {
-        unique.push_back(t);
-      }
-    }
-    std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
+    auto [unique, displayName] = TypeUtils::canonicalizeUnionMembers(std::move(members));
     if (unique.size() == 1U) {
       Type* cached = unique[0];
       getOrCreateLlvmType(cached);
       result = std::make_unique<Value>(cached);
     } else {
-      displayName.clear();
-      for (size_t i = 0; i < unique.size(); ++i) {
-        if (i > 0) {
-          displayName += " | ";
-        }
-        displayName += unique[i]->toString();
-      }
       auto u = std::make_unique<Type>(BaseType::TY_UNION);
       u->setUnionMembers(std::move(unique));
       u->setDisplayName(displayName);

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -388,7 +388,7 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
     unsigned maxAlloc = 0;
     unsigned maxAbiAlign = 1;
     for (Type* m : mem) {
-      llvm::Type* lt = m->getLlvmType();
+      llvm::Type* const lt = getStoredAggregateFieldLlvmType(m);
       maxAlloc = std::max(maxAlloc, static_cast<unsigned>(dl.getTypeAllocSize(lt).getFixedValue()));
       maxAbiAlign =
           std::max(maxAbiAlign, static_cast<unsigned>(dl.getABITypeAlign(lt).value()));

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -216,6 +216,7 @@ auto Codegen::visit(const TypeExpr* node) -> void {
       auto u = std::make_unique<Type>(BaseType::TY_UNION);
       u->setUnionMembers(std::move(unique));
       u->setDisplayName(displayName);
+      u->setDeclarationSpan(node->getSpan());
       Type* cached = cacheType(std::move(u));
       getOrCreateLlvmType(cached);
       result = std::make_unique<Value>(cached);
@@ -375,9 +376,10 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
     break;
   }
   case BaseType::TY_UNION: {
+    llvm::SMRange const unionDeclSpan = type->getDeclarationSpan();
     const std::vector<Type*>& mem = type->getUnionMembers();
     if (mem.empty()) {
-      throw CodegenError({}, "Internal error: union type has no members");
+      throw CodegenError(unionDeclSpan, "Internal error: union type has no members");
     }
     for (Type* m : mem) {
       getOrCreateLlvmType(m);
@@ -398,7 +400,7 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
     unsigned const tagBitWidth = roundUnionTagToSupportedBitWidth(minTagBits);
     if (tagBitWidth == 0) {
       throw CodegenError(
-          {},
+          unionDeclSpan,
           "Union has too many members for the discriminant (tag width would exceed 64 bits)");
     }
     llvm::Type* const tagTy = builder->getIntNTy(tagBitWidth);
@@ -454,7 +456,9 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
 
 auto Codegen::getOrCreateUnionTagLlvmType(lesma::Type* unionTy) -> llvm::Type* {
   if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION)) {
-    throw CodegenError({}, "Internal error: getOrCreateUnionTagLlvmType expects a union type");
+    llvm::SMRange const span =
+        unionTy != nullptr ? unionTy->getDeclarationSpan() : llvm::SMRange{};
+    throw CodegenError(span, "Internal error: getOrCreateUnionTagLlvmType expects a union type");
   }
   getOrCreateLlvmType(unionTy);
   auto* st = llvm::cast<llvm::StructType>(unionTy->getLlvmType());

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -29,8 +29,12 @@ auto traitExistentialBaseName(const std::string& displayName) -> std::string {
   return displayName;
 }
 
-/** Minimum tag bits: ceil(log2(memberCount)), at least 1 (memberCount must be > 0). */
-auto unionDiscriminantMinBits(std::size_t memberCount) -> unsigned {
+} // namespace
+
+using namespace lesma;
+using namespace llvm;
+
+auto Codegen::unionDiscriminantMinBits(std::size_t memberCount) -> unsigned {
   unsigned bits = 0;
   for (std::size_t x = memberCount - 1; x != 0; x >>= 1) {
     ++bits;
@@ -38,8 +42,7 @@ auto unionDiscriminantMinBits(std::size_t memberCount) -> unsigned {
   return std::max(1U, bits);
 }
 
-/** Round up to a whole number of bytes (8, 16, 32, 64); 0 if \p minBits > 64. */
-auto roundUnionTagToSupportedBitWidth(unsigned minBits) -> unsigned {
+auto Codegen::roundUnionTagToSupportedBitWidth(unsigned minBits) -> unsigned {
   if (minBits <= 8) {
     return 8;
   }
@@ -54,11 +57,6 @@ auto roundUnionTagToSupportedBitWidth(unsigned minBits) -> unsigned {
   }
   return 0;
 }
-
-} // namespace
-
-using namespace lesma;
-using namespace llvm;
 
 auto Codegen::visit(const TypeExpr* node) -> void {
   // For primitive types, cache them so they survive beyond result's lifetime

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -201,19 +201,25 @@ auto Codegen::visit(const TypeExpr* node) -> void {
       }
     }
     std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
-    displayName.clear();
-    for (size_t i = 0; i < unique.size(); ++i) {
-      if (i > 0) {
-        displayName += " | ";
+    if (unique.size() == 1U) {
+      Type* cached = unique[0];
+      getOrCreateLlvmType(cached);
+      result = std::make_unique<Value>(cached);
+    } else {
+      displayName.clear();
+      for (size_t i = 0; i < unique.size(); ++i) {
+        if (i > 0) {
+          displayName += " | ";
+        }
+        displayName += unique[i]->toString();
       }
-      displayName += unique[i]->toString();
+      auto u = std::make_unique<Type>(BaseType::TY_UNION);
+      u->setUnionMembers(std::move(unique));
+      u->setDisplayName(displayName);
+      Type* cached = cacheType(std::move(u));
+      getOrCreateLlvmType(cached);
+      result = std::make_unique<Value>(cached);
     }
-    auto u = std::make_unique<Type>(BaseType::TY_UNION);
-    u->setUnionMembers(std::move(unique));
-    u->setDisplayName(displayName);
-    Type* cached = cacheType(std::move(u));
-    getOrCreateLlvmType(cached);
-    result = std::make_unique<Value>(cached);
   } else if (node->getType() == TokenType::CUSTOM_TYPE) {
     const std::string lookupName = node->getLookupName();
     auto git = currentGenericTypes.find(lookupName);

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,32 @@ auto traitExistentialBaseName(const std::string& displayName) -> std::string {
     return displayName.substr(0U, pos);
   }
   return displayName;
+}
+
+/** Minimum tag bits: ceil(log2(memberCount)), at least 1 (memberCount must be > 0). */
+auto unionDiscriminantMinBits(std::size_t memberCount) -> unsigned {
+  unsigned bits = 0;
+  for (std::size_t x = memberCount - 1; x != 0; x >>= 1) {
+    ++bits;
+  }
+  return std::max(1U, bits);
+}
+
+/** Round up to a whole number of bytes (8, 16, 32, 64); 0 if \p minBits > 64. */
+auto roundUnionTagToSupportedBitWidth(unsigned minBits) -> unsigned {
+  if (minBits <= 8) {
+    return 8;
+  }
+  if (minBits <= 16) {
+    return 16;
+  }
+  if (minBits <= 32) {
+    return 32;
+  }
+  if (minBits <= 64) {
+    return 64;
+  }
+  return 0;
 }
 
 } // namespace
@@ -343,6 +370,9 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
   }
   case BaseType::TY_UNION: {
     const std::vector<Type*>& mem = type->getUnionMembers();
+    if (mem.empty()) {
+      throw CodegenError({}, "Internal error: union type has no members");
+    }
     for (Type* m : mem) {
       getOrCreateLlvmType(m);
     }
@@ -358,8 +388,15 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
     unsigned const payloadBytes = llvm::alignTo(maxAlloc, maxAbiAlign);
     unsigned const numI64 = std::max(1U, (payloadBytes + 7U) / 8U);
     llvm::Type* const payloadTy = llvm::ArrayType::get(builder->getInt64Ty(), numI64);
-    llvm::StructType* const st = llvm::StructType::get(theModule->getContext(),
-                                                       {builder->getInt8Ty(), payloadTy});
+    unsigned const minTagBits = unionDiscriminantMinBits(mem.size());
+    unsigned const tagBitWidth = roundUnionTagToSupportedBitWidth(minTagBits);
+    if (tagBitWidth == 0) {
+      throw CodegenError(
+          {},
+          "Union has too many members for the discriminant (tag width would exceed 64 bits)");
+    }
+    llvm::Type* const tagTy = builder->getIntNTy(tagBitWidth);
+    llvm::StructType* const st = llvm::StructType::get(theModule->getContext(), {tagTy, payloadTy});
     type->setLlvmType(st);
     break;
   }
@@ -407,6 +444,15 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
     break;
   }
   return type->getLlvmType();
+}
+
+auto Codegen::getOrCreateUnionTagLlvmType(lesma::Type* unionTy) -> llvm::Type* {
+  if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION)) {
+    throw CodegenError({}, "Internal error: getOrCreateUnionTagLlvmType expects a union type");
+  }
+  getOrCreateLlvmType(unionTy);
+  auto* st = llvm::cast<llvm::StructType>(unionTy->getLlvmType());
+  return st->getElementType(0U);
 }
 
 auto Codegen::getStoredAggregateFieldLlvmType(lesma::Type* fieldType) -> llvm::Type* {

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -388,8 +388,7 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
     for (Type* m : mem) {
       llvm::Type* const lt = getStoredAggregateFieldLlvmType(m);
       maxAlloc = std::max(maxAlloc, static_cast<unsigned>(dl.getTypeAllocSize(lt).getFixedValue()));
-      maxAbiAlign =
-          std::max(maxAbiAlign, static_cast<unsigned>(dl.getABITypeAlign(lt).value()));
+      maxAbiAlign = std::max(maxAbiAlign, static_cast<unsigned>(dl.getABITypeAlign(lt).value()));
     }
     unsigned const payloadBytes = llvm::alignTo(maxAlloc, maxAbiAlign);
     unsigned const numI64 = std::max(1U, (payloadBytes + 7U) / 8U);
@@ -454,8 +453,7 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
 
 auto Codegen::getOrCreateUnionTagLlvmType(lesma::Type* unionTy) -> llvm::Type* {
   if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION)) {
-    llvm::SMRange const span =
-        unionTy != nullptr ? unionTy->getDeclarationSpan() : llvm::SMRange{};
+    llvm::SMRange const span = unionTy != nullptr ? unionTy->getDeclarationSpan() : llvm::SMRange{};
     throw CodegenError(span, "Internal error: getOrCreateUnionTagLlvmType expects a union type");
   }
   getOrCreateLlvmType(unionTy);
@@ -475,7 +473,7 @@ auto Codegen::getStoredAggregateFieldLlvmType(lesma::Type* fieldType) -> llvm::T
 }
 
 auto Codegen::loadStoredAggregateFieldValue(llvm::Value* slotPtr, lesma::Type* fieldType,
-                                           const llvm::Twine& name) -> llvm::Value* {
+                                            const llvm::Twine& name) -> llvm::Value* {
   return builder->CreateLoad(getStoredAggregateFieldLlvmType(fieldType), slotPtr, name);
 }
 
@@ -526,7 +524,8 @@ auto Codegen::captureImportedSpecializationState() const -> ImportedSpecializati
   return importedState;
 }
 
-auto Codegen::mergeImportedSpecializationState(ImportedSpecializationState const& imported) -> void {
+auto Codegen::mergeImportedSpecializationState(ImportedSpecializationState const& imported)
+    -> void {
   for (const auto& entry : imported.genericClasses) {
     genericClasses.insert(entry);
   }
@@ -611,7 +610,7 @@ auto Codegen::emitErasedThunkForTraitMethod(lesma::Type* classType, const std::s
 
   std::string thunkName = "lesma.trait.thunk." + cacheKey;
   for (char& c : thunkName) {
-    if (!(std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '.' || c == '_')) {
+    if (std::isalnum(static_cast<unsigned char>(c)) == 0 && c != '.' && c != '_') {
       c = '_';
     }
   }
@@ -668,7 +667,7 @@ auto Codegen::getOrEmitWitnessTable(lesma::Type* classType, const std::string& t
   llvm::Constant* init = llvm::ConstantArray::get(at, constants);
   std::string gname = "lesma.witness." + cacheKey;
   for (char& c : gname) {
-    if (!(std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '.' || c == '_')) {
+    if (std::isalnum(static_cast<unsigned char>(c)) == 0 && c != '.' && c != '_') {
       c = '_';
     }
   }

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -135,6 +136,55 @@ auto Codegen::visit(const TypeExpr* node) -> void {
     auto tup = std::make_unique<Type>(BaseType::TY_TUPLE, nullptr, std::move(fields));
     tup->setDisplayName(displayName);
     Type* cached = cacheType(std::move(tup));
+    getOrCreateLlvmType(cached);
+    result = std::make_unique<Value>(cached);
+  } else if (node->getType() == TokenType::UNION_TYPE) {
+    std::vector<Type*> members;
+    std::string displayName;
+    for (TypeExpr* param : node->getParams()) {
+      param->accept(*this);
+      Type* elemTy = result->getType();
+      if (!members.empty()) {
+        displayName += " | ";
+      }
+      displayName += elemTy->toString();
+      members.push_back(elemTy);
+    }
+    std::vector<Type*> flat;
+    for (Type* t : members) {
+      if (t->is(BaseType::TY_UNION)) {
+        for (Type* inner : t->getUnionMembers()) {
+          flat.push_back(inner);
+        }
+      } else {
+        flat.push_back(t);
+      }
+    }
+    std::vector<Type*> unique;
+    for (Type* t : flat) {
+      bool dup = false;
+      for (Type* u : unique) {
+        if (t->isEqual(u)) {
+          dup = true;
+          break;
+        }
+      }
+      if (!dup) {
+        unique.push_back(t);
+      }
+    }
+    std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
+    displayName.clear();
+    for (size_t i = 0; i < unique.size(); ++i) {
+      if (i > 0) {
+        displayName += " | ";
+      }
+      displayName += unique[i]->toString();
+    }
+    auto u = std::make_unique<Type>(BaseType::TY_UNION);
+    u->setUnionMembers(std::move(unique));
+    u->setDisplayName(displayName);
+    Type* cached = cacheType(std::move(u));
     getOrCreateLlvmType(cached);
     result = std::make_unique<Value>(cached);
   } else if (node->getType() == TokenType::CUSTOM_TYPE) {
@@ -288,6 +338,28 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
         st = llvm::StructType::create(theModule->getContext(), elementTypes);
       }
     }
+    type->setLlvmType(st);
+    break;
+  }
+  case BaseType::TY_UNION: {
+    const std::vector<Type*>& mem = type->getUnionMembers();
+    for (Type* m : mem) {
+      getOrCreateLlvmType(m);
+    }
+    const llvm::DataLayout& dl = theModule->getDataLayout();
+    unsigned maxAlloc = 0;
+    unsigned maxAbiAlign = 1;
+    for (Type* m : mem) {
+      llvm::Type* lt = m->getLlvmType();
+      maxAlloc = std::max(maxAlloc, static_cast<unsigned>(dl.getTypeAllocSize(lt).getFixedValue()));
+      maxAbiAlign =
+          std::max(maxAbiAlign, static_cast<unsigned>(dl.getABITypeAlign(lt).value()));
+    }
+    unsigned const payloadBytes = llvm::alignTo(maxAlloc, maxAbiAlign);
+    unsigned const numI64 = std::max(1U, (payloadBytes + 7U) / 8U);
+    llvm::Type* const payloadTy = llvm::ArrayType::get(builder->getInt64Ty(), numI64);
+    llvm::StructType* const st = llvm::StructType::get(theModule->getContext(),
+                                                       {builder->getInt8Ty(), payloadTy});
     type->setLlvmType(st);
     break;
   }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -880,8 +880,7 @@ auto Codegen::visit(const VarDecl* node) -> void {
   }
 }
 
-namespace {
-auto cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> lesma::Value* {
+auto Codegen::cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> lesma::Value* {
   if (is == nullptr) {
     return nullptr;
   }
@@ -895,7 +894,7 @@ auto cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> lesma::Va
   return scope->lookup(lit->getValue());
 }
 
-auto cgUnionComplementMemberIndex(lesma::Type* unionTy, lesma::Type* excluded)
+auto Codegen::cgUnionComplementMemberIndex(lesma::Type* unionTy, lesma::Type* excluded)
     -> std::optional<unsigned> {
   if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION) || excluded == nullptr) {
     return std::nullopt;
@@ -911,7 +910,6 @@ auto cgUnionComplementMemberIndex(lesma::Type* unionTy, lesma::Type* excluded)
   }
   return std::nullopt;
 }
-} // namespace
 
 auto Codegen::lookupUnionNarrowVariant(lesma::Value* sym) const -> std::optional<unsigned> {
   if (sym == nullptr) {
@@ -956,8 +954,10 @@ auto Codegen::fillCodegenUnionNarrowVariantMap(const If* node, unsigned blockInd
     if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
       return;
     }
-    is0->getRight()->accept(*this);
-    lesma::Type* rhsTy = result->getType();
+    lesma::Type* rhsTy = is0->getResolvedRhsType();
+    if (rhsTy == nullptr) {
+      return;
+    }
     if (is0->getOperator() == TokenType::IS) {
       if (auto idx = cgUnionComplementMemberIndex(sym->getType(), rhsTy)) {
         out[sym] = *idx;
@@ -977,8 +977,10 @@ auto Codegen::fillCodegenUnionNarrowVariantMap(const If* node, unsigned blockInd
   if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
     return;
   }
-  is->getRight()->accept(*this);
-  lesma::Type* rhsTy = result->getType();
+  lesma::Type* rhsTy = is->getResolvedRhsType();
+  if (rhsTy == nullptr) {
+    return;
+  }
   if (is->getOperator() == TokenType::IS) {
     if (auto idx = unionVariantIndexOf(sym->getType(), rhsTy)) {
       out[sym] = *idx;
@@ -1001,20 +1003,29 @@ auto Codegen::emitUnionPayloadLoadFromSlot(llvm::Value* unionAllocaPtr, lesma::T
   return builder->CreateLoad(memLt, payloadPtr, "union.payload");
 }
 
-auto Codegen::emitUnionWrapValue(llvm::SMRange /*span*/, lesma::Value* val, lesma::Type* unionTy,
+auto Codegen::emitUnionWrapValueToSlot(llvm::SMRange /*span*/, lesma::Value* val,
+                                       lesma::Type* unionTy, unsigned variantIndex,
+                                       llvm::Value* destSlot) -> std::unique_ptr<lesma::Value> {
+  getOrCreateLlvmType(unionTy);
+  getOrCreateLlvmType(val->getType());
+  auto* st = llvm::cast<llvm::StructType>(unionTy->getLlvmType());
+  llvm::Value* tagPtr = builder->CreateStructGEP(st, destSlot, 0U, "union.tag.ptr");
+  llvm::Type* tagTy = getOrCreateUnionTagLlvmType(unionTy);
+  builder->CreateStore(llvm::ConstantInt::get(tagTy, variantIndex), tagPtr);
+  llvm::Value* payPtr = builder->CreateStructGEP(st, destSlot, 1U, "union.pay.ptr");
+  builder->CreateStore(val->getLlvmValue(), payPtr);
+  llvm::Value* agg = builder->CreateLoad(st, destSlot, "union.val");
+  return std::make_unique<lesma::Value>("", unionTy, agg);
+}
+
+auto Codegen::emitUnionWrapValue(llvm::SMRange span, lesma::Value* val, lesma::Type* unionTy,
                                  unsigned variantIndex) -> std::unique_ptr<lesma::Value> {
   getOrCreateLlvmType(unionTy);
   getOrCreateLlvmType(val->getType());
   auto* st = llvm::cast<llvm::StructType>(unionTy->getLlvmType());
   llvm::Function* f = builder->GetInsertBlock()->getParent();
   llvm::AllocaInst* slot = createAllocaInEntry(f, st, "union.wrap.slot");
-  llvm::Value* tagPtr = builder->CreateStructGEP(st, slot, 0U, "union.tag.ptr");
-  llvm::Type* tagTy = getOrCreateUnionTagLlvmType(unionTy);
-  builder->CreateStore(llvm::ConstantInt::get(tagTy, variantIndex), tagPtr);
-  llvm::Value* payPtr = builder->CreateStructGEP(st, slot, 1U, "union.pay.ptr");
-  builder->CreateStore(val->getLlvmValue(), payPtr);
-  llvm::Value* agg = builder->CreateLoad(st, slot, "union.val");
-  return std::make_unique<lesma::Value>("", unionTy, agg);
+  return emitUnionWrapValueToSlot(span, val, unionTy, variantIndex, slot);
 }
 
 auto Codegen::visit(const If* node) -> void {
@@ -3557,8 +3568,10 @@ auto Codegen::visit(const IsOp* node) -> void {
   node->getLeft()->accept(*this);
   auto leftOwner = std::move(result);
   Type* leftType = leftOwner->getType();
-  node->getRight()->accept(*this);
-  Type* rightType = result->getType();
+  Type* rightType = node->getResolvedRhsType();
+  if (rightType == nullptr) {
+    throw CodegenError(node->getSpan(), "Internal: `is` expression missing resolved RHS type");
+  }
 
   if (leftType != nullptr && leftType->is(BaseType::TY_UNION)) {
     auto idxOpt = unionVariantIndexOf(leftType, rightType);
@@ -4248,6 +4261,8 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
         auto* fromSt = llvm::cast<llvm::StructType>(fromU->getLlvmType());
         llvm::AllocaInst* srcSlot = createAllocaInEntry(func, fromSt, "union.widen.src");
         builder->CreateStore(agg, srcSlot);
+        auto* destSt = llvm::cast<llvm::StructType>(type->getLlvmType());
+        llvm::AllocaInst* wrapSlot = createAllocaInEntry(func, destSt, "union.widen.wrap");
 
         llvm::BasicBlock* mergeBB =
             llvm::BasicBlock::Create(theModule->getContext(), "union.widen.merge", func);
@@ -4270,7 +4285,7 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
           llvm::Value* loaded = emitUnionPayloadLoadFromSlot(srcSlot, fromU, memTy);
           auto tmp = std::make_unique<lesma::Value>("", memTy, loaded);
           std::unique_ptr<lesma::Value> wrapped =
-              emitUnionWrapValue(span, tmp.get(), type, destIdxPerFrom[i]);
+              emitUnionWrapValueToSlot(span, tmp.get(), type, destIdxPerFrom[i], wrapSlot);
           llvm::Value* outAgg = wrapped->getLlvmValue();
           builder->CreateBr(mergeBB);
           phiIncomings.emplace_back(outAgg, caseBB);

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -4225,6 +4225,75 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
   if (type != nullptr && type->is(BaseType::TY_UNION) && val != nullptr &&
       val->getType() != nullptr) {
     const auto& mem = type->getUnionMembers();
+    if (val->getType()->is(BaseType::TY_UNION)) {
+      lesma::Type* fromU = val->getType();
+      const auto& fromMembers = fromU->getUnionMembers();
+      std::vector<unsigned> destIdxPerFrom;
+      destIdxPerFrom.reserve(fromMembers.size());
+      bool canWidenWithMatchingArms = !fromMembers.empty();
+      for (Type* fm : fromMembers) {
+        std::optional<unsigned> dest;
+        for (unsigned j = 0; j < mem.size(); ++j) {
+          if (mem[j] != nullptr && mem[j]->isEqual(fm)) {
+            dest = j;
+            break;
+          }
+        }
+        if (!dest.has_value()) {
+          canWidenWithMatchingArms = false;
+          break;
+        }
+        destIdxPerFrom.push_back(*dest);
+      }
+      if (canWidenWithMatchingArms) {
+        getOrCreateLlvmType(fromU);
+        getOrCreateLlvmType(type);
+        llvm::Value* agg = val->getLlvmValue();
+        llvm::Function* func = builder->GetInsertBlock()->getParent();
+        auto* fromSt = llvm::cast<llvm::StructType>(fromU->getLlvmType());
+        llvm::AllocaInst* srcSlot = createAllocaInEntry(func, fromSt, "union.widen.src");
+        builder->CreateStore(agg, srcSlot);
+
+        llvm::BasicBlock* mergeBB =
+            llvm::BasicBlock::Create(theModule->getContext(), "union.widen.merge", func);
+        llvm::BasicBlock* defaultBB =
+            llvm::BasicBlock::Create(theModule->getContext(), "union.widen.badtag", func);
+
+        llvm::Value* tagVal = builder->CreateExtractValue(agg, {0U}, "union.widen.tag");
+        llvm::Type* fromTagTy = getOrCreateUnionTagLlvmType(fromU);
+        auto* sw = builder->CreateSwitch(tagVal, defaultBB,
+                                         static_cast<unsigned>(fromMembers.size()));
+        std::vector<std::pair<llvm::Value*, llvm::BasicBlock*>> phiIncomings;
+        phiIncomings.reserve(fromMembers.size());
+
+        for (unsigned i = 0; i < fromMembers.size(); ++i) {
+          llvm::BasicBlock* caseBB = llvm::BasicBlock::Create(
+              theModule->getContext(), "union.widen.case." + std::to_string(i), func);
+          sw->addCase(llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(fromTagTy, i)), caseBB);
+          builder->SetInsertPoint(caseBB);
+          Type* memTy = fromMembers[i];
+          llvm::Value* loaded = emitUnionPayloadLoadFromSlot(srcSlot, fromU, memTy);
+          auto tmp = std::make_unique<lesma::Value>("", memTy, loaded);
+          std::unique_ptr<lesma::Value> wrapped =
+              emitUnionWrapValue(span, tmp.get(), type, destIdxPerFrom[i]);
+          llvm::Value* outAgg = wrapped->getLlvmValue();
+          builder->CreateBr(mergeBB);
+          phiIncomings.emplace_back(outAgg, caseBB);
+        }
+
+        builder->SetInsertPoint(defaultBB);
+        builder->CreateUnreachable();
+
+        builder->SetInsertPoint(mergeBB);
+        llvm::PHINode* phi =
+            builder->CreatePHI(type->getLlvmType(),
+                               static_cast<unsigned>(phiIncomings.size()), "union.widen.out");
+        for (auto const& pr : phiIncomings) {
+          phi->addIncoming(pr.first, pr.second);
+        }
+        return std::make_unique<lesma::Value>("", type, phi);
+      }
+    }
     for (unsigned i = 0; i < mem.size(); ++i) {
       if (val->getType()->isEqual(mem[i])) {
         return emitUnionWrapValue(span, val, type, i);

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1054,7 +1054,24 @@ auto Codegen::emitUnionWrapValueToSlot(llvm::SMRange /*span*/, lesma::Value* val
   llvm::Type* tagTy = getOrCreateUnionTagLlvmType(unionTy);
   builder->CreateStore(llvm::ConstantInt::get(tagTy, variantIndex), tagPtr);
   llvm::Value* payPtr = builder->CreateStructGEP(st, destSlot, 1U, "union.pay.ptr");
-  builder->CreateStore(val->getLlvmValue(), payPtr);
+  llvm::Type* payStoredTy = getStoredAggregateFieldLlvmType(val->getType());
+  llvm::Value* v = val->getLlvmValue();
+  if (v->getType() != payStoredTy) {
+    if (v->getType()->isIntegerTy() && payStoredTy->isIntegerTy()) {
+      v = builder->CreateIntCast(v, payStoredTy, /*isSigned=*/true, "union.pay.ic");
+    } else if (v->getType()->isFloatingPointTy() && payStoredTy->isFloatingPointTy()) {
+      v = builder->CreateFPCast(v, payStoredTy, "union.pay.fc");
+    } else if (theModule->getDataLayout().getTypeSizeInBits(v->getType()) ==
+               theModule->getDataLayout().getTypeSizeInBits(payStoredTy)) {
+      v = builder->CreateBitCast(v, payStoredTy, "union.pay.cast");
+    } else {
+      throw CodegenError({}, "Internal error: union payload store type mismatch");
+    }
+  }
+  llvm::Value* typedPayPtr =
+      builder->CreateBitCast(payPtr, llvm::PointerType::get(theModule->getContext(), 0U),
+                             "union.pay.tptr");
+  builder->CreateStore(v, typedPayPtr);
   llvm::Value* agg = builder->CreateLoad(st, destSlot, "union.val");
   return std::make_unique<lesma::Value>("", unionTy, agg);
 }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -29,8 +29,8 @@
 #include <llvm/IR/GlobalVariable.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
-#include <llvm/IR/Module.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/MC/TargetRegistry.h>
@@ -76,8 +76,7 @@ LLD_HAS_DRIVER(elf)
 namespace {
 
 [[nodiscard]] auto makeCallableSignatureKey(const std::string& name,
-                                            const std::vector<lesma::Type*>& types)
-    -> std::string {
+                                            const std::vector<lesma::Type*>& types) -> std::string {
   std::string key = name;
   for (lesma::Type* type : types) {
     key += "|" + (type != nullptr ? type->toString() : "?");
@@ -106,8 +105,9 @@ namespace {
 
 /** Vtable initializers must reference Function* in the emitting module; imported codegen may still
  *  hold pointers into a module that was already moved to the JIT. */
-[[nodiscard]] auto materializeVtableFunctionPointer(llvm::Module* mod, llvm::PointerType* ptrTyTyped,
-                                                    lesma::Value* rs) -> llvm::Constant* {
+[[nodiscard]] auto materializeVtableFunctionPointer(llvm::Module* mod,
+                                                    llvm::PointerType* ptrTyTyped, lesma::Value* rs)
+    -> llvm::Constant* {
   if (rs == nullptr) {
     return nullptr;
   }
@@ -177,21 +177,20 @@ namespace {
 
 using namespace lesma;
 
-Codegen::Codegen(std::shared_ptr<Parser> parser, std::shared_ptr<SourceMgr> srcMgr,
-                 const std::string& filename, std::vector<std::string> imports, bool jit, bool main,
-                 std::string alias, const std::shared_ptr<ThreadSafeContext>& context,
-                 std::shared_ptr<std::vector<std::string>> sharedModules,
-                 std::shared_ptr<std::vector<std::unique_ptr<SymbolTable>>> sharedScopes,
-                 std::shared_ptr<std::vector<ImportedSpecializationState>>
-                     sharedImportedSpecializationStates,
-                 std::unique_ptr<SymbolTable> preScope,
-                 std::vector<std::unique_ptr<lesma::Type>> preTypeCache,
-                 std::unordered_map<lesma::Type*, std::unordered_map<std::string, lesma::Type*>>
-                     preSpecializedClassTypeEnvs,
-                 std::unordered_map<lesma::Type*, lesma::Type*> preSpecializedClassTemplateOf,
-                 std::unordered_map<std::string, lesma::Type*> preSpecializedClassTypesByKey,
-                 bool emitDebug, llvm::OptimizationLevel optimizationLevelForDebugArg,
-                 std::shared_ptr<std::vector<std::string>> sharedPendingJitModuleInits) {
+Codegen::Codegen(
+    std::shared_ptr<Parser> parser, std::shared_ptr<SourceMgr> srcMgr, const std::string& filename,
+    std::vector<std::string> imports, bool jit, bool main, std::string alias,
+    const std::shared_ptr<ThreadSafeContext>& context,
+    std::shared_ptr<std::vector<std::string>> sharedModules,
+    std::shared_ptr<std::vector<std::unique_ptr<SymbolTable>>> sharedScopes,
+    std::shared_ptr<std::vector<ImportedSpecializationState>> sharedImportedSpecializationStates,
+    std::unique_ptr<SymbolTable> preScope, std::vector<std::unique_ptr<lesma::Type>> preTypeCache,
+    std::unordered_map<lesma::Type*, std::unordered_map<std::string, lesma::Type*>>
+        preSpecializedClassTypeEnvs,
+    std::unordered_map<lesma::Type*, lesma::Type*> preSpecializedClassTemplateOf,
+    std::unordered_map<std::string, lesma::Type*> preSpecializedClassTypesByKey, bool emitDebug,
+    llvm::OptimizationLevel optimizationLevelForDebugArg,
+    std::shared_ptr<std::vector<std::string>> sharedPendingJitModuleInits) {
   InitializeNativeTarget();
   InitializeNativeTargetAsmPrinter();
   InitializeNativeTargetAsmParser();
@@ -234,9 +233,10 @@ Codegen::Codegen(std::shared_ptr<Parser> parser, std::shared_ptr<SourceMgr> srcM
   if (sharedModules && sharedScopes) {
     importedModules = std::move(sharedModules);
     importedScopes = std::move(sharedScopes);
-    importedSpecializationStates = sharedImportedSpecializationStates != nullptr
-                                       ? std::move(sharedImportedSpecializationStates)
-                                       : std::make_shared<std::vector<ImportedSpecializationState>>();
+    importedSpecializationStates =
+        sharedImportedSpecializationStates != nullptr
+            ? std::move(sharedImportedSpecializationStates)
+            : std::make_shared<std::vector<ImportedSpecializationState>>();
   } else {
     importedModules = std::make_shared<std::vector<std::string>>(std::move(imports));
     importedScopes = std::make_shared<std::vector<std::unique_ptr<SymbolTable>>>();
@@ -341,13 +341,13 @@ auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* c
     param->setName(paramName);
 
     Value* existingParam = lookupInCurrentScope(paramName);
-    if (field->type != nullptr && field->type->is(BaseType::TY_FUNCTION) && existingParam != nullptr &&
-        existingParam->getStoresFuncValuePair()) {
+    if (field->type != nullptr && field->type->is(BaseType::TY_FUNCTION) &&
+        existingParam != nullptr && existingParam->getStoresFuncValuePair()) {
       existingParam->setType(field->type);
       existingParam->setLlvmValue(param);
       existingParam->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
-      emitParameterDebugDeclare(f, param, paramName, static_cast<unsigned>(fieldIndex + 1), declFile,
-                                declLine, param->getType(), nullptr);
+      emitParameterDebugDeclare(f, param, paramName, static_cast<unsigned>(fieldIndex + 1),
+                                declFile, declLine, param->getType(), nullptr);
       fieldIndex++;
       continue;
     }
@@ -457,9 +457,8 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
 
   BasicBlock* entry = BasicBlock::Create(theModule->getContext(), "entry", f);
   builder->SetInsertPoint(entry);
-  llvm::SMRange const bodySpan = node->isExpressionBody()
-                                     ? node->getExpressionBody()->getSpan()
-                                     : node->getBlockBody()->getSpan();
+  llvm::SMRange const bodySpan = node->isExpressionBody() ? node->getExpressionBody()->getSpan()
+                                                          : node->getBlockBody()->getSpan();
   setDebugLoc(bodySpan);
 
   llvm::DIFile* declFile = moduleDiFile;
@@ -482,12 +481,12 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
     param->setName(paramName);
 
     Value* existingParam = lookupInCurrentScope(paramName);
-    if (field->type != nullptr && field->type->is(BaseType::TY_FUNCTION) && existingParam != nullptr &&
-        existingParam->getStoresFuncValuePair()) {
+    if (field->type != nullptr && field->type->is(BaseType::TY_FUNCTION) &&
+        existingParam != nullptr && existingParam->getStoresFuncValuePair()) {
       existingParam->setLlvmValue(param);
       existingParam->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
-      emitParameterDebugDeclare(f, param, paramName, static_cast<unsigned>(fieldIndex + 1), declFile,
-                                declLine, param->getType(), nullptr);
+      emitParameterDebugDeclare(f, param, paramName, static_cast<unsigned>(fieldIndex + 1),
+                                declFile, declLine, param->getType(), nullptr);
       fieldIndex++;
       continue;
     }
@@ -566,8 +565,8 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
 auto Codegen::getFuncValuePairLlvmType() -> llvm::StructType* {
   if (funcValuePairLlvmType == nullptr) {
     funcValuePairLlvmType = llvm::StructType::create(
-        theModule->getContext(), std::array<llvm::Type*, 2>{builder->getPtrTy(), builder->getPtrTy()},
-        "lesma.funcval");
+        theModule->getContext(),
+        std::array<llvm::Type*, 2>{builder->getPtrTy(), builder->getPtrTy()}, "lesma.funcval");
   }
   return funcValuePairLlvmType;
 }
@@ -798,14 +797,14 @@ auto Codegen::visit(const VarDecl* node) -> void {
     existing->setMutable(node->getMutability());
     if (valueResult != nullptr) {
       llvm::Instruction* st = nullptr;
-      if (valueResult->getLlvmValue() == nullptr &&
-          storedType->is(BaseType::TY_FUNCTION) && !storedType->getGenericParams().empty()) {
-        st = builder->CreateStore(llvm::ConstantAggregateZero::get(getFuncValuePairLlvmType()), ptr);
+      if (valueResult->getLlvmValue() == nullptr && storedType->is(BaseType::TY_FUNCTION) &&
+          !storedType->getGenericParams().empty()) {
+        st =
+            builder->CreateStore(llvm::ConstantAggregateZero::get(getFuncValuePairLlvmType()), ptr);
       } else if (storedType->is(BaseType::TY_FUNCTION) && valueResult->getLlvmValue() != nullptr &&
                  valueResult->getLlvmValue()->getType() == getFuncValuePairLlvmType()) {
         st = builder->CreateStore(valueResult->getLlvmValue(), ptr);
-      } else if (valueResult->getStoresFuncValuePair() &&
-                 storedType->is(BaseType::TY_FUNCTION)) {
+      } else if (valueResult->getStoresFuncValuePair() && storedType->is(BaseType::TY_FUNCTION)) {
         llvm::StructType* pt = getFuncValuePairLlvmType();
         llvm::Value* loaded =
             builder->CreateLoad(pt, valueResult->getLlvmValue(), name + ".fnpair.load");
@@ -915,8 +914,12 @@ auto Codegen::lookupUnionNarrowVariant(lesma::Value* sym) const -> std::optional
   if (sym == nullptr) {
     return std::nullopt;
   }
+  const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+  if (!key.declarationSpan.isValid() && key.fallbackAnchor == nullptr) {
+    return std::nullopt;
+  }
   for (auto it = unionNarrowVariantStack.rbegin(); it != unionNarrowVariantStack.rend(); ++it) {
-    auto j = it->find(sym);
+    auto j = it->find(key);
     if (j != it->end()) {
       return j->second;
     }
@@ -938,9 +941,10 @@ auto Codegen::unionVariantIndexOf(lesma::Type* unionTy, lesma::Type* memberTy) c
   return std::nullopt;
 }
 
-auto Codegen::fillCodegenUnionNarrowVariantMap(const If* node, unsigned blockIndex,
-                                               std::unordered_map<lesma::Value*, unsigned>& out)
-    -> void {
+auto Codegen::fillCodegenUnionNarrowVariantMap(
+    const If* node, unsigned blockIndex,
+    std::unordered_map<UnionNarrowingStableKey, unsigned, UnionNarrowingStableKeyHash,
+                       UnionNarrowingStableKeyEq>& out) -> void {
   if (blockIndex >= node->getBlocks().size()) {
     return;
   }
@@ -960,11 +964,17 @@ auto Codegen::fillCodegenUnionNarrowVariantMap(const If* node, unsigned blockInd
     }
     if (is0->getOperator() == TokenType::IS) {
       if (auto idx = cgUnionComplementMemberIndex(sym->getType(), rhsTy)) {
-        out[sym] = *idx;
+        const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+        if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+          out[key] = *idx;
+        }
       }
     } else if (is0->getOperator() == TokenType::IS_NOT) {
       if (auto idx = unionVariantIndexOf(sym->getType(), rhsTy)) {
-        out[sym] = *idx;
+        const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+        if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+          out[key] = *idx;
+        }
       }
     }
     return;
@@ -983,11 +993,17 @@ auto Codegen::fillCodegenUnionNarrowVariantMap(const If* node, unsigned blockInd
   }
   if (is->getOperator() == TokenType::IS) {
     if (auto idx = unionVariantIndexOf(sym->getType(), rhsTy)) {
-      out[sym] = *idx;
+      const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+      if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+        out[key] = *idx;
+      }
     }
   } else if (is->getOperator() == TokenType::IS_NOT) {
     if (auto idx = cgUnionComplementMemberIndex(sym->getType(), rhsTy)) {
-      out[sym] = *idx;
+      const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+      if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+        out[key] = *idx;
+      }
     }
   }
 }
@@ -997,8 +1013,7 @@ auto Codegen::emitUnionPayloadLoadFromSlot(llvm::Value* unionAllocaPtr, lesma::T
   getOrCreateLlvmType(unionTy);
   getOrCreateLlvmType(memberTy);
   auto* st = llvm::cast<llvm::StructType>(unionTy->getLlvmType());
-  llvm::Value* payloadPtr =
-      builder->CreateStructGEP(st, unionAllocaPtr, 1U, "union.payload.ptr");
+  llvm::Value* payloadPtr = builder->CreateStructGEP(st, unionAllocaPtr, 1U, "union.payload.ptr");
   llvm::Type* memLt = getStoredAggregateFieldLlvmType(memberTy);
   return builder->CreateLoad(memLt, payloadPtr, "union.payload");
 }
@@ -1051,7 +1066,9 @@ auto Codegen::visit(const If* node) -> void {
     builder->CreateCondBr(result->getLlvmValue(), bIfTrue, bIfFalse);
     builder->SetInsertPoint(bIfTrue);
 
-    std::unordered_map<lesma::Value*, unsigned> narrowMap;
+    std::unordered_map<UnionNarrowingStableKey, unsigned, UnionNarrowingStableKeyHash,
+                       UnionNarrowingStableKeyEq>
+        narrowMap;
     fillCodegenUnionNarrowVariantMap(node, static_cast<unsigned>(i), narrowMap);
     bool const pushedNarrowing = !narrowMap.empty();
     if (pushedNarrowing) {
@@ -1150,8 +1167,7 @@ auto Codegen::visit(const ForIn* node) -> void {
     auto fields = listType->getFields();
     if (!fields.empty() && fields.front()->type != nullptr &&
         fields.front()->type->is(BaseType::TY_ARRAY)) {
-      unsigned const bufIdx =
-          TypeUtils::classDataFieldStructIndex(listType, 0U);
+      unsigned const bufIdx = TypeUtils::classDataFieldStructIndex(listType, 0U);
       auto* storagePtr =
           builder->CreateStructGEP(cast<llvm::StructType>(getOrCreateLlvmType(listType)),
                                    iterable->getLlvmValue(), bufIdx, "list.storage.ptr");
@@ -1555,10 +1571,10 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
       break;
     }
     Type* storageTy = layoutFields[layoutIdx]->type;
-    unsigned const structIdx = TypeUtils::classDataFieldStructIndex(classType, static_cast<unsigned>(layoutIdx));
-    llvm::Value* slotPtr =
-        builder->CreateStructGEP(structTy, selfPtr, structIdx,
-                                 v->getIdentifier()->getValue() + ".ptr");
+    unsigned const structIdx =
+        TypeUtils::classDataFieldStructIndex(classType, static_cast<unsigned>(layoutIdx));
+    llvm::Value* slotPtr = builder->CreateStructGEP(structTy, selfPtr, structIdx,
+                                                    v->getIdentifier()->getValue() + ".ptr");
     layoutIdx++;
     if (v->getValue() != nullptr) {
       v->getValue()->accept(*this);
@@ -1571,8 +1587,9 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
                            v->getIdentifier()->getValue());
       }
       getOrCreateLlvmType(storageTy);
-      llvm::Value* loaded = loadStoredAggregateFieldValue(
-          ps->getLlvmValue(), storageTy, llvm::Twine(v->getIdentifier()->getValue()).concat(".arg"));
+      llvm::Value* loaded =
+          loadStoredAggregateFieldValue(ps->getLlvmValue(), storageTy,
+                                        llvm::Twine(v->getIdentifier()->getValue()).concat(".arg"));
       builder->CreateStore(loaded, slotPtr);
     }
   }
@@ -1633,8 +1650,7 @@ auto Codegen::getOrEmitClassVtableGlobal(lesma::Type* classTy, const Class* astN
   }
 
   auto* arrTy = llvm::ArrayType::get(ptrTy, order.size());
-  std::vector<llvm::Constant*> elems(order.size(),
-                                     llvm::ConstantPointerNull::get(ptrTyTyped));
+  std::vector<llvm::Constant*> elems(order.size(), llvm::ConstantPointerNull::get(ptrTyTyped));
 
   if (Type* sup = classTy->getClassSuperclass()) {
     const Class* supAst = nullptr;
@@ -1678,8 +1694,8 @@ auto Codegen::getOrEmitClassVtableGlobal(lesma::Type* classTy, const Class* astN
   llvm::Constant* init = llvm::ConstantArray::get(arrTy, elems);
   // LinkOnceODR + hidden keeps one definition across ORC JIT modules and survives GlobalDCE better
   // than private linkage when stores reference the vtable by symbol name after inlining.
-  auto* gv = new llvm::GlobalVariable(*theModule, arrTy, true, llvm::GlobalValue::LinkOnceODRLinkage,
-                                      init, vn);
+  auto* gv = new llvm::GlobalVariable(*theModule, arrTy, true,
+                                      llvm::GlobalValue::LinkOnceODRLinkage, init, vn);
   gv->setVisibility(llvm::GlobalValue::HiddenVisibility);
   llvm::appendToCompilerUsed(*theModule, {gv});
   classVtableGlobals[classTy] = gv;
@@ -1789,8 +1805,8 @@ auto Codegen::visit(const FuncDecl* node) -> void {
   lesma::Type* returnType = wrapNominalReturnAsPointer(result->getType());
   getOrCreateLlvmType(returnType);
 
-  lesma::Value* existingFunc = scope->lookupFunction(node->getName(), paramTypes,
-                                                     FunctionLookupKind::OVERLOAD_IDENTITY);
+  lesma::Value* existingFunc =
+      scope->lookupFunction(node->getName(), paramTypes, FunctionLookupKind::OVERLOAD_IDENTITY);
   if (existingFunc == nullptr) {
     auto normalizeFunctionParamType = [](lesma::Type* type) -> lesma::Type* {
       if (type != nullptr && type->is(BaseType::TY_PTR) && type->getElementType() != nullptr &&
@@ -1853,9 +1869,9 @@ auto Codegen::visit(const FuncDecl* node) -> void {
     appendGenericBindingSuffix(node->getSpan(), signatureKey, bindingOrder, currentGenericTypes);
   }
   if (selfSymbol != nullptr && !currentGenericTypes.empty()) {
-    if (auto it = specializedFunctions.find(mangledName);
-        it != specializedFunctions.end() && it->second != nullptr &&
-        it->second->getLlvmValue() != nullptr) {
+    if (auto it = specializedFunctions.find(mangledName); it != specializedFunctions.end() &&
+                                                          it->second != nullptr &&
+                                                          it->second->getLlvmValue() != nullptr) {
       result = std::make_unique<Value>(*it->second);
       return;
     }
@@ -1980,8 +1996,8 @@ auto Codegen::visit(const ExternFuncDecl* node) -> void {
     getOrCreateLlvmType(retType);
   }
 
-  lesma::Value* existingFunc = scope->lookupFunction(node->getName(), paramTypes,
-                                                     FunctionLookupKind::OVERLOAD_IDENTITY);
+  lesma::Value* existingFunc =
+      scope->lookupFunction(node->getName(), paramTypes, FunctionLookupKind::OVERLOAD_IDENTITY);
   if (existingFunc == nullptr) {
     throw CodegenError(node->getSpan(), "Missing typechecked extern symbol for {}",
                        node->getName());
@@ -2172,7 +2188,8 @@ auto Codegen::visit(const Return* node) -> void {
   } else {
     node->getValue()->accept(*this);
     getOrCreateLlvmType(result->getType());
-    if (result != nullptr && result->getStoresFuncValuePair() && result->getLlvmValue() != nullptr) {
+    if (result != nullptr && result->getStoresFuncValuePair() &&
+        result->getLlvmValue() != nullptr) {
       llvm::StructType* pt = getFuncValuePairLlvmType();
       llvm::Value* toRet = result->getLlvmValue();
       if (result->getCategory() == ValueCategory::ADDRESSABLE_STORAGE) {
@@ -2427,12 +2444,13 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
     fnType->setReturnType(retType);
   }
   getOrCreateLlvmType(retType);
-  llvm::Type* llvmReturnType =
-      retType->is(BaseType::TY_CLASS) || retType->is(BaseType::TY_PTR) ? builder->getPtrTy()
-                                                                        : retType->getLlvmType();
+  llvm::Type* llvmReturnType = retType->is(BaseType::TY_CLASS) || retType->is(BaseType::TY_PTR)
+                                   ? builder->getPtrTy()
+                                   : retType->getLlvmType();
   std::string const lambdaName = resolved->getName();
   llvm::FunctionType* llvmFnType = FunctionType::get(llvmReturnType, paramLLVMTypes, false);
-  Function* f = Function::Create(llvmFnType, llvm::GlobalValue::PrivateLinkage, lambdaName, *theModule);
+  Function* f =
+      Function::Create(llvmFnType, llvm::GlobalValue::PrivateLinkage, lambdaName, *theModule);
   resolved->setLlvmValue(f);
   resolved->setMangledName(lambdaName);
   resolved->setClosureCalleeUsesEnvParameter(!caps.empty());
@@ -2452,8 +2470,8 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
   if (!caps.empty()) {
     llvm::Argument* envArg = f->getArg(argIdx++);
     envArg->setName("__env");
-    llvm::Value* typedEnv =
-        builder->CreateBitCast(envArg, envStructTy->getPointerTo(), "env.ptr");
+    llvm::Value* typedEnv = builder->CreateBitCast(
+        envArg, llvm::PointerType::get(envStructTy->getContext(), 0U), "env.ptr");
     SymbolTable* body = resolved->getBodyScope();
     for (size_t i = 0; i < caps.size(); ++i) {
       Value* outer = caps[i];
@@ -2465,8 +2483,8 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
         throw CodegenError(node->getSpan(), "Internal error: missing capture shadow for {}",
                            outer->getName());
       }
-      llvm::Value* slot =
-          builder->CreateStructGEP(envStructTy, typedEnv, static_cast<unsigned>(i), outer->getName());
+      llvm::Value* slot = builder->CreateStructGEP(envStructTy, typedEnv, static_cast<unsigned>(i),
+                                                   outer->getName());
       Type* outerTy = outer->getType();
       getOrCreateLlvmType(outerTy);
       llvm::Value* loaded = builder->CreateLoad(outerTy->getLlvmType(), slot);
@@ -2538,7 +2556,8 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
     llvm::Value* envSize = llvm::ConstantInt::get(
         i64Ty, theModule->getDataLayout().getTypeAllocSize(envStructTy).getFixedValue());
     envStoreVal = emitMalloc(envSize, lambdaName + ".env");
-    llvm::Value* typedEnv = builder->CreateBitCast(envStoreVal, envStructTy->getPointerTo());
+    llvm::Value* typedEnv =
+        builder->CreateBitCast(envStoreVal, llvm::PointerType::get(envStructTy->getContext(), 0U));
     for (size_t i = 0; i < caps.size(); ++i) {
       Value* outer = caps[i];
       if (outer->getLlvmValue() == nullptr) {
@@ -2547,8 +2566,8 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
       }
       Type* outerTy = outer->getType();
       getOrCreateLlvmType(outerTy);
-      llvm::Value* v =
-          builder->CreateLoad(outerTy->getLlvmType(), outer->getLlvmValue(), outer->getName() + ".v");
+      llvm::Value* v = builder->CreateLoad(outerTy->getLlvmType(), outer->getLlvmValue(),
+                                           outer->getName() + ".v");
       llvm::Value* slot =
           builder->CreateStructGEP(envStructTy, typedEnv, static_cast<unsigned>(i), "cap.slot");
       builder->CreateStore(v, slot);
@@ -3044,8 +3063,7 @@ auto Codegen::superMethodReceiverMatchesFormalCodegen(Type* formalReceiverClass,
     return true;
   }
   if (auto specIt = specializedClassTemplateOf.find(staticSuperType);
-      specIt != specializedClassTemplateOf.end() &&
-      formalReceiverClass->isEqual(specIt->second)) {
+      specIt != specializedClassTemplateOf.end() && formalReceiverClass->isEqual(specIt->second)) {
     return true;
   }
   return false;
@@ -3063,7 +3081,8 @@ auto Codegen::visit(const DotOp* node) -> void {
       if (auto* curFn = builder->GetInsertBlock()->getParent()) {
         if (resolved != nullptr && resolved->getLlvmValue() != nullptr &&
             resolved->getLlvmValue() == curFn) {
-          // `super.new` must never lower to the ctor currently being emitted (mis-resolved overload).
+          // `super.new` must never lower to the ctor currently being emitted (mis-resolved
+          // overload).
           resolved = nullptr;
         }
       }
@@ -3080,8 +3099,7 @@ auto Codegen::visit(const DotOp* node) -> void {
     // Instance methods take implicit `self` as fields[0]. Constructor chaining uses
     // `super.new(self, ...)` so the receiver is already the first explicit argument.
     std::unique_ptr<lesma::Value> implicitSelfValue;
-    bool const chainingCtorWithExplicitReceiver =
-        method->getName() == "new" && !args.empty();
+    bool const chainingCtorWithExplicitReceiver = method->getName() == "new" && !args.empty();
     if (!chainingCtorWithExplicitReceiver) {
       Value* selfSym = scope->lookup("self");
       if (selfSym == nullptr) {
@@ -3299,7 +3317,8 @@ auto Codegen::visit(const DotOp* node) -> void {
         }
         unsigned const structIdx =
             TypeUtils::classDataFieldStructIndex(cls->getType(), static_cast<unsigned>(index));
-        auto* ptr = builder->CreateStructGEP(cls->getType()->getLlvmType(), fieldBasePtr, structIdx);
+        auto* ptr =
+            builder->CreateStructGEP(cls->getType()->getLlvmType(), fieldBasePtr, structIdx);
         if (isAssignment) {
           result = std::make_unique<Value>(
               "", cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), type)),
@@ -3705,7 +3724,8 @@ auto Codegen::visit(const ListLiteral* node) -> void {
     auto* classHandle = emitMalloc(classSize, "list.obj");
     emitInitClassVtablePointer(listType, classHandle);
     unsigned const bufIdx = TypeUtils::classDataFieldStructIndex(listType, 0U);
-    auto* storagePtr = builder->CreateStructGEP(structType, classHandle, bufIdx, "list.storage.ptr");
+    auto* storagePtr =
+        builder->CreateStructGEP(structType, classHandle, bufIdx, "list.storage.ptr");
 
     auto* listStructTy = getOrCreateListStructType(bufferType);
     auto* headerSize = builder->getInt64(
@@ -4271,8 +4291,8 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
 
         llvm::Value* tagVal = builder->CreateExtractValue(agg, {0U}, "union.widen.tag");
         llvm::Type* fromTagTy = getOrCreateUnionTagLlvmType(fromU);
-        auto* sw = builder->CreateSwitch(tagVal, defaultBB,
-                                         static_cast<unsigned>(fromMembers.size()));
+        auto* sw =
+            builder->CreateSwitch(tagVal, defaultBB, static_cast<unsigned>(fromMembers.size()));
         std::vector<std::pair<llvm::Value*, llvm::BasicBlock*>> phiIncomings;
         phiIncomings.reserve(fromMembers.size());
 
@@ -4295,9 +4315,8 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
         builder->CreateUnreachable();
 
         builder->SetInsertPoint(mergeBB);
-        llvm::PHINode* phi =
-            builder->CreatePHI(type->getLlvmType(),
-                               static_cast<unsigned>(phiIncomings.size()), "union.widen.out");
+        llvm::PHINode* phi = builder->CreatePHI(
+            type->getLlvmType(), static_cast<unsigned>(phiIncomings.size()), "union.widen.out");
         for (auto const& pr : phiIncomings) {
           phi->addIncoming(pr.first, pr.second);
         }
@@ -4340,8 +4359,7 @@ auto Codegen::materializeSymbolValue(lesma::Value* symbol) -> std::unique_ptr<le
   }
 
   Type* lesmaTy = symbol->getType();
-  if (lesmaTy != nullptr && !currentGenericTypes.empty() &&
-      typeContainsUnboundGeneric(lesmaTy)) {
+  if (lesmaTy != nullptr && !currentGenericTypes.empty() && typeContainsUnboundGeneric(lesmaTy)) {
     lesmaTy = substituteTypeForSpecializationEnv(lesmaTy, currentGenericTypes);
   }
   if (lesmaTy == nullptr) {
@@ -4352,8 +4370,7 @@ auto Codegen::materializeSymbolValue(lesma::Value* symbol) -> std::unique_ptr<le
     if (std::optional<unsigned> const idx = lookupUnionNarrowVariant(symbol)) {
       Type* memTy = lesmaTy->getUnionMembers().at(*idx);
       getOrCreateLlvmType(memTy);
-      llvm::Value* v =
-          emitUnionPayloadLoadFromSlot(symbol->getLlvmValue(), lesmaTy, memTy);
+      llvm::Value* v = emitUnionPayloadLoadFromSlot(symbol->getLlvmValue(), lesmaTy, memTy);
       return std::make_unique<Value>("", memTy, v);
     }
   }
@@ -4530,14 +4547,13 @@ auto Codegen::appendCallableArgument(lesma::Value* arg, std::vector<lesma::Type*
   paramsLLVM.push_back(llvmArg);
 }
 
-auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionName,
-                                const std::vector<lesma::Type*>& paramTypes,
-                                const std::vector<llvm::Value*>& paramsLLVM,
-                                const std::vector<lesma::Type*>& explicitTypeArgs,
-                                Value* typecheckCalleeFallback,
-                                Type* allocatedClassMonomorph,
-                                const std::vector<std::pair<std::string, lesma::Type*>>*
-                                    genericBindingHint) -> std::unique_ptr<lesma::Value> {
+auto Codegen::callNamedFunction(
+    llvm::SMRange span, const std::string& functionName,
+    const std::vector<lesma::Type*>& paramTypes, const std::vector<llvm::Value*>& paramsLLVM,
+    const std::vector<lesma::Type*>& explicitTypeArgs, Value* typecheckCalleeFallback,
+    Type* allocatedClassMonomorph,
+    const std::vector<std::pair<std::string, lesma::Type*>>* genericBindingHint)
+    -> std::unique_ptr<lesma::Value> {
   std::vector<lesma::Type*> localParamTypes = paramTypes;
   std::vector<llvm::Value*> localParamsLLVM = paramsLLVM;
   auto hintedGenericBindings = [&]() -> std::unordered_map<std::string, lesma::Type*> {
@@ -4582,12 +4598,12 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
     auto env = (selfSymbol == nullptr && genericBindingHint != nullptr)
                    ? hintedGenericBindings()
                    : computeGenericFunctionBindingEnv(genericFuncTemplateForLookup, localParamTypes,
-                                                     genericNames, explicitTypeArgs);
+                                                      genericNames, explicitTypeArgs);
     appendGenericBindingSuffix(span, out, genericNames, env);
   };
-  auto buildFunctionSpecializationEnv =
-      [&](const FuncDecl* templateDecl,
-          const std::vector<std::string>& genericNames) -> std::unordered_map<std::string, lesma::Type*> {
+  auto buildFunctionSpecializationEnv = [&](const FuncDecl* templateDecl,
+                                            const std::vector<std::string>& genericNames)
+      -> std::unordered_map<std::string, lesma::Type*> {
     std::unordered_map<std::string, lesma::Type*> env;
     if (selfSymbol != nullptr && selfSymbol->getType() != nullptr) {
       lesma::Type* selfTy = selfSymbol->getType();
@@ -4600,8 +4616,8 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
     } else if (genericBindingHint != nullptr) {
       env = hintedGenericBindings();
     }
-    auto inferred =
-        computeGenericFunctionBindingEnv(templateDecl, localParamTypes, genericNames, explicitTypeArgs);
+    auto inferred = computeGenericFunctionBindingEnv(templateDecl, localParamTypes, genericNames,
+                                                     explicitTypeArgs);
     env.insert(inferred.begin(), inferred.end());
     for (const auto& [name, ty] : inferred) {
       env[name] = ty;
@@ -4775,11 +4791,11 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
       if (lamSym != nullptr && lamSym->getType() != nullptr &&
           !lamSym->getType()->getGenericParams().empty()) {
         std::vector<std::string> genericNames = lamSym->getType()->getGenericParams();
-        auto bindingEnv =
-            (selfSymbol == nullptr && genericBindingHint != nullptr) ? hintedGenericBindings()
-                                                                     : std::unordered_map<std::string, lesma::Type*>{};
+        auto bindingEnv = (selfSymbol == nullptr && genericBindingHint != nullptr)
+                              ? hintedGenericBindings()
+                              : std::unordered_map<std::string, lesma::Type*>{};
         symbol = specializeLambda(lamNode, localParamTypes, genericNames, explicitTypeArgs,
-                                bindingEnv.empty() ? nullptr : &bindingEnv);
+                                  bindingEnv.empty() ? nullptr : &bindingEnv);
       }
     }
   }
@@ -4832,8 +4848,7 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
     if (fields.size() == localParamsLLVM.size()) {
       callParamsLLVM.clear();
       for (size_t i = 0; i < fields.size(); ++i) {
-        auto holder =
-            std::make_unique<Value>("", localParamTypes[i], localParamsLLVM[i]);
+        auto holder = std::make_unique<Value>("", localParamTypes[i], localParamsLLVM[i]);
         auto casted = cast(span, holder.get(), fields[i]->type);
         callParamsLLVM.push_back(casted->getLlvmValue());
       }
@@ -4857,10 +4872,8 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
       llvm::Value* pairPtr = symbol->getLlvmValue();
       llvm::Value* fnSlot = builder->CreateStructGEP(pairTy, pairPtr, 0U);
       llvm::Value* envSlot = builder->CreateStructGEP(pairTy, pairPtr, 1U);
-      callableValue =
-          builder->CreateLoad(builder->getPtrTy(), fnSlot, functionName + ".code");
-      loadedClosureEnv =
-          builder->CreateLoad(builder->getPtrTy(), envSlot, functionName + ".env");
+      callableValue = builder->CreateLoad(builder->getPtrTy(), fnSlot, functionName + ".code");
+      loadedClosureEnv = builder->CreateLoad(builder->getPtrTy(), envSlot, functionName + ".env");
     } else {
       if (symbol->getLlvmValue() == nullptr) {
         throw CodegenError(span, "Function {} is declared but not defined", functionName);
@@ -4993,8 +5006,7 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
           fields.front()->type->is(BaseType::TY_ARRAY)) {
         listClassType = receiverType;
         bufferType = fields.front()->type;
-        unsigned const bufIdx =
-            TypeUtils::classDataFieldStructIndex(listClassType, 0U);
+        unsigned const bufIdx = TypeUtils::classDataFieldStructIndex(listClassType, 0U);
         auto* storagePtr =
             builder->CreateStructGEP(cast<llvm::StructType>(getOrCreateLlvmType(listClassType)),
                                      receiver->getLlvmValue(), bufIdx, "list.storage.ptr");
@@ -5197,7 +5209,8 @@ auto Codegen::emitUnionClassMethodDispatch(llvm::SMRange span, lesma::Value* uni
   }
   getOrCreateLlvmType(commonRetTy);
   llvm::Type* retLt = commonRetTy->getLlvmType();
-  llvm::PHINode* phi = builder->CreatePHI(retLt, static_cast<unsigned>(phiVals.size()), "union.m.phi");
+  llvm::PHINode* phi =
+      builder->CreatePHI(retLt, static_cast<unsigned>(phiVals.size()), "union.m.phi");
   for (unsigned j = 0; j < phiVals.size(); ++j) {
     phi->addIncoming(phiVals[j], phiBBs[j]);
   }
@@ -5245,8 +5258,7 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
       receiver->getType()->getElementType() != nullptr) {
     lesma::Type* elemTy = receiver->getType()->getElementType();
     if (Value* structSym = lookupClassStructSymbol(elemTy);
-        structSym != nullptr && structSym->getType() != nullptr &&
-        structSym->getType() != elemTy) {
+        structSym != nullptr && structSym->getType() != nullptr && structSym->getType() != elemTy) {
       lesma::Type* specClassTy = structSym->getType();
       lesma::Type* ptrToSpec =
           cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), specClassTy));
@@ -5293,7 +5305,8 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
         finalParams.push_back(castVal->getLlvmValue());
       }
       lesma::Type* returnTy = directMethod->getType()->getReturnType();
-      if (returnTy != nullptr && !currentGenericTypes.empty() && typeContainsUnboundGeneric(returnTy)) {
+      if (returnTy != nullptr && !currentGenericTypes.empty() &&
+          typeContainsUnboundGeneric(returnTy)) {
         returnTy = substituteTypeForSpecializationEnv(returnTy, currentGenericTypes);
       }
       if (returnTy != nullptr) {
@@ -5311,10 +5324,10 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
         }
       }
       unsigned vtableArrayLen = static_cast<unsigned>(vtOrder.size());
-      const bool canUseVirtual =
-          methodName != "new" && vtableSlot != ~0U && !vtOrder.empty() && vtableSlot < vtableArrayLen &&
-          (receiverType->getClassSuperclass() != nullptr ||
-           receiverType->getClassHasDerivedClass());
+      const bool canUseVirtual = methodName != "new" && vtableSlot != ~0U && !vtOrder.empty() &&
+                                 vtableSlot < vtableArrayLen &&
+                                 (receiverType->getClassSuperclass() != nullptr ||
+                                  receiverType->getClassHasDerivedClass());
       if (canUseVirtual) {
         llvm::Type* const ptrTy = builder->getPtrTy();
         auto* st = llvm::cast<llvm::StructType>(getOrCreateLlvmType(receiverType));
@@ -5322,14 +5335,12 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
         llvm::Value* vtablePtrAddr = builder->CreateStructGEP(st, recvPtr, 0, "vtable.ptr.ptr");
         llvm::Value* vtablePtr = builder->CreateLoad(ptrTy, vtablePtrAddr, "vtable.ptr");
         auto* arrTy = llvm::ArrayType::get(ptrTy, vtableArrayLen);
-        llvm::Value* fnPtrSlot =
-            builder->CreateGEP(arrTy, vtablePtr,
-                               {builder->getInt64(0), builder->getInt64(vtableSlot)}, "vt.fn.ptr");
+        llvm::Value* fnPtrSlot = builder->CreateGEP(
+            arrTy, vtablePtr, {builder->getInt64(0), builder->getInt64(vtableSlot)}, "vt.fn.ptr");
         llvm::Value* fnPtrVal = builder->CreateLoad(ptrTy, fnPtrSlot, "vt.fn");
         auto* calleeFn = llvm::cast<llvm::Function>(directMethod->getLlvmValue());
         llvm::FunctionType* ft = calleeFn->getFunctionType();
-        llvm::Value* useVirtual =
-            builder->CreateIsNotNull(fnPtrVal, "vt.fn.has.target");
+        llvm::Value* useVirtual = builder->CreateIsNotNull(fnPtrVal, "vt.fn.has.target");
         llvm::Value* directFnPtr =
             builder->CreateBitCast(directMethod->getLlvmValue(), ptrTy, "direct.fn.ptr");
         llvm::Value* selectedFnPtr =
@@ -5348,8 +5359,7 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
     }
   }
   selfSymbol = cls;
-  auto resultValue =
-      callNamedFunction(span, methodName, paramTypes, paramsLLVM, explicitTypeArgs);
+  auto resultValue = callNamedFunction(span, methodName, paramTypes, paramsLLVM, explicitTypeArgs);
   selfSymbol = savedSelfSymbol;
   return resultValue;
 }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -997,7 +997,7 @@ auto Codegen::emitUnionPayloadLoadFromSlot(llvm::Value* unionAllocaPtr, lesma::T
   auto* st = llvm::cast<llvm::StructType>(unionTy->getLlvmType());
   llvm::Value* payloadPtr =
       builder->CreateStructGEP(st, unionAllocaPtr, 1U, "union.payload.ptr");
-  llvm::Type* memLt = memberTy->getLlvmType();
+  llvm::Type* memLt = getStoredAggregateFieldLlvmType(memberTy);
   llvm::Value* typedPtr = builder->CreateBitCast(
       payloadPtr, llvm::PointerType::getUnqual(memLt->getContext()));
   return builder->CreateLoad(memLt, typedPtr, "union.payload");
@@ -1014,7 +1014,7 @@ auto Codegen::emitUnionWrapValue(llvm::SMRange /*span*/, lesma::Value* val, lesm
   llvm::Type* tagTy = getOrCreateUnionTagLlvmType(unionTy);
   builder->CreateStore(llvm::ConstantInt::get(tagTy, variantIndex), tagPtr);
   llvm::Value* payPtr = builder->CreateStructGEP(st, slot, 1U, "union.pay.ptr");
-  llvm::Type* memLt = val->getType()->getLlvmType();
+  llvm::Type* memLt = getStoredAggregateFieldLlvmType(val->getType());
   llvm::Value* typedPtr = builder->CreateBitCast(
       payPtr, llvm::PointerType::getUnqual(memLt->getContext()));
   builder->CreateStore(val->getLlvmValue(), typedPtr);
@@ -4302,10 +4302,7 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
           val->getType()->is(BaseType::TY_PTR) && val->getType()->getElementType() != nullptr &&
           val->getType()->getElementType()->isEqual(mem[i])) {
         getOrCreateLlvmType(mem[i]);
-        llvm::Type* clsLt = mem[i]->getLlvmType();
-        llvm::Value* loaded =
-            builder->CreateLoad(clsLt, val->getLlvmValue(), "union.wrap.class.from.ptr");
-        auto tmp = std::make_unique<lesma::Value>("", mem[i], loaded);
+        auto tmp = std::make_unique<lesma::Value>("", mem[i], val->getLlvmValue());
         return emitUnionWrapValue(span, tmp.get(), type, i);
       }
     }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -4739,6 +4739,7 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
             functionName);
       }
       localParamsLLVM.push_back(field->defaultValue->getLlvmValue());
+      localParamTypes.push_back(field->type);
     }
   }
 

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1070,14 +1070,8 @@ auto Codegen::visit(const If* node) -> void {
                        UnionNarrowingStableKeyEq>
         narrowMap;
     fillCodegenUnionNarrowVariantMap(node, static_cast<unsigned>(i), narrowMap);
-    bool const pushedNarrowing = !narrowMap.empty();
-    if (pushedNarrowing) {
-      unionNarrowVariantStack.push_back(std::move(narrowMap));
-    }
+    UnionNarrowingScope const unionNarrowScope{unionNarrowVariantStack, std::move(narrowMap)};
     node->getBlocks().at(i)->accept(*this);
-    if (pushedNarrowing) {
-      unionNarrowVariantStack.pop_back();
-    }
 
     if (!isBreak && builder->GetInsertBlock()->getTerminator() == nullptr) {
       builder->CreateBr(bEnd);

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -4290,14 +4290,20 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
       }
     }
     for (unsigned i = 0; i < mem.size(); ++i) {
-      if (val->getType()->isEqual(mem[i])) {
+      Type* memI = mem[i];
+      if (memI == nullptr) {
+        continue;
+      }
+      if (val->getType()->isEqual(memI)) {
         return emitUnionWrapValue(span, val, type, i);
       }
-      if (mem[i] != nullptr && mem[i]->is(BaseType::TY_CLASS) && val->getType() != nullptr &&
+      if (memI->is(BaseType::TY_CLASS) && val->getType() != nullptr &&
           val->getType()->is(BaseType::TY_PTR) && val->getType()->getElementType() != nullptr &&
-          val->getType()->getElementType()->isEqual(mem[i])) {
-        getOrCreateLlvmType(mem[i]);
-        auto tmp = std::make_unique<lesma::Value>("", mem[i], val->getLlvmValue());
+          val->getType()->getElementType()->isEqual(memI)) {
+        // Class union arms use pointer ABI; *T rvalues already carry the same handle the union
+        // stores for T (no LLVM load—val is the handle, not a slot address).
+        getOrCreateLlvmType(memI);
+        auto tmp = std::make_unique<lesma::Value>("", memI, val->getLlvmValue());
         return emitUnionWrapValue(span, tmp.get(), type, i);
       }
     }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -630,6 +631,14 @@ namespace {
     }
     return false;
   }
+  if (type->is(BaseType::TY_UNION)) {
+    for (lesma::Type* m : type->getUnionMembers()) {
+      if (typeContainsUnboundGenericImpl(m, active)) {
+        return true;
+      }
+    }
+    return false;
+  }
   return false;
 }
 
@@ -871,6 +880,147 @@ auto Codegen::visit(const VarDecl* node) -> void {
   }
 }
 
+namespace {
+auto cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> lesma::Value* {
+  if (is == nullptr) {
+    return nullptr;
+  }
+  auto* lit = dynamic_cast<const Literal*>(is->getLeft());
+  if (lit == nullptr || lit->getType() != TokenType::IDENTIFIER) {
+    return nullptr;
+  }
+  if (lesma::Value* rs = lit->getResolvedSymbol()) {
+    return rs;
+  }
+  return scope->lookup(lit->getValue());
+}
+
+auto cgUnionComplementMemberIndex(lesma::Type* unionTy, lesma::Type* excluded)
+    -> std::optional<unsigned> {
+  if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION) || excluded == nullptr) {
+    return std::nullopt;
+  }
+  const auto& mem = unionTy->getUnionMembers();
+  if (mem.size() != 2U) {
+    return std::nullopt;
+  }
+  for (unsigned i = 0; i < mem.size(); ++i) {
+    if (!mem[i]->isEqual(excluded)) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+} // namespace
+
+auto Codegen::lookupUnionNarrowVariant(lesma::Value* sym) const -> std::optional<unsigned> {
+  if (sym == nullptr) {
+    return std::nullopt;
+  }
+  for (auto it = unionNarrowVariantStack.rbegin(); it != unionNarrowVariantStack.rend(); ++it) {
+    auto j = it->find(sym);
+    if (j != it->end()) {
+      return j->second;
+    }
+  }
+  return std::nullopt;
+}
+
+auto Codegen::unionVariantIndexOf(lesma::Type* unionTy, lesma::Type* memberTy) const
+    -> std::optional<unsigned> {
+  if (unionTy == nullptr || memberTy == nullptr || !unionTy->is(BaseType::TY_UNION)) {
+    return std::nullopt;
+  }
+  const auto& mem = unionTy->getUnionMembers();
+  for (unsigned i = 0; i < mem.size(); ++i) {
+    if (mem[i]->isEqual(memberTy)) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+auto Codegen::fillCodegenUnionNarrowVariantMap(const If* node, unsigned blockIndex,
+                                               std::unordered_map<lesma::Value*, unsigned>& out)
+    -> void {
+  if (blockIndex >= node->getBlocks().size()) {
+    return;
+  }
+  Expression* cond = node->getConds()[blockIndex];
+  if (dynamic_cast<const Else*>(cond) != nullptr) {
+    if (blockIndex == 0U) {
+      return;
+    }
+    auto* is0 = dynamic_cast<const IsOp*>(node->getConds()[0]);
+    lesma::Value* sym = cgUnionTryGetIsOpVarSymbol(is0, scope);
+    if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
+      return;
+    }
+    is0->getRight()->accept(*this);
+    lesma::Type* rhsTy = result->getType();
+    if (is0->getOperator() == TokenType::IS) {
+      if (auto idx = cgUnionComplementMemberIndex(sym->getType(), rhsTy)) {
+        out[sym] = *idx;
+      }
+    } else if (is0->getOperator() == TokenType::IS_NOT) {
+      if (auto idx = unionVariantIndexOf(sym->getType(), rhsTy)) {
+        out[sym] = *idx;
+      }
+    }
+    return;
+  }
+  auto* is = dynamic_cast<const IsOp*>(cond);
+  if (is == nullptr) {
+    return;
+  }
+  lesma::Value* sym = cgUnionTryGetIsOpVarSymbol(is, scope);
+  if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
+    return;
+  }
+  is->getRight()->accept(*this);
+  lesma::Type* rhsTy = result->getType();
+  if (is->getOperator() == TokenType::IS) {
+    if (auto idx = unionVariantIndexOf(sym->getType(), rhsTy)) {
+      out[sym] = *idx;
+    }
+  } else if (is->getOperator() == TokenType::IS_NOT) {
+    if (auto idx = cgUnionComplementMemberIndex(sym->getType(), rhsTy)) {
+      out[sym] = *idx;
+    }
+  }
+}
+
+auto Codegen::emitUnionPayloadLoadFromSlot(llvm::Value* unionAllocaPtr, lesma::Type* unionTy,
+                                           lesma::Type* memberTy) -> llvm::Value* {
+  getOrCreateLlvmType(unionTy);
+  getOrCreateLlvmType(memberTy);
+  auto* st = llvm::cast<llvm::StructType>(unionTy->getLlvmType());
+  llvm::Value* payloadPtr =
+      builder->CreateStructGEP(st, unionAllocaPtr, 1U, "union.payload.ptr");
+  llvm::Type* memLt = memberTy->getLlvmType();
+  llvm::Value* typedPtr = builder->CreateBitCast(
+      payloadPtr, llvm::PointerType::getUnqual(memLt->getContext()));
+  return builder->CreateLoad(memLt, typedPtr, "union.payload");
+}
+
+auto Codegen::emitUnionWrapValue(llvm::SMRange /*span*/, lesma::Value* val, lesma::Type* unionTy,
+                                 unsigned variantIndex) -> std::unique_ptr<lesma::Value> {
+  getOrCreateLlvmType(unionTy);
+  getOrCreateLlvmType(val->getType());
+  auto* st = llvm::cast<llvm::StructType>(unionTy->getLlvmType());
+  llvm::Function* f = builder->GetInsertBlock()->getParent();
+  llvm::AllocaInst* slot = createAllocaInEntry(f, st, "union.wrap.slot");
+  llvm::Value* tagPtr = builder->CreateStructGEP(st, slot, 0U, "union.tag.ptr");
+  builder->CreateStore(builder->getInt8(static_cast<uint8_t>(variantIndex)), tagPtr);
+  llvm::Value* payPtr = builder->CreateStructGEP(st, slot, 1U, "union.pay.ptr");
+  llvm::Type* memLt = val->getType()->getLlvmType();
+  llvm::Value* typedPtr = builder->CreateBitCast(
+      payPtr, llvm::PointerType::getUnqual(memLt->getContext()));
+  builder->CreateStore(val->getLlvmValue(), typedPtr);
+  llvm::Value* agg = builder->CreateLoad(st, slot, "union.val");
+  return std::make_unique<lesma::Value>("", unionTy, agg);
+}
+
 auto Codegen::visit(const If* node) -> void {
   setDebugLoc(node->getSpan());
   auto* parentFct = builder->GetInsertBlock()->getParent();
@@ -894,7 +1044,16 @@ auto Codegen::visit(const If* node) -> void {
     builder->CreateCondBr(result->getLlvmValue(), bIfTrue, bIfFalse);
     builder->SetInsertPoint(bIfTrue);
 
+    std::unordered_map<lesma::Value*, unsigned> narrowMap;
+    fillCodegenUnionNarrowVariantMap(node, static_cast<unsigned>(i), narrowMap);
+    bool const pushedNarrowing = !narrowMap.empty();
+    if (pushedNarrowing) {
+      unionNarrowVariantStack.push_back(std::move(narrowMap));
+    }
     node->getBlocks().at(i)->accept(*this);
+    if (pushedNarrowing) {
+      unionNarrowVariantStack.pop_back();
+    }
 
     if (!isBreak && builder->GetInsertBlock()->getTerminator() == nullptr) {
       builder->CreateBr(bEnd);
@@ -3031,6 +3190,30 @@ auto Codegen::visit(const DotOp* node) -> void {
     return;
   }
 
+  if (leftValue != nullptr && leftValue->getType() != nullptr &&
+      leftValue->getType()->is(BaseType::TY_UNION)) {
+    auto* method = dynamic_cast<FuncCall*>(node->getRight());
+    if (method == nullptr) {
+      throw CodegenError(node->getSpan(), "Dot on a union requires a method call");
+    }
+    std::vector<std::unique_ptr<lesma::Value>> argStorage;
+    std::vector<lesma::Value*> args;
+    for (auto* arg : method->getArguments()) {
+      arg->accept(*this);
+      argStorage.push_back(std::move(result));
+      args.push_back(argStorage.back().get());
+    }
+    std::vector<lesma::Type*> explicitTypeArgs;
+    for (auto* explicitTypeArg : method->getExplicitTypeArgs()) {
+      explicitTypeArg->accept(*this);
+      explicitTypeArgs.push_back(result->getType());
+    }
+    setDebugLoc(node->getSpan());
+    result = emitUnionClassMethodDispatch(node->getSpan(), leftValue.get(), method->getName(), args,
+                                          explicitTypeArgs);
+    return;
+  }
+
   if (leftValue != nullptr && leftValue->getType() != nullptr) {
     lesma::Type* forTrait = leftValue->getType();
     if (forTrait->is(BaseType::TY_PTR) && forTrait->getElementType() != nullptr) {
@@ -3376,9 +3559,32 @@ auto Codegen::visit(const CastOp* node) -> void {
 auto Codegen::visit(const IsOp* node) -> void {
   setDebugLoc(node->getSpan());
   node->getLeft()->accept(*this);
-  auto* leftType = result->getType();
+  auto leftOwner = std::move(result);
+  Type* leftType = leftOwner->getType();
   node->getRight()->accept(*this);
-  auto* rightType = result->getType();
+  Type* rightType = result->getType();
+
+  if (leftType != nullptr && leftType->is(BaseType::TY_UNION)) {
+    auto idxOpt = unionVariantIndexOf(leftType, rightType);
+    if (!idxOpt.has_value()) {
+      throw CodegenError(node->getSpan(), "`is` type is not a member of the union value type");
+    }
+    getOrCreateLlvmType(leftType);
+    llvm::Value* agg = leftOwner->getLlvmValue();
+    llvm::Value* tagVal = builder->CreateExtractValue(agg, {0U}, "union.tag");
+    llvm::Value* cmp =
+        builder->CreateICmpEQ(tagVal, builder->getInt8(static_cast<uint8_t>(*idxOpt)));
+    llvm::Value* val = nullptr;
+    if (node->getOperator() == TokenType::IS) {
+      val = cmp;
+    } else {
+      val = builder->CreateNot(cmp);
+    }
+    result = std::make_unique<Value>(
+        "", cacheType(std::make_unique<Type>(BaseType::TY_BOOL, builder->getInt1Ty())), val);
+    return;
+  }
+
   if (leftType != nullptr && leftType->is(BaseType::TY_PTR) &&
       leftType->getElementType() != nullptr && leftType->getElementType()->is(BaseType::TY_CLASS)) {
     leftType = leftType->getElementType();
@@ -4015,6 +4221,25 @@ auto Codegen::visit(const Else* /*node*/) -> void {
 
 auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
     -> std::unique_ptr<lesma::Value> {
+  if (type != nullptr && type->is(BaseType::TY_UNION) && val != nullptr &&
+      val->getType() != nullptr) {
+    const auto& mem = type->getUnionMembers();
+    for (unsigned i = 0; i < mem.size(); ++i) {
+      if (val->getType()->isEqual(mem[i])) {
+        return emitUnionWrapValue(span, val, type, i);
+      }
+      if (mem[i] != nullptr && mem[i]->is(BaseType::TY_CLASS) && val->getType() != nullptr &&
+          val->getType()->is(BaseType::TY_PTR) && val->getType()->getElementType() != nullptr &&
+          val->getType()->getElementType()->isEqual(mem[i])) {
+        getOrCreateLlvmType(mem[i]);
+        llvm::Type* clsLt = mem[i]->getLlvmType();
+        llvm::Value* loaded =
+            builder->CreateLoad(clsLt, val->getLlvmValue(), "union.wrap.class.from.ptr");
+        auto tmp = std::make_unique<lesma::Value>("", mem[i], loaded);
+        return emitUnionWrapValue(span, tmp.get(), type, i);
+      }
+    }
+  }
   return CodegenTypeUtils::cast(span, val, type, builder.get());
 }
 
@@ -4040,6 +4265,15 @@ auto Codegen::materializeSymbolValue(lesma::Value* symbol) -> std::unique_ptr<le
     throw CodegenError({}, "Symbol {} has no type for materialization", symbol->getName());
   }
   getOrCreateLlvmType(lesmaTy);
+  if (lesmaTy->is(BaseType::TY_UNION)) {
+    if (std::optional<unsigned> const idx = lookupUnionNarrowVariant(symbol)) {
+      Type* memTy = lesmaTy->getUnionMembers().at(*idx);
+      getOrCreateLlvmType(memTy);
+      llvm::Value* v =
+          emitUnionPayloadLoadFromSlot(symbol->getLlvmValue(), lesmaTy, memTy);
+      return std::make_unique<Value>("", memTy, v);
+    }
+  }
   if (symbolUsesDirectLlvmValue(symbol)) {
     auto out = std::make_unique<Value>(*symbol);
     out->setType(lesmaTy);
@@ -4508,6 +4742,20 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
     }
   }
 
+  std::vector<llvm::Value*> callParamsLLVM = localParamsLLVM;
+  if (callableLesmaType->is(BaseType::TY_FUNCTION)) {
+    std::vector<Field*> const fields = callableLesmaType->getFields();
+    if (fields.size() == localParamsLLVM.size()) {
+      callParamsLLVM.clear();
+      for (size_t i = 0; i < fields.size(); ++i) {
+        auto holder =
+            std::make_unique<Value>("", localParamTypes[i], localParamsLLVM[i]);
+        auto casted = cast(span, holder.get(), fields[i]->type);
+        callParamsLLVM.push_back(casted->getLlvmValue());
+      }
+    }
+  }
+
   llvm::Value* callableValue = nullptr;
   llvm::Value* loadedClosureEnv = nullptr;
   if (callableLesmaType->is(BaseType::TY_CLASS)) {
@@ -4548,13 +4796,24 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
       callParamTypes.push_back(builder->getPtrTy());
       callArgs.push_back(envArg);
     }
-    callParamTypes.reserve(callParamTypes.size() + localParamTypes.size());
-    callArgs.reserve(callArgs.size() + localParamsLLVM.size());
-    for (auto* t : localParamTypes) {
-      getOrCreateLlvmType(t);
-      callParamTypes.push_back(t->getLlvmType());
+    callParamTypes.reserve(callParamTypes.size() + callableLesmaType->getFields().size());
+    callArgs.reserve(callArgs.size() + callParamsLLVM.size());
+    for (Field* pf : callableLesmaType->getFields()) {
+      if (pf->type == nullptr) {
+        continue;
+      }
+      getOrCreateLlvmType(pf->type);
+      llvm::Type* plt = pf->type->getLlvmType();
+      if (pf->type->is(BaseType::TY_CLASS)) {
+        plt = builder->getPtrTy();
+      } else if (pf->type->is(BaseType::TY_FUNCTION)) {
+        plt = getFuncValuePairLlvmType();
+      } else if (pf->type->is(BaseType::TY_PTR)) {
+        plt = builder->getPtrTy();
+      }
+      callParamTypes.push_back(plt);
     }
-    callArgs.insert(callArgs.end(), localParamsLLVM.begin(), localParamsLLVM.end());
+    callArgs.insert(callArgs.end(), callParamsLLVM.begin(), callParamsLLVM.end());
     Type* retType = callableLesmaType->getReturnType();
     if (retType == nullptr) {
       retType = cacheType(std::make_unique<Type>(BaseType::TY_VOID, builder->getVoidTy()));
@@ -4581,10 +4840,10 @@ auto Codegen::callNamedFunction(llvm::SMRange span, const std::string& functionN
     if (envArgForCall != nullptr) {
       std::vector<llvm::Value*> withEnv;
       withEnv.push_back(envArgForCall);
-      withEnv.insert(withEnv.end(), localParamsLLVM.begin(), localParamsLLVM.end());
+      withEnv.insert(withEnv.end(), callParamsLLVM.begin(), callParamsLLVM.end());
       callInst = builder->CreateCall(func, withEnv);
     } else {
-      callInst = builder->CreateCall(func, localParamsLLVM);
+      callInst = builder->CreateCall(func, callParamsLLVM);
     }
   } else {
     llvm::Value* calleePtr = callableValue;
@@ -4757,6 +5016,102 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
   }
 
   throw CodegenError(span, "Function {} not in current scope.", methodName);
+}
+
+auto Codegen::emitUnionClassMethodDispatch(llvm::SMRange span, lesma::Value* unionValue,
+                                           const std::string& methodName,
+                                           const std::vector<lesma::Value*>& args,
+                                           const std::vector<lesma::Type*>& explicitTypeArgs)
+    -> std::unique_ptr<lesma::Value> {
+  if (!explicitTypeArgs.empty()) {
+    throw CodegenError(span, "Explicit type arguments are not supported on union method calls");
+  }
+  lesma::Type* unionTy = unionValue->getType();
+  if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION)) {
+    throw CodegenError(span, "Internal error: union method dispatch without union type");
+  }
+  const std::vector<Type*>& members = unionTy->getUnionMembers();
+  if (members.empty()) {
+    throw CodegenError(span, "Internal error: empty union in method dispatch");
+  }
+  Type* mem0 = members[0];
+  lesma::Type* selfPtr0 =
+      cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), mem0));
+  std::vector<lesma::Type*> lookupParams;
+  lookupParams.push_back(selfPtr0);
+  for (lesma::Value* arg : args) {
+    Type* t = arg->getType();
+    if (t != nullptr && t->is(BaseType::TY_CLASS)) {
+      t = cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), t));
+    }
+    lookupParams.push_back(t);
+  }
+  lesma::Value* probeMeth = scope->lookupFunction(methodName, lookupParams);
+  if (probeMeth == nullptr || probeMeth->getType() == nullptr ||
+      !probeMeth->getType()->is(BaseType::TY_FUNCTION)) {
+    throw CodegenError(span, "Internal error: could not resolve union method '{}'", methodName);
+  }
+  lesma::Type* commonRetTy = probeMeth->getType()->getReturnType();
+
+  llvm::Function* parent = builder->GetInsertBlock()->getParent();
+  llvm::Type* st = getOrCreateLlvmType(unionTy);
+  auto* structTy = llvm::cast<llvm::StructType>(st);
+  llvm::Value* uv = unionValue->getLlvmValue();
+  llvm::Value* unionPtr = nullptr;
+  if (uv->getType()->isPointerTy()) {
+    unionPtr = uv;
+  } else {
+    llvm::AllocaInst* tmpSlot = createAllocaInEntry(parent, structTy, "union.class.dispatch.slot");
+    builder->CreateStore(uv, tmpSlot);
+    unionPtr = tmpSlot;
+  }
+
+  llvm::Value* tagPtr = builder->CreateStructGEP(structTy, unionPtr, 0U, "union.dispatch.tag.ptr");
+  llvm::Value* tagVal = builder->CreateLoad(builder->getInt8Ty(), tagPtr, "union.dispatch.tag");
+
+  llvm::BasicBlock* mergeBB =
+      llvm::BasicBlock::Create(theModule->getContext(), "union.m.merge", parent);
+  llvm::BasicBlock* defBB =
+      llvm::BasicBlock::Create(theModule->getContext(), "union.m.bad", parent);
+
+  llvm::SwitchInst* sw =
+      builder->CreateSwitch(tagVal, defBB, static_cast<unsigned>(members.size()));
+  builder->SetInsertPoint(defBB);
+  builder->CreateUnreachable();
+
+  std::vector<llvm::Value*> phiVals;
+  std::vector<llvm::BasicBlock*> phiBBs;
+  for (unsigned i = 0; i < members.size(); ++i) {
+    llvm::BasicBlock* caseBB =
+        llvm::BasicBlock::Create(theModule->getContext(), "union.m.case", parent);
+    sw->addCase(builder->getInt8(static_cast<uint8_t>(i)), caseBB);
+    builder->SetInsertPoint(caseBB);
+    llvm::Value* payloadVal = emitUnionPayloadLoadFromSlot(unionPtr, unionTy, members[i]);
+    auto recv = std::make_unique<lesma::Value>("", members[i], payloadVal);
+    std::unique_ptr<lesma::Value> out =
+        callMethodByName(span, recv.get(), methodName, args, explicitTypeArgs);
+    if (commonRetTy != nullptr && commonRetTy->is(BaseType::TY_VOID)) {
+      builder->CreateBr(mergeBB);
+    } else {
+      llvm::Value* rv = out->getLlvmValue();
+      builder->CreateBr(mergeBB);
+      phiVals.push_back(rv);
+      phiBBs.push_back(caseBB);
+    }
+  }
+
+  builder->SetInsertPoint(mergeBB);
+  if (commonRetTy != nullptr && commonRetTy->is(BaseType::TY_VOID)) {
+    return std::make_unique<lesma::Value>(
+        "", cacheType(std::make_unique<Type>(BaseType::TY_VOID, builder->getVoidTy())), nullptr);
+  }
+  getOrCreateLlvmType(commonRetTy);
+  llvm::Type* retLt = commonRetTy->getLlvmType();
+  llvm::PHINode* phi = builder->CreatePHI(retLt, static_cast<unsigned>(phiVals.size()), "union.m.phi");
+  for (unsigned j = 0; j < phiVals.size(); ++j) {
+    phi->addIncoming(phiVals[j], phiBBs[j]);
+  }
+  return std::make_unique<lesma::Value>("", commonRetTy, phi);
 }
 
 auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -5159,13 +5159,18 @@ auto Codegen::emitUnionClassMethodDispatch(llvm::SMRange span, lesma::Value* uni
     auto recv = std::make_unique<lesma::Value>("", members[i], payloadVal);
     std::unique_ptr<lesma::Value> out =
         callMethodByName(span, recv.get(), methodName, args, explicitTypeArgs);
+    llvm::BasicBlock* currentBB = builder->GetInsertBlock();
+    if (currentBB == nullptr) {
+      currentBB = caseBB;
+    }
+    builder->SetInsertPoint(currentBB);
     if (commonRetTy != nullptr && commonRetTy->is(BaseType::TY_VOID)) {
       builder->CreateBr(mergeBB);
     } else {
       llvm::Value* rv = out->getLlvmValue();
       builder->CreateBr(mergeBB);
       phiVals.push_back(rv);
-      phiBBs.push_back(caseBB);
+      phiBBs.push_back(currentBB);
     }
   }
 

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1011,7 +1011,8 @@ auto Codegen::emitUnionWrapValue(llvm::SMRange /*span*/, lesma::Value* val, lesm
   llvm::Function* f = builder->GetInsertBlock()->getParent();
   llvm::AllocaInst* slot = createAllocaInEntry(f, st, "union.wrap.slot");
   llvm::Value* tagPtr = builder->CreateStructGEP(st, slot, 0U, "union.tag.ptr");
-  builder->CreateStore(builder->getInt8(static_cast<uint8_t>(variantIndex)), tagPtr);
+  llvm::Type* tagTy = getOrCreateUnionTagLlvmType(unionTy);
+  builder->CreateStore(llvm::ConstantInt::get(tagTy, variantIndex), tagPtr);
   llvm::Value* payPtr = builder->CreateStructGEP(st, slot, 1U, "union.pay.ptr");
   llvm::Type* memLt = val->getType()->getLlvmType();
   llvm::Value* typedPtr = builder->CreateBitCast(
@@ -3572,8 +3573,8 @@ auto Codegen::visit(const IsOp* node) -> void {
     getOrCreateLlvmType(leftType);
     llvm::Value* agg = leftOwner->getLlvmValue();
     llvm::Value* tagVal = builder->CreateExtractValue(agg, {0U}, "union.tag");
-    llvm::Value* cmp =
-        builder->CreateICmpEQ(tagVal, builder->getInt8(static_cast<uint8_t>(*idxOpt)));
+    llvm::Value* cmp = builder->CreateICmpEQ(
+        tagVal, llvm::ConstantInt::get(tagVal->getType(), static_cast<uint64_t>(*idxOpt)));
     llvm::Value* val = nullptr;
     if (node->getOperator() == TokenType::IS) {
       val = cmp;
@@ -5068,7 +5069,8 @@ auto Codegen::emitUnionClassMethodDispatch(llvm::SMRange span, lesma::Value* uni
   }
 
   llvm::Value* tagPtr = builder->CreateStructGEP(structTy, unionPtr, 0U, "union.dispatch.tag.ptr");
-  llvm::Value* tagVal = builder->CreateLoad(builder->getInt8Ty(), tagPtr, "union.dispatch.tag");
+  llvm::Type* tagTy = getOrCreateUnionTagLlvmType(unionTy);
+  llvm::Value* tagVal = builder->CreateLoad(tagTy, tagPtr, "union.dispatch.tag");
 
   llvm::BasicBlock* mergeBB =
       llvm::BasicBlock::Create(theModule->getContext(), "union.m.merge", parent);
@@ -5085,7 +5087,7 @@ auto Codegen::emitUnionClassMethodDispatch(llvm::SMRange span, lesma::Value* uni
   for (unsigned i = 0; i < members.size(); ++i) {
     llvm::BasicBlock* caseBB =
         llvm::BasicBlock::Create(theModule->getContext(), "union.m.case", parent);
-    sw->addCase(builder->getInt8(static_cast<uint8_t>(i)), caseBB);
+    sw->addCase(llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(tagTy, i)), caseBB);
     builder->SetInsertPoint(caseBB);
     llvm::Value* payloadVal = emitUnionPayloadLoadFromSlot(unionPtr, unionTy, members[i]);
     auto recv = std::make_unique<lesma::Value>("", members[i], payloadVal);

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -998,9 +998,7 @@ auto Codegen::emitUnionPayloadLoadFromSlot(llvm::Value* unionAllocaPtr, lesma::T
   llvm::Value* payloadPtr =
       builder->CreateStructGEP(st, unionAllocaPtr, 1U, "union.payload.ptr");
   llvm::Type* memLt = getStoredAggregateFieldLlvmType(memberTy);
-  llvm::Value* typedPtr = builder->CreateBitCast(
-      payloadPtr, llvm::PointerType::getUnqual(memLt->getContext()));
-  return builder->CreateLoad(memLt, typedPtr, "union.payload");
+  return builder->CreateLoad(memLt, payloadPtr, "union.payload");
 }
 
 auto Codegen::emitUnionWrapValue(llvm::SMRange /*span*/, lesma::Value* val, lesma::Type* unionTy,
@@ -1014,10 +1012,7 @@ auto Codegen::emitUnionWrapValue(llvm::SMRange /*span*/, lesma::Value* val, lesm
   llvm::Type* tagTy = getOrCreateUnionTagLlvmType(unionTy);
   builder->CreateStore(llvm::ConstantInt::get(tagTy, variantIndex), tagPtr);
   llvm::Value* payPtr = builder->CreateStructGEP(st, slot, 1U, "union.pay.ptr");
-  llvm::Type* memLt = getStoredAggregateFieldLlvmType(val->getType());
-  llvm::Value* typedPtr = builder->CreateBitCast(
-      payPtr, llvm::PointerType::getUnqual(memLt->getContext()));
-  builder->CreateStore(val->getLlvmValue(), typedPtr);
+  builder->CreateStore(val->getLlvmValue(), payPtr);
   llvm::Value* agg = builder->CreateLoad(st, slot, "union.val");
   return std::make_unique<lesma::Value>("", unionTy, agg);
 }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -4,6 +4,8 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <ranges>
+#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -883,7 +885,7 @@ auto Codegen::cgUnionTryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> 
   if (is == nullptr) {
     return nullptr;
   }
-  auto* lit = dynamic_cast<const Literal*>(is->getLeft());
+  const auto* lit = dynamic_cast<const Literal*>(is->getLeft());
   if (lit == nullptr || lit->getType() != TokenType::IDENTIFIER) {
     return nullptr;
   }
@@ -953,33 +955,57 @@ auto Codegen::fillCodegenUnionNarrowVariantMap(
     if (blockIndex == 0U) {
       return;
     }
-    auto* is0 = dynamic_cast<const IsOp*>(node->getConds()[0]);
-    lesma::Value* sym = cgUnionTryGetIsOpVarSymbol(is0, scope);
-    if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
-      return;
-    }
-    lesma::Type* rhsTy = is0->getResolvedRhsType();
-    if (rhsTy == nullptr) {
-      return;
-    }
-    if (is0->getOperator() == TokenType::IS) {
-      if (auto idx = cgUnionComplementMemberIndex(sym->getType(), rhsTy)) {
-        const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
-        if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
-          out[key] = *idx;
+    const std::vector<Expression*> conds = node->getConds();
+    lesma::Value* sym = nullptr;
+    std::set<unsigned> possible;
+    for (unsigned j = 0; j < blockIndex; ++j) {
+      const auto* isJ = dynamic_cast<const IsOp*>(conds[j]);
+      if (isJ == nullptr) {
+        continue;
+      }
+      lesma::Value* symJ = cgUnionTryGetIsOpVarSymbol(isJ, scope);
+      if (symJ == nullptr || symJ->getType() == nullptr ||
+          !symJ->getType()->is(BaseType::TY_UNION)) {
+        continue;
+      }
+      if (sym == nullptr) {
+        sym = symJ;
+        const auto& mem = sym->getType()->getUnionMembers();
+        for (unsigned vi = 0; vi < mem.size(); ++vi) {
+          possible.insert(vi);
+        }
+      } else if (symJ != sym) {
+        continue;
+      }
+      lesma::Type* unionTy = sym->getType();
+      lesma::Type* rhsTy = isJ->getResolvedRhsType();
+      if (rhsTy == nullptr) {
+        continue;
+      }
+      if (isJ->getOperator() == TokenType::IS) {
+        if (auto idx = unionVariantIndexOf(unionTy, rhsTy)) {
+          possible.erase(*idx);
+        }
+      } else if (isJ->getOperator() == TokenType::IS_NOT) {
+        if (auto idx = unionVariantIndexOf(unionTy, rhsTy)) {
+          if (possible.contains(*idx)) {
+            possible = {*idx};
+          } else {
+            possible.clear();
+          }
         }
       }
-    } else if (is0->getOperator() == TokenType::IS_NOT) {
-      if (auto idx = unionVariantIndexOf(sym->getType(), rhsTy)) {
-        const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
-        if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
-          out[key] = *idx;
-        }
-      }
+    }
+    if (sym == nullptr || possible.size() != 1U) {
+      return;
+    }
+    const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+    if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+      out[key] = *possible.begin();
     }
     return;
   }
-  auto* is = dynamic_cast<const IsOp*>(cond);
+  const auto* is = dynamic_cast<const IsOp*>(cond);
   if (is == nullptr) {
     return;
   }
@@ -1384,6 +1410,7 @@ auto Codegen::declareSynthesizedClassConstructor(const Class* astNode, lesma::Ty
   auto linkage = shouldExport ? Function::ExternalLinkage : Function::PrivateLinkage;
 
   std::vector<llvm::Type*> paramLLVMTypes;
+  paramLLVMTypes.reserve(paramTypes.size());
   for (auto* pt : paramTypes) {
     paramLLVMTypes.push_back(pt->getLlvmType());
   }
@@ -4641,13 +4668,11 @@ auto Codegen::callNamedFunction(
         if (it == specializedClassTypeEnvs.end()) {
           return false;
         }
-        for (const auto& [name, ty] : it->second) {
-          (void) name;
-          if (ty != nullptr && ty->is(BaseType::TY_GENERIC)) {
-            return false;
-          }
-        }
-        return true;
+        return std::ranges::all_of(
+            it->second, [](const std::pair<const std::string, lesma::Type*>& e) {
+              lesma::Type* ty = e.second;
+              return ty == nullptr || !ty->is(BaseType::TY_GENERIC);
+            });
       };
       if (allocatedClassMonomorph != nullptr && monomorphEnvIsConcrete(allocatedClassMonomorph)) {
         classSym = emitClassMonomorph(allocatedClassMonomorph, templateClass);

--- a/src/liblesma/Backend/MangleUtils.cpp
+++ b/src/liblesma/Backend/MangleUtils.cpp
@@ -104,6 +104,16 @@ auto getTypeMangledName(llvm::SMRange span, Type* type) -> std::string {
     }
     return "(" + s + ")";
   }
+  if (type->is(BaseType::TY_UNION)) {
+    std::string s = "union_";
+    for (Type* m : type->getUnionMembers()) {
+      if (m == nullptr) {
+        throw CodegenError(span, "unresolved union member in {}", type->toString());
+      }
+      s += getTypeMangledName(span, m) + "_";
+    }
+    return "(" + s + ")";
+  }
 
   throw CodegenError(span, "Unknown type found during mangling");
 }

--- a/src/liblesma/Driver/AnalysisResult.h
+++ b/src/liblesma/Driver/AnalysisResult.h
@@ -114,7 +114,7 @@ struct AnalysisResult {
   std::unordered_map<std::string, std::shared_ptr<ImportedModuleAnalysis>> importedModules;
 
   [[nodiscard]] auto hasErrors() const -> bool {
-    for (const AnalysisDiagnostic& d : diagnostics) {
+    for (const auto& d : diagnostics) {
       if (d.severity == AnalysisDiagnosticSeverity::Error) {
         return true;
       }

--- a/src/liblesma/Driver/AnalysisResult.h
+++ b/src/liblesma/Driver/AnalysisResult.h
@@ -48,6 +48,8 @@ struct IndexedSymbolOccurrence {
   std::string name;
   std::optional<std::string> dotBase;
   llvm::SMRange span;
+  /** Non-owning; if set, hover uses this type instead of the resolved symbol's declared type. */
+  Type* flowSensitiveType = nullptr;
   /** When set, semantic tokens use this range instead of \c span (e.g. operator glyphs only). */
   std::optional<llvm::SMRange> semanticHighlightSpan;
   std::optional<IndexedDeclarationIdentity> declaration;

--- a/src/liblesma/Frontend/Lexer.cpp
+++ b/src/liblesma/Frontend/Lexer.cpp
@@ -77,6 +77,8 @@ auto Lexer::scanOne(bool continuation) -> std::unique_ptr<Token> {
     return makeToken(TokenType::COLON);
   case ',':
     return makeToken(TokenType::COMMA);
+  case '|':
+    return makeToken(TokenType::PIPE);
   case '.': {
     if (matchAndAdvance('.')) {
       if (matchAndAdvance('.')) {

--- a/src/liblesma/Frontend/Parser.cpp
+++ b/src/liblesma/Frontend/Parser.cpp
@@ -370,6 +370,9 @@ auto Parser::parseTypeAt(unsigned long& off) -> bool {
   }
   while (index + off < tokens.size() && peek(off)->type == TokenType::PIPE) {
     off++;
+    while (index + off < tokens.size() && peek(off)->type == TokenType::NEWLINE) {
+      off++;
+    }
     if (!parseTypePrimaryAt(off)) {
       return false;
     }

--- a/src/liblesma/Frontend/Parser.cpp
+++ b/src/liblesma/Frontend/Parser.cpp
@@ -247,7 +247,8 @@ auto Parser::parseTypePrimary() -> std::unique_ptr<TypeExpr> {
       advance();
     }
     std::unique_ptr<TypeExpr> innerFirst = parseType();
-    if (advanceIfMatchAny<TokenType::COMMA>()) {
+    const bool hadTrailingComma = advanceIfMatchAny<TokenType::COMMA>();
+    if (hadTrailingComma) {
       std::vector<std::unique_ptr<TypeExpr>> elems;
       elems.push_back(std::move(innerFirst));
       while (!check(TokenType::RIGHT_PAREN)) {
@@ -267,6 +268,9 @@ auto Parser::parseTypePrimary() -> std::unique_ptr<TypeExpr> {
         }
         lexeme += elems[i]->getName();
       }
+      if (elems.size() == 1U) {
+        lexeme += ",";
+      }
       lexeme += ")";
       return TypeExpr::makeTupleType(llvm::SMRange{left->getStart(), right->getEnd()},
                                      std::move(lexeme), std::move(elems));
@@ -276,7 +280,7 @@ auto Parser::parseTypePrimary() -> std::unique_ptr<TypeExpr> {
   }
   if (check(TokenType::STAR)) {
     advance();
-    auto elementType = parseType();
+    auto elementType = parseTypePrimary();
     return std::make_unique<TypeExpr>(llvm::SMRange{type->getStart(), elementType->getEnd()},
                                       "*" + elementType->getName(), TokenType::PTR_TYPE,
                                       std::move(elementType));
@@ -387,7 +391,7 @@ auto Parser::parseTypePrimaryAt(unsigned long& off) -> bool {
 
   if (check(TokenType::STAR, off)) {
     off++;
-    return parseTypeAt(off);
+    return parseTypePrimaryAt(off);
   }
 
   if (check(TokenType::LEFT_PAREN, off)) {

--- a/src/liblesma/Frontend/Parser.cpp
+++ b/src/liblesma/Frontend/Parser.cpp
@@ -211,6 +211,35 @@ auto Parser::parseIgnoredTypeArgList() -> void {
 }
 
 auto Parser::parseType() -> std::unique_ptr<TypeExpr> {
+  std::vector<std::unique_ptr<TypeExpr>> arms;
+  arms.push_back(parseTypePrimary());
+  if (arms[0] == nullptr) {
+    return nullptr;
+  }
+  while (advanceIfMatchAny<TokenType::PIPE>()) {
+    while (check(TokenType::NEWLINE)) {
+      advance();
+    }
+    std::unique_ptr<TypeExpr> next = parseTypePrimary();
+    if (next == nullptr) {
+      return nullptr;
+    }
+    arms.push_back(std::move(next));
+  }
+  if (arms.size() == 1U) {
+    return std::move(arms[0]);
+  }
+  std::string lexeme = arms[0]->getName();
+  for (size_t i = 1; i < arms.size(); ++i) {
+    lexeme += " | ";
+    lexeme += arms[i]->getName();
+  }
+  return TypeExpr::makeUnionType(
+      llvm::SMRange{arms.front()->getStart(), arms.back()->getEnd()}, std::move(lexeme),
+      std::move(arms));
+}
+
+auto Parser::parseTypePrimary() -> std::unique_ptr<TypeExpr> {
   auto* type = peek();
   if (check(TokenType::LEFT_PAREN)) {
     auto* left = consume(TokenType::LEFT_PAREN);
@@ -336,6 +365,19 @@ auto Parser::parseType() -> std::unique_ptr<TypeExpr> {
 }
 
 auto Parser::parseTypeAt(unsigned long& off) -> bool {
+  if (!parseTypePrimaryAt(off)) {
+    return false;
+  }
+  while (index + off < tokens.size() && peek(off)->type == TokenType::PIPE) {
+    off++;
+    if (!parseTypePrimaryAt(off)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto Parser::parseTypePrimaryAt(unsigned long& off) -> bool {
   if (index + off >= tokens.size()) {
     return false;
   }

--- a/src/liblesma/Frontend/Parser.h
+++ b/src/liblesma/Frontend/Parser.h
@@ -134,6 +134,8 @@ private:
   auto parseReturn() -> std::unique_ptr<Statement>;
   auto parseDefer() -> std::unique_ptr<Statement>;
   auto parseType() -> std::unique_ptr<TypeExpr>;
+  /** One union arm: no top-level `|` (inner `parseType` still allows unions in parens / ptr). */
+  auto parseTypePrimary() -> std::unique_ptr<TypeExpr>;
   auto parseExpression() -> std::unique_ptr<Expression>;
   auto parseOr() -> std::unique_ptr<Expression>;
   auto parseAnd() -> std::unique_ptr<Expression>;
@@ -157,6 +159,7 @@ private:
   // GREATER LEFT_PAREN (so parsing as call with explicit type args is valid).
   auto hasExplicitTypeArgsAndParen() -> bool;
   auto parseTypeAt(unsigned long& off) -> bool;
+  auto parseTypePrimaryAt(unsigned long& off) -> bool;
   auto skipOneTypeAt(unsigned long& off) -> bool;
 };
 } // namespace lesma

--- a/src/liblesma/Symbol/SymbolTable.cpp
+++ b/src/liblesma/Symbol/SymbolTable.cpp
@@ -182,6 +182,22 @@ auto matchGenericParameter(Type* formalTy, Type* argTy,
   if (formalTy == nullptr || argTy == nullptr) {
     return formalTy == argTy;
   }
+  if (formalTy->is(BaseType::TY_UNION)) {
+    if (argTy->is(BaseType::TY_UNION)) {
+      return formalTy->isEqual(argTy);
+    }
+    for (Type* m : formalTy->getUnionMembers()) {
+      if (m != nullptr && m->is(BaseType::TY_CLASS) && argTy != nullptr &&
+          argTy->is(BaseType::TY_PTR) && argTy->getElementType() != nullptr &&
+          matchGenericParameter(m, argTy->getElementType(), genericBindings, lookupKind)) {
+        return true;
+      }
+      if (matchGenericParameter(m, argTy, genericBindings, lookupKind)) {
+        return true;
+      }
+    }
+    return false;
+  }
   if (formalTy->is(BaseType::TY_TRAIT_EXISTENTIAL)) {
     const std::string& want = formalTy->getDisplayName();
     Type* cls = argTy;

--- a/src/liblesma/Symbol/SymbolTable.cpp
+++ b/src/liblesma/Symbol/SymbolTable.cpp
@@ -188,11 +188,16 @@ auto matchGenericParameter(Type* formalTy, Type* argTy,
     }
     for (Type* m : formalTy->getUnionMembers()) {
       if (m != nullptr && m->is(BaseType::TY_CLASS) && argTy != nullptr &&
-          argTy->is(BaseType::TY_PTR) && argTy->getElementType() != nullptr &&
-          matchGenericParameter(m, argTy->getElementType(), genericBindings, lookupKind)) {
-        return true;
+          argTy->is(BaseType::TY_PTR) && argTy->getElementType() != nullptr) {
+        auto probeBindings = genericBindings;
+        if (matchGenericParameter(m, argTy->getElementType(), probeBindings, lookupKind)) {
+          genericBindings = std::move(probeBindings);
+          return true;
+        }
       }
-      if (matchGenericParameter(m, argTy, genericBindings, lookupKind)) {
+      auto probeBindings = genericBindings;
+      if (matchGenericParameter(m, argTy, probeBindings, lookupKind)) {
+        genericBindings = std::move(probeBindings);
         return true;
       }
     }

--- a/src/liblesma/Symbol/SymbolTable.cpp
+++ b/src/liblesma/Symbol/SymbolTable.cpp
@@ -178,13 +178,63 @@ auto typeContainsGeneric(Type* type) -> bool {
 
 auto matchGenericParameter(Type* formalTy, Type* argTy,
                            std::unordered_map<std::string, Type*>& genericBindings,
+                           FunctionLookupKind lookupKind) -> bool;
+
+// Union-vs-union: pair formal and arg members (any bijection); commit genericBindings only on
+// full success (probes + backtrack like the non-union union branch).
+[[nodiscard]] auto
+matchGenericUnionAgainstUnion(const std::vector<Type*>& formalMembers, size_t formalIndex,
+                              const std::vector<Type*>& argMembers, std::vector<bool>& usedArg,
+                              std::unordered_map<std::string, Type*> trialBindings,
+                              std::unordered_map<std::string, Type*>& genericBindings,
+                              FunctionLookupKind lookupKind) -> bool {
+  if (formalIndex == formalMembers.size()) {
+    genericBindings = std::move(trialBindings);
+    return true;
+  }
+  Type* fm = formalMembers[formalIndex];
+  if (fm == nullptr) {
+    return false;
+  }
+  for (size_t aj = 0; aj < argMembers.size(); ++aj) {
+    if (usedArg[aj]) {
+      continue;
+    }
+    Type* am = argMembers[aj];
+    if (am == nullptr) {
+      continue;
+    }
+    auto probeBindings = trialBindings;
+    if (!matchGenericParameter(fm, am, probeBindings, lookupKind)) {
+      continue;
+    }
+    usedArg[aj] = true;
+    if (matchGenericUnionAgainstUnion(formalMembers, formalIndex + 1, argMembers, usedArg,
+                                      std::move(probeBindings), genericBindings, lookupKind)) {
+      return true;
+    }
+    usedArg[aj] = false;
+  }
+  return false;
+}
+
+auto matchGenericParameter(Type* formalTy, Type* argTy,
+                           std::unordered_map<std::string, Type*>& genericBindings,
                            FunctionLookupKind lookupKind) -> bool {
   if (formalTy == nullptr || argTy == nullptr) {
     return formalTy == argTy;
   }
   if (formalTy->is(BaseType::TY_UNION)) {
     if (argTy->is(BaseType::TY_UNION)) {
-      return formalTy->isEqual(argTy);
+      const std::vector<Type*>& formalMembers = formalTy->getUnionMembers();
+      const std::vector<Type*>& argMembers = argTy->getUnionMembers();
+      if (formalMembers.size() != argMembers.size()) {
+        return false;
+      }
+      std::vector<bool> usedArg(argMembers.size(), false);
+      std::unordered_map<std::string, Type*> trialBindings = genericBindings;
+      return matchGenericUnionAgainstUnion(formalMembers, 0, argMembers, usedArg,
+                                           std::move(trialBindings), genericBindings, lookupKind);
     }
     for (Type* m : formalTy->getUnionMembers()) {
       if (m != nullptr && m->is(BaseType::TY_CLASS) && argTy != nullptr &&
@@ -277,7 +327,7 @@ auto matchGenericParameter(Type* formalTy, Type* argTy,
       }
     }
     return matchGenericParameter(formalTy->getReturnType(), argTy->getReturnType(), genericBindings,
-                               lookupKind);
+                                 lookupKind);
   }
   return formalTy->isEqual(argTy);
 }
@@ -420,8 +470,8 @@ auto selectBestFunctionTypeMatchTail(const std::vector<Type*>& candidateFunction
 } // namespace lesma
 
 auto SymbolTable::lookupFunction(const std::string& name, std::vector<lesma::Type*> paramTypes,
-                                 FunctionLookupKind lookupKind,
-                                 Type* excludeFormalReceiverClass) -> Value* {
+                                 FunctionLookupKind lookupKind, Type* excludeFormalReceiverClass)
+    -> Value* {
   auto range = symbols.equal_range(name);
   Value* bestCandidate = nullptr;
   std::vector<int> bestRanks;
@@ -506,8 +556,8 @@ auto SymbolTable::lookupFunction(const std::string& name, std::vector<lesma::Typ
 auto SymbolTable::lookupSuperClassMethod(
     const std::string& name, std::vector<lesma::Type*> paramTypes,
     const std::function<bool(Type* formalReceiverClass)>& receiverMatches,
-    Type* staticSuperclassType,
-    const std::unordered_map<std::string, Type*>* seedGenericBindings) -> Value* {
+    Type* staticSuperclassType, const std::unordered_map<std::string, Type*>* seedGenericBindings)
+    -> Value* {
   auto range = symbols.equal_range(name);
   Value* bestCandidate = nullptr;
   std::vector<int> bestRanks;
@@ -620,7 +670,8 @@ auto SymbolTable::lookupSuperClassMethod(
             candidateRanks2.push_back(rankForMatchedOverloadParam(formalTy, argTy));
             continue;
           }
-          if (!matchGenericParameter(formalTy, argTy, genericBindings2, FunctionLookupKind::VALUE)) {
+          if (!matchGenericParameter(formalTy, argTy, genericBindings2,
+                                     FunctionLookupKind::VALUE)) {
             paramsMatch2 = false;
             break;
           }
@@ -648,8 +699,7 @@ auto SymbolTable::lookupSuperClassMethod(
         withLlvm = cand;
       }
     }
-    if (withLlvm != nullptr &&
-        !rankVectorBetter(bestRanks, withLlvmRanks) &&
+    if (withLlvm != nullptr && !rankVectorBetter(bestRanks, withLlvmRanks) &&
         !rankVectorBetter(withLlvmRanks, bestRanks)) {
       bestCandidate = withLlvm;
     }

--- a/src/liblesma/Symbol/Type.h
+++ b/src/liblesma/Symbol/Type.h
@@ -35,6 +35,8 @@ enum class BaseType : std::uint8_t {
   TY_TRAIT_EXISTENTIAL,
   /** Structural product type `(T1, T2, ...)` lowered to LLVM struct. */
   TY_TUPLE,
+  /** Tagged union `T1 | T2 | ...` (canonical member order). */
+  TY_UNION,
 };
 
 class Type;
@@ -98,6 +100,8 @@ class Type {
   bool signedInt = true;
   /** For TY_INT when LLVM type is not yet set: 0 means default width (64). */
   std::uint16_t intWidth = 0;
+  /** For TY_UNION: variant types in tag order (non-owning; same lifetime as type cache). */
+  std::vector<Type*> unionMembers;
 
 public:
   explicit Type(BaseType baseType)
@@ -218,6 +222,9 @@ public:
   auto replaceFields(std::vector<std::unique_ptr<Field>> newFields) -> void {
     fields = std::move(newFields);
   }
+
+  [[nodiscard]] auto getUnionMembers() const -> const std::vector<Type*>& { return unionMembers; }
+  auto setUnionMembers(std::vector<Type*> members) -> void { unionMembers = std::move(members); }
 
   auto isEqual(Type* rhs) const -> bool {
     std::set<std::pair<Type const*, Type const*>> active;
@@ -434,6 +441,27 @@ private:
       }
       return true;
     }
+    case BaseType::TY_UNION: {
+      const auto& lu = getUnionMembers();
+      const auto& ru = rhs->getUnionMembers();
+      if (lu.size() != ru.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < lu.size(); ++i) {
+        Type* lt = lu[i];
+        Type* rt = ru[i];
+        if (lt == nullptr || rt == nullptr) {
+          if (lt != rt) {
+            return false;
+          }
+          continue;
+        }
+        if (!lt->isEqualImpl(rt, active)) {
+          return false;
+        }
+      }
+      return true;
+    }
     case BaseType::TY_CLASS:
     case BaseType::TY_ENUM:
       // Handled above; unreachable but required for switch completeness.
@@ -514,13 +542,27 @@ public:
       result += ">";
       break;
     }
+    case BaseType::TY_UNION: {
+      if (!displayName.empty()) {
+        result = displayName;
+        break;
+      }
+      for (size_t i = 0; i < unionMembers.size(); ++i) {
+        if (i > 0) {
+          result += " | ";
+        }
+        result += unionMembers[i] != nullptr ? unionMembers[i]->toString() : "?";
+      }
+      break;
+    }
     }
 
     if (elementType != nullptr && baseType != BaseType::TY_PTR) {
       result += "<" + elementType->toString() + ">";
     }
 
-    if (!fields.empty() && !isOneOf({BaseType::TY_CLASS, BaseType::TY_ENUM, BaseType::TY_TUPLE})) {
+    if (!fields.empty() &&
+        !isOneOf({BaseType::TY_CLASS, BaseType::TY_ENUM, BaseType::TY_TUPLE, BaseType::TY_UNION})) {
       result += baseType == BaseType::TY_FUNCTION ? " ( " : " { ";
       for (const auto& field : fields) {
         result += field->name + ": " + field->type->toString() + "; ";

--- a/src/liblesma/Symbol/TypeUtils.cpp
+++ b/src/liblesma/Symbol/TypeUtils.cpp
@@ -1,6 +1,10 @@
 #include "TypeUtils.h"
 
+#include <algorithm>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "liblesma/Symbol/Type.h"
 
@@ -67,5 +71,49 @@ auto makeSpecializedClassKey(Type* classTemplate, const std::vector<std::string>
     key << "<unbound:" << name << ">";
   }
   return key.str();
+}
+
+auto canonicalizeUnionMembers(std::vector<Type*> arms)
+    -> std::pair<std::vector<Type*>, std::string> {
+  std::vector<Type*> flat;
+  flat.reserve(arms.size());
+  auto appendFlattened = [&](Type* cur, auto&& self) -> void {
+    if (cur == nullptr) {
+      return;
+    }
+    if (cur->is(BaseType::TY_UNION)) {
+      for (Type* inner : cur->getUnionMembers()) {
+        self(inner, self);
+      }
+    } else {
+      flat.push_back(cur);
+    }
+  };
+  for (Type* a : arms) {
+    appendFlattened(a, appendFlattened);
+  }
+  std::vector<Type*> unique;
+  unique.reserve(flat.size());
+  for (Type* m : flat) {
+    bool duplicate = false;
+    for (Type* u : unique) {
+      if (m->isEqual(u)) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (!duplicate) {
+      unique.push_back(m);
+    }
+  }
+  std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
+  std::string displayName;
+  for (size_t i = 0; i < unique.size(); ++i) {
+    if (i > 0U) {
+      displayName += " | ";
+    }
+    displayName += unique[i]->toString();
+  }
+  return {std::move(unique), std::move(displayName)};
 }
 } // namespace lesma::TypeUtils

--- a/src/liblesma/Symbol/TypeUtils.h
+++ b/src/liblesma/Symbol/TypeUtils.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace lesma {
@@ -23,5 +24,10 @@ auto findFieldInFields(Type* structType, const std::string& field) -> Field*;
 /** Stable specialization registry key shared by typecheck and codegen. */
 auto makeSpecializedClassKey(Type* classTemplate, const std::vector<std::string>& genericParamNames,
                              const std::unordered_map<std::string, Type*>& env) -> std::string;
+/** Flatten nested \c TY_UNION arms (null arms skipped, matching prior substitution behavior),
+ *  dedupe with \c Type::isEqual, sort by \c toString(), and build the `a | b` display string.
+ *  Used everywhere \c setUnionMembers runs so mangling and specialization caches stay stable. */
+[[nodiscard]] auto canonicalizeUnionMembers(std::vector<Type*> arms)
+    -> std::pair<std::vector<Type*>, std::string>;
 } // namespace TypeUtils
 } // namespace lesma

--- a/src/liblesma/Symbol/UnionNarrowingStableKey.h
+++ b/src/liblesma/Symbol/UnionNarrowingStableKey.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <string_view>
+
+#include "llvm/Support/SMLoc.h"
+
+#include "liblesma/Symbol/Value.h"
+
+namespace lesma {
+
+/** Stable identity for union narrowing maps: declaration site after resolving lambda capture
+ *  shadows, or the anchored \c Value* when no declaration span is recorded. */
+struct UnionNarrowingStableKey {
+  std::string_view declarationFilePath;
+  llvm::SMRange declarationSpan;
+  const Value* fallbackAnchor = nullptr;
+
+  [[nodiscard]] friend bool operator==(UnionNarrowingStableKey a,
+                                       UnionNarrowingStableKey b) noexcept {
+    const bool aLoc = a.declarationSpan.isValid();
+    const bool bLoc = b.declarationSpan.isValid();
+    if (aLoc && bLoc) {
+      return a.declarationFilePath == b.declarationFilePath &&
+             a.declarationSpan.Start == b.declarationSpan.Start &&
+             a.declarationSpan.End == b.declarationSpan.End;
+    }
+    if (!aLoc && !bLoc) {
+      return a.fallbackAnchor == b.fallbackAnchor;
+    }
+    return false;
+  }
+};
+
+struct UnionNarrowingStableKeyHash {
+  [[nodiscard]] auto operator()(UnionNarrowingStableKey k) const noexcept -> std::size_t {
+    if (k.declarationSpan.isValid()) {
+      std::size_t h = std::hash<std::string_view>{}(k.declarationFilePath);
+      h ^= std::hash<const void*>{}(k.declarationSpan.Start.getPointer()) + 0x9e3779b9U +
+           (h << 6U) + (h >> 2U);
+      h ^= std::hash<const void*>{}(k.declarationSpan.End.getPointer()) + 0x9e3779b9U + (h << 6U) +
+           (h >> 2U);
+      return h;
+    }
+    return std::hash<const void*>{}(k.fallbackAnchor);
+  }
+};
+
+struct UnionNarrowingStableKeyEq {
+  [[nodiscard]] auto operator()(UnionNarrowingStableKey a, UnionNarrowingStableKey b) const noexcept
+      -> bool {
+    return a == b;
+  }
+};
+
+[[nodiscard]] inline auto unionNarrowingStableKeyForSymbol(Value* sym) -> UnionNarrowingStableKey {
+  Value* anchor = sym;
+  while (anchor != nullptr && anchor->getClosureSlotOuter() != nullptr) {
+    anchor = anchor->getClosureSlotOuter();
+  }
+  if (anchor == nullptr) {
+    return {std::string_view{}, llvm::SMRange(), nullptr};
+  }
+  llvm::SMRange span = anchor->getDeclarationSpan();
+  if (span.isValid()) {
+    return {std::string_view(anchor->getDeclarationFilePath()), span, nullptr};
+  }
+  return {std::string_view{}, llvm::SMRange(), anchor};
+}
+
+} // namespace lesma

--- a/src/liblesma/Token/TokenType.h
+++ b/src/liblesma/Token/TokenType.h
@@ -29,6 +29,7 @@ enum class TokenType : std::uint8_t {
   AMPERSAND,
   RANGE,
   ELLIPSIS,
+  PIPE,
 
   // One or two character tokens.
   BANG,
@@ -78,6 +79,8 @@ enum class TokenType : std::uint8_t {
   FLOAT32_TYPE,
   /** Structural tuple type `(T1, T2, ...)` in TypeExpr; not a lexer token. */
   TUPLE_TYPE,
+  /** Structural union type `T1 | T2 | ...` in TypeExpr; not a lexer token. */
+  UNION_TYPE,
 
   // Keywords.
   AND,

--- a/src/liblesma/Typecheck/AnalysisIndex.cpp
+++ b/src/liblesma/Typecheck/AnalysisIndex.cpp
@@ -132,8 +132,8 @@ auto appendIndexedOccurrence(AnalysisIndex& index, const std::string& name,
                              std::optional<IndexedTokenKind> fallbackTokenKind,
                              const Value* resolvedSymbol = nullptr,
                              std::optional<IndexedDeclarationIdentity> declaration = std::nullopt,
-                             std::optional<llvm::SMRange> semanticHighlightSpan = std::nullopt)
-    -> void {
+                             std::optional<llvm::SMRange> semanticHighlightSpan = std::nullopt,
+                             Type* flowSensitiveType = nullptr) -> void {
   if (!span.isValid()) {
     return;
   }
@@ -147,6 +147,7 @@ auto appendIndexedOccurrence(AnalysisIndex& index, const std::string& name,
       .name = name,
       .dotBase = std::move(dotBase),
       .span = span,
+      .flowSensitiveType = flowSensitiveType,
       .semanticHighlightSpan = std::move(semanticHighlightSpan),
       .declaration = std::move(declaration),
       .isTypePosition = isTypePosition,
@@ -161,6 +162,9 @@ auto resolvedTypeForExpr(const Expression* expr) -> Type* {
     return nullptr;
   }
   if (auto const* lit = dynamic_cast<const Literal*>(expr)) {
+    if (lit->getLspFlowSensitiveType() != nullptr) {
+      return lit->getLspFlowSensitiveType();
+    }
     Value* const resolvedSymbol = lit->getResolvedSymbol();
     return resolvedSymbol != nullptr ? resolvedSymbol->getType() : nullptr;
   }
@@ -361,7 +365,8 @@ auto collectIndexFromExpr(const Expression* expr, AnalysisIndex& index) -> void 
                               0U,
                               indexedTokenKindFromResolvedSymbol(resolvedSymbol, false, false,
                                                                  IndexedTokenKind::Variable),
-                              resolvedSymbol);
+                              resolvedSymbol, std::nullopt, std::nullopt,
+                              lit->getLspFlowSensitiveType());
     }
     return;
   }

--- a/src/liblesma/Typecheck/AnalysisIndex.cpp
+++ b/src/liblesma/Typecheck/AnalysisIndex.cpp
@@ -320,7 +320,8 @@ auto collectIndexFromTypeExpr(const TypeExpr* typeExpr, AnalysisIndex& index) ->
     return;
   }
   if (typeExpr->getType() != TokenType::PTR_TYPE && typeExpr->getType() != TokenType::FUNC_TYPE &&
-      typeExpr->getType() != TokenType::TUPLE_TYPE) {
+      typeExpr->getType() != TokenType::TUPLE_TYPE &&
+      typeExpr->getType() != TokenType::UNION_TYPE) {
     Value* const resolvedSymbol = typeExpr->getResolvedSymbol();
     llvm::SMRange span = typeExpr->getSpan();
     std::string name = typeExpr->getName();

--- a/src/liblesma/Typecheck/AnalysisIndex.cpp
+++ b/src/liblesma/Typecheck/AnalysisIndex.cpp
@@ -60,7 +60,6 @@ auto indexedTokenKindFromDeclarationKind(ValueDeclarationKind declarationKind)
   case ValueDeclarationKind::ENUM_MEMBER:
     return IndexedTokenKind::EnumMember;
   case ValueDeclarationKind::TYPE:
-    return IndexedTokenKind::Type;
   case ValueDeclarationKind::TRAIT:
     return IndexedTokenKind::Type;
   case ValueDeclarationKind::TYPE_PARAMETER:
@@ -148,7 +147,7 @@ auto appendIndexedOccurrence(AnalysisIndex& index, const std::string& name,
       .dotBase = std::move(dotBase),
       .span = span,
       .flowSensitiveType = flowSensitiveType,
-      .semanticHighlightSpan = std::move(semanticHighlightSpan),
+      .semanticHighlightSpan = semanticHighlightSpan,
       .declaration = std::move(declaration),
       .isTypePosition = isTypePosition,
       .isMemberAccess = isMemberAccess,
@@ -332,8 +331,7 @@ auto collectIndexFromTypeExpr(const TypeExpr* typeExpr, AnalysisIndex& index) ->
     if (typeExpr->getType() == TokenType::LIST_TYPE) {
       name = "list";
       span = makeNameSpan(typeExpr->getStart(), name);
-    } else if (typeExpr->getType() == TokenType::CUSTOM_TYPE &&
-               !typeExpr->getTypeArgs().empty()) {
+    } else if (typeExpr->getType() == TokenType::CUSTOM_TYPE && !typeExpr->getTypeArgs().empty()) {
       // `dict<K,V>` / `Box<T>`: index only the constructor name so hover/definition match
       // `root->lookup("dict")`, not the full spelling `dict<...>`.
       name = typeExpr->getLookupName();
@@ -361,12 +359,11 @@ auto collectIndexFromExpr(const Expression* expr, AnalysisIndex& index) -> void 
   if (auto const* lit = dynamic_cast<const Literal*>(expr)) {
     if (lit->getType() == TokenType::IDENTIFIER) {
       Value* const resolvedSymbol = lit->getResolvedSymbol();
-      appendIndexedOccurrence(index, lit->getValue(), std::nullopt, lit->getSpan(), false, false,
-                              0U,
-                              indexedTokenKindFromResolvedSymbol(resolvedSymbol, false, false,
-                                                                 IndexedTokenKind::Variable),
-                              resolvedSymbol, std::nullopt, std::nullopt,
-                              lit->getLspFlowSensitiveType());
+      appendIndexedOccurrence(
+          index, lit->getValue(), std::nullopt, lit->getSpan(), false, false, 0U,
+          indexedTokenKindFromResolvedSymbol(resolvedSymbol, false, false,
+                                             IndexedTokenKind::Variable),
+          resolvedSymbol, std::nullopt, std::nullopt, lit->getLspFlowSensitiveType());
     }
     return;
   }

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -2923,7 +2923,10 @@ auto Typechecker::fillUnionNarrowingForIfBlock(
     if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
       return;
     }
-    Type* unionTy = sym->getType();
+    Type* unionTy = lookupUnionNarrowedType(sym);
+    if (unionTy == nullptr) {
+      unionTy = sym->getType();
+    }
     auto isUnionMember = [unionTy](Type* rhs) -> bool {
       if (rhs == nullptr) {
         return false;
@@ -2984,7 +2987,10 @@ auto Typechecker::fillUnionNarrowingForIfBlock(
   if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
     return;
   }
-  Type* unionTy = sym->getType();
+  Type* unionTy = lookupUnionNarrowedType(sym);
+  if (unionTy == nullptr) {
+    unionTy = sym->getType();
+  }
   auto isUnionMember = [unionTy](Type* rhs) -> bool {
     if (rhs == nullptr) {
       return false;

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -152,8 +152,7 @@ void insertGenericParamSymbols(SymbolTable* genericsScope,
 struct TypecheckImportActiveGuard {
   std::string key;
 
-  explicit TypecheckImportActiveGuard(std::string normalizedPath)
-      : key(std::move(normalizedPath)) {
+  explicit TypecheckImportActiveGuard(std::string normalizedPath) : key(std::move(normalizedPath)) {
     if (!typecheckingImportPathsInProgress().insert(key).second) {
       throw TypeCheckError(llvm::SMRange(), "Circular import detected: {}", key);
     }
@@ -2413,7 +2412,7 @@ void Typechecker::markValueRead(Value* sym) {
 }
 
 void Typechecker::markImportNameStubUsedForQualifiedAccess(const std::string& modulePath,
-                                                          const std::string& exportedName) {
+                                                           const std::string& exportedName) {
   if (declarationPass) {
     return;
   }
@@ -2753,6 +2752,37 @@ auto Typechecker::lookupUnionNarrowedType(Value* sym) const -> Type* {
   return nullptr;
 }
 
+void Typechecker::invalidateUnionNarrowingForSymbol(Value* sym) {
+  if (sym == nullptr) {
+    return;
+  }
+  for (auto& frame : unionNarrowingStack) {
+    frame.erase(sym);
+  }
+}
+
+auto Typechecker::rootStorageSymbolForAssignmentLhs(Expression* lhs) -> Value* {
+  if (lhs == nullptr) {
+    return nullptr;
+  }
+  if (auto const* lit = dynamic_cast<Literal*>(lhs)) {
+    if (lit->getType() != TokenType::IDENTIFIER) {
+      return nullptr;
+    }
+    if (Value* rs = lit->getResolvedSymbol()) {
+      return rs;
+    }
+    return scope->lookup(lit->getValue());
+  }
+  if (auto* dot = dynamic_cast<DotOp*>(lhs)) {
+    return rootStorageSymbolForAssignmentLhs(dot->getLeft());
+  }
+  if (auto* sub = dynamic_cast<SubscriptOp*>(lhs)) {
+    return rootStorageSymbolForAssignmentLhs(sub->getLeft());
+  }
+  return nullptr;
+}
+
 namespace {
 
 auto tryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> Value* {
@@ -2770,8 +2800,8 @@ auto tryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> Value* {
 }
 } // namespace
 
-auto Typechecker::narrowUnionByExcludingMembers(Type* unionTy,
-                                                const std::vector<Type*>& toExclude) -> Type* {
+auto Typechecker::narrowUnionByExcludingMembers(Type* unionTy, const std::vector<Type*>& toExclude)
+    -> Type* {
   if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION)) {
     return nullptr;
   }
@@ -2781,8 +2811,8 @@ auto Typechecker::narrowUnionByExcludingMembers(Type* unionTy,
     if (ex == nullptr) {
       continue;
     }
-    auto it = std::ranges::find_if(remainder,
-                                   [ex](Type* m) { return m != nullptr && m->isEqual(ex); });
+    auto it =
+        std::ranges::find_if(remainder, [ex](Type* m) { return m != nullptr && m->isEqual(ex); });
     if (it != remainder.end()) {
       remainder.erase(it);
       ++removed;
@@ -3128,7 +3158,8 @@ auto Typechecker::visit(const Import* node) -> void {
     }
   };
   if (node->getImportAll() && node->getImportScope() && getExports) {
-    ExportDiscoveryResult const discovery = getExports(node->getFilePath(), node->isStd(), mainFilePath);
+    ExportDiscoveryResult const discovery =
+        getExports(node->getFilePath(), node->isStd(), mainFilePath);
     if (!discovery.failureMessage.empty()) {
       std::string const msg = fmt::format("Import * failed: {}", discovery.failureMessage);
       if (warningDiagnostics == nullptr) {
@@ -3881,6 +3912,7 @@ auto Typechecker::visit(const Assignment* node) -> void {
                              rhsType->toString(), lhsType->toString());
       }
     }
+    invalidateUnionNarrowingForSymbol(sym);
     return;
   }
   if (dynamic_cast<DotOp*>(node->getLeftHandSide()) != nullptr) {
@@ -3928,6 +3960,7 @@ auto Typechecker::visit(const Assignment* node) -> void {
                              rhsType->toString(), targetType->toString());
       }
     }
+    invalidateUnionNarrowingForSymbol(rootStorageSymbolForAssignmentLhs(node->getLeftHandSide()));
     return;
   }
   if (auto* subscript = dynamic_cast<SubscriptOp*>(node->getLeftHandSide())) {
@@ -3966,6 +3999,7 @@ auto Typechecker::visit(const Assignment* node) -> void {
                                rhsType->toString(), lhsType->toString());
         }
       }
+      invalidateUnionNarrowingForSymbol(rootStorageSymbolForAssignmentLhs(node->getLeftHandSide()));
       return;
     }
 
@@ -3994,11 +4028,11 @@ auto Typechecker::visit(const Assignment* node) -> void {
         throw TypeCheckError(node->getSpan(), "Operator []= not found for assignment target");
       }
     }
+    invalidateUnionNarrowingForSymbol(rootStorageSymbolForAssignmentLhs(node->getLeftHandSide()));
     return;
   }
   throw TypeCheckError(node->getSpan(), "Invalid assignment target");
 }
-
 auto Typechecker::visit(const Break* node) -> void {
   (void) node;
   // We don't track break targets in typecheck; Codegen will enforce.
@@ -4574,7 +4608,8 @@ auto Typechecker::visit(const LambdaExpr* node) -> void {
     scope = genericsScope->getParent();
     currentGenericTypes = std::move(savedGenerics);
   }
-  if (!node->getGenericParamDecls().empty() && !lambdaSymbolPtr->getClosureCaptureOuters().empty()) {
+  if (!node->getGenericParamDecls().empty() &&
+      !lambdaSymbolPtr->getClosureCaptureOuters().empty()) {
     throw TypeCheckError(node->getSpan(),
                          "Generic lambdas that capture outer variables are not supported yet");
   }
@@ -5001,7 +5036,7 @@ auto Typechecker::visit(const DotOp* node) -> void {
       result = std::make_unique<Value>(retType);
       return;
     }
-      throw TypeCheckError(node->getSpan(), "Expected method call after dot on trait value");
+    throw TypeCheckError(node->getSpan(), "Expected method call after dot on trait value");
   }
   if (base->is(BaseType::TY_UNION)) {
     auto* fc = dynamic_cast<FuncCall*>(node->getRight());

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -5630,8 +5630,10 @@ auto Typechecker::visit(const Literal* node) -> void {
           markValueRead(sym);
           node->setResolvedSymbol(shadow);
           result = std::make_unique<Value>(*shadow);
+          node->setLspFlowSensitiveType(nullptr);
           if (Type* n = lookupUnionNarrowedType(shadow)) {
             result->setType(n);
+            node->setLspFlowSensitiveType(n);
           }
           break;
         }
@@ -5640,8 +5642,10 @@ auto Typechecker::visit(const Literal* node) -> void {
     node->setResolvedSymbol(sym);
     markValueRead(sym);
     result = std::make_unique<Value>(*sym);
+    node->setLspFlowSensitiveType(nullptr);
     if (Type* n = lookupUnionNarrowedType(sym)) {
       result->setType(n);
+      node->setLspFlowSensitiveType(n);
     }
     break;
   }

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -401,11 +401,11 @@ auto Typechecker::getOrCreateLambdaCaptureShadow(Value* outerSym, const std::str
   return raw;
 }
 
-auto Typechecker::resolveMethodReturnType(Type* baseType, const std::string& methodName,
-                                          const std::vector<Type*>& argTypes, llvm::SMRange span)
-    -> Type* {
+auto Typechecker::resolveMethodWithTraitEnv(Type* baseType, const std::string& methodName,
+                                            const std::vector<Type*>& argTypes, llvm::SMRange span)
+    -> ResolvedMethodCallInfo {
   if (baseType == nullptr) {
-    return nullptr;
+    return {};
   }
   Type* base = baseType;
   if (base->is(BaseType::TY_PTR) && base->getElementType() != nullptr) {
@@ -415,11 +415,11 @@ auto Typechecker::resolveMethodReturnType(Type* baseType, const std::string& met
     const std::string traitKey = traitExistentialBaseName(base->getDisplayName());
     auto trIt = traitMethodSignatures.find(traitKey);
     if (trIt == traitMethodSignatures.end()) {
-      return nullptr;
+      return {};
     }
     auto methIt = trIt->second.find(methodName);
     if (methIt == trIt->second.end() || methIt->second.empty()) {
-      return nullptr;
+      return {};
     }
     Type* selfType = base->is(BaseType::TY_PTR)
                          ? base
@@ -435,17 +435,17 @@ auto Typechecker::resolveMethodReturnType(Type* baseType, const std::string& met
     }
     Type* matched = selectBestFunctionTypeMatch(methIt->second, methodArgTypes);
     if (matched == nullptr) {
-      return nullptr;
+      return {};
     }
     Type* ret = matched->getReturnType();
     if (auto envIt = specializedTraitExistentialEnv.find(base);
         envIt != specializedTraitExistentialEnv.end() && ret != nullptr) {
       ret = substituteInType(ret, envIt->second);
     }
-    return ret;
+    return {ret, nullptr, {}};
   }
   if (!base->is(BaseType::TY_CLASS) && !base->is(BaseType::TY_ENUM)) {
-    return nullptr;
+    return {};
   }
 
   Type* receiverForLookup = base;
@@ -488,27 +488,51 @@ auto Typechecker::resolveMethodReturnType(Type* baseType, const std::string& met
     }
   }
   if (method == nullptr || !method->getType()->is(BaseType::TY_FUNCTION)) {
-    return nullptr;
+    return {};
   }
 
   enforcePrivateMemberReadable(span, method);
 
-  auto fields = method->getType()->getFields();
+  auto* methodType = method->getType();
+  auto fields = methodType->getFields();
   for (size_t i = 0; i < fields.size() && i < methodArgTypes.size(); ++i) {
     inferGenericBindings(fields[i]->type, methodArgTypes[i], methodTypeEnv, span);
   }
-  Type* retType = method->getType()->getReturnType();
+  Type* retType = methodType->getReturnType();
   if (!methodTypeEnv.empty() && retType != nullptr) {
     retType = substituteInType(retType, methodTypeEnv);
   }
+
+  std::unordered_map<std::string, Type*> traitBoundSubs = methodTypeEnv;
+  const auto& methodGenericNames = methodType->getGenericParams();
+  if (!methodGenericNames.empty()) {
+    std::unordered_map<std::string, Type*> extraInferred;
+    for (size_t i = 0; i < fields.size() && i < methodArgTypes.size(); ++i) {
+      inferGenericBindings(fields[i]->type, methodArgTypes[i], extraInferred, span);
+    }
+    for (const auto& kv : extraInferred) {
+      if (std::find(methodGenericNames.begin(), methodGenericNames.end(), kv.first) ==
+          methodGenericNames.end()) {
+        continue;
+      }
+      traitBoundSubs[kv.first] = kv.second;
+    }
+  }
+
   if (method->getDeclarationKind() == ValueDeclarationKind::METHOD ||
       method->getDeclarationKind() == ValueDeclarationKind::FUNCTION) {
     method->setUsed(true);
   }
   if (importedMethod && retType != nullptr) {
-    return materializeImportedType(retType);
+    retType = materializeImportedType(retType);
   }
-  return retType;
+  return {retType, method, std::move(traitBoundSubs)};
+}
+
+auto Typechecker::resolveMethodReturnType(Type* baseType, const std::string& methodName,
+                                          const std::vector<Type*>& argTypes, llvm::SMRange span)
+    -> Type* {
+  return resolveMethodWithTraitEnv(baseType, methodName, argTypes, span).returnType;
 }
 
 auto Typechecker::isMutableListReceiver(const Expression* expr) -> bool {
@@ -5144,26 +5168,30 @@ auto Typechecker::visit(const DotOp* node) -> void {
       argTypes.push_back(t);
     }
     Type* commonRet = nullptr;
+    Value* resolvedSymbol = nullptr;
     for (Type* mem : base->getUnionMembers()) {
       if (mem == nullptr || !mem->is(BaseType::TY_CLASS)) {
         throw TypeCheckError(node->getSpan(),
                              "Calling a method on a union requires every variant to be a class "
                              "type");
       }
-      Type* r = resolveMethodReturnType(mem, fc->getName(), argTypes, node->getSpan());
-      if (r == nullptr) {
+      ResolvedMethodCallInfo resolved =
+          resolveMethodWithTraitEnv(mem, fc->getName(), argTypes, node->getSpan());
+      if (resolved.returnType == nullptr) {
         throw TypeCheckError(node->getSpan(), "Method '{}' is not available on all union members",
                              fc->getName());
       }
+      verifyGenericTraitBounds(resolved.method, resolved.traitBoundSubs, node->getSpan());
       if (commonRet == nullptr) {
-        commonRet = r;
-      } else if (!commonRet->isEqual(r)) {
+        commonRet = resolved.returnType;
+      } else if (!commonRet->isEqual(resolved.returnType)) {
         throw TypeCheckError(node->getSpan(),
                              "Method '{}' has incompatible return types across union members",
                              fc->getName());
       }
+      resolvedSymbol = resolved.method;
     }
-    fc->setResolvedSymbol(nullptr);
+    fc->setResolvedSymbol(resolvedSymbol);
     result = std::make_unique<Value>(commonRet);
     return;
   }

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1310,8 +1310,15 @@ auto Typechecker::inferGenericBindings(Type* pattern, Type* actual,
         if (used[aj]) {
           continue;
         }
+        if (!pmem[fi]->isEqual(amem[aj])) {
+          continue;
+        }
         auto probe = acc;
-        inferGenericBindings(pmem[fi], amem[aj], probe, span);
+        try {
+          inferGenericBindings(pmem[fi], amem[aj], probe, span);
+        } catch (const TypeCheckError&) {
+          continue;
+        }
         used[aj] = true;
         if (self(self, fi + 1, probe)) {
           return true;

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -2754,21 +2754,6 @@ auto Typechecker::lookupUnionNarrowedType(Value* sym) const -> Type* {
 }
 
 namespace {
-auto unionComplementMember(Type* unionTy, Type* excluded) -> Type* {
-  if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION) || excluded == nullptr) {
-    return nullptr;
-  }
-  const auto& mem = unionTy->getUnionMembers();
-  if (mem.size() != 2U) {
-    return nullptr;
-  }
-  for (Type* m : mem) {
-    if (!m->isEqual(excluded)) {
-      return m;
-    }
-  }
-  return nullptr;
-}
 
 auto tryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> Value* {
   if (is == nullptr) {
@@ -2785,6 +2770,44 @@ auto tryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> Value* {
 }
 } // namespace
 
+auto Typechecker::narrowUnionByExcludingMembers(Type* unionTy,
+                                                const std::vector<Type*>& toExclude) -> Type* {
+  if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION)) {
+    return nullptr;
+  }
+  std::vector<Type*> remainder = unionTy->getUnionMembers();
+  unsigned removed = 0U;
+  for (Type* ex : toExclude) {
+    if (ex == nullptr) {
+      continue;
+    }
+    auto it = std::ranges::find_if(remainder,
+                                   [ex](Type* m) { return m != nullptr && m->isEqual(ex); });
+    if (it != remainder.end()) {
+      remainder.erase(it);
+      ++removed;
+    }
+  }
+  if (removed == 0U || remainder.empty()) {
+    return nullptr;
+  }
+  if (remainder.size() == 1U) {
+    return remainder.front();
+  }
+  std::ranges::sort(remainder, [](Type* a, Type* b) { return a->toString() < b->toString(); });
+  std::string displayName;
+  for (size_t i = 0; i < remainder.size(); ++i) {
+    if (i > 0U) {
+      displayName += " | ";
+    }
+    displayName += remainder[i]->toString();
+  }
+  auto u = std::make_unique<Type>(BaseType::TY_UNION);
+  u->setDisplayName(displayName);
+  u->setUnionMembers(std::move(remainder));
+  return cacheType(std::move(u));
+}
+
 auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockIndex,
                                                std::unordered_map<Value*, Type*>& out) -> void {
   if (blockIndex >= node->getBlocks().size()) {
@@ -2795,12 +2818,50 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
     if (blockIndex == 0) {
       return;
     }
-    auto* is0 = dynamic_cast<const IsOp*>(node->getConds()[0]);
+    const auto* is0 = dynamic_cast<const IsOp*>(node->getConds()[0]);
     if (is0 == nullptr) {
       return;
     }
     Value* sym = tryGetIsOpVarSymbol(is0, scope);
     if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
+      return;
+    }
+    Type* unionTy = sym->getType();
+    auto isUnionMember = [unionTy](Type* rhs) -> bool {
+      if (rhs == nullptr) {
+        return false;
+      }
+      for (Type* m : unionTy->getUnionMembers()) {
+        if (m->isEqual(rhs)) {
+          return true;
+        }
+      }
+      return false;
+    };
+    std::vector<Type*> excluded;
+    for (unsigned i = 0; i < blockIndex; ++i) {
+      const auto* isPrev = dynamic_cast<const IsOp*>(node->getConds()[i]);
+      if (isPrev == nullptr || isPrev->getOperator() != TokenType::IS) {
+        continue;
+      }
+      if (tryGetIsOpVarSymbol(isPrev, scope) != sym) {
+        continue;
+      }
+      Type* rhsPrev = nullptr;
+      try {
+        rhsPrev = resolveType(isPrev->getRight());
+      } catch (const TypeCheckError&) {
+        continue;
+      }
+      if (isUnionMember(rhsPrev)) {
+        excluded.push_back(rhsPrev);
+      }
+    }
+    if (!excluded.empty()) {
+      Type* narrowed = narrowUnionByExcludingMembers(unionTy, excluded);
+      if (narrowed != nullptr) {
+        out[sym] = narrowed;
+      }
       return;
     }
     Type* rhsTy = nullptr;
@@ -2809,17 +2870,12 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
     } catch (const TypeCheckError&) {
       return;
     }
-    if (is0->getOperator() == TokenType::IS) {
-      Type* narrowed = unionComplementMember(sym->getType(), rhsTy);
-      if (narrowed != nullptr) {
-        out[sym] = narrowed;
-      }
-    } else if (is0->getOperator() == TokenType::IS_NOT) {
+    if (is0->getOperator() == TokenType::IS_NOT && isUnionMember(rhsTy)) {
       out[sym] = rhsTy;
     }
     return;
   }
-  auto* is = dynamic_cast<const IsOp*>(cond);
+  const auto* is = dynamic_cast<const IsOp*>(cond);
   if (is == nullptr) {
     return;
   }
@@ -2827,6 +2883,18 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
   if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
     return;
   }
+  Type* unionTy = sym->getType();
+  auto isUnionMember = [unionTy](Type* rhs) -> bool {
+    if (rhs == nullptr) {
+      return false;
+    }
+    for (Type* m : unionTy->getUnionMembers()) {
+      if (m->isEqual(rhs)) {
+        return true;
+      }
+    }
+    return false;
+  };
   Type* rhsTy = nullptr;
   try {
     rhsTy = resolveType(is->getRight());
@@ -2834,20 +2902,37 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
     return;
   }
   if (is->getOperator() == TokenType::IS) {
-    bool member = false;
-    for (Type* m : sym->getType()->getUnionMembers()) {
-      if (m->isEqual(rhsTy)) {
-        member = true;
-        break;
-      }
-    }
-    if (member) {
+    if (isUnionMember(rhsTy)) {
       out[sym] = rhsTy;
     }
   } else if (is->getOperator() == TokenType::IS_NOT) {
-    Type* narrowed = unionComplementMember(sym->getType(), rhsTy);
-    if (narrowed != nullptr) {
-      out[sym] = narrowed;
+    std::vector<Type*> excluded;
+    for (unsigned i = 0; i < blockIndex; ++i) {
+      const auto* isPrev = dynamic_cast<const IsOp*>(node->getConds()[i]);
+      if (isPrev == nullptr || isPrev->getOperator() != TokenType::IS) {
+        continue;
+      }
+      if (tryGetIsOpVarSymbol(isPrev, scope) != sym) {
+        continue;
+      }
+      Type* rhsPrev = nullptr;
+      try {
+        rhsPrev = resolveType(isPrev->getRight());
+      } catch (const TypeCheckError&) {
+        continue;
+      }
+      if (isUnionMember(rhsPrev)) {
+        excluded.push_back(rhsPrev);
+      }
+    }
+    if (isUnionMember(rhsTy)) {
+      excluded.push_back(rhsTy);
+    }
+    if (!excluded.empty()) {
+      Type* narrowed = narrowUnionByExcludingMembers(unionTy, excluded);
+      if (narrowed != nullptr) {
+        out[sym] = narrowed;
+      }
     }
   }
 }

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1774,12 +1774,8 @@ auto Typechecker::isAssignableTo(Type* from, Type* to) -> bool {
       }
       return true;
     }
-    for (Type* m : to->getUnionMembers()) {
-      if (isAssignableTo(from, m)) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(to->getUnionMembers(),
+                               [this, from](Type* m) -> bool { return isAssignableTo(from, m); });
   }
   return false;
 }
@@ -2850,7 +2846,7 @@ auto tryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> Value* {
   if (is == nullptr) {
     return nullptr;
   }
-  auto* lit = dynamic_cast<const Literal*>(is->getLeft());
+  const auto* lit = dynamic_cast<const Literal*>(is->getLeft());
   if (lit == nullptr || lit->getType() != TokenType::IDENTIFIER) {
     return nullptr;
   }
@@ -2925,12 +2921,9 @@ auto Typechecker::fillUnionNarrowingForIfBlock(
       if (rhs == nullptr) {
         return false;
       }
-      for (Type* m : unionTy->getUnionMembers()) {
-        if (m->isEqual(rhs)) {
-          return true;
-        }
-      }
-      return false;
+
+      return std::ranges::any_of(unionTy->getUnionMembers(),
+                                 [rhs](Type* m) -> bool { return m->isEqual(rhs); });
     };
     std::vector<Type*> excluded;
     for (unsigned i = 0; i < blockIndex; ++i) {

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -5333,6 +5333,7 @@ auto Typechecker::visit(const IsOp* node) -> void {
   node->getLeft()->accept(*this);
   Type* lhsTy = result->getType();
   Type* rhsTy = resolveType(node->getRight());
+  node->setResolvedRhsType(rhsTy);
   if (lhsTy != nullptr && lhsTy->is(BaseType::TY_UNION)) {
     bool found = false;
     for (Type* m : lhsTy->getUnionMembers()) {

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1716,6 +1716,21 @@ auto Typechecker::isAssignableTo(Type* from, Type* to) -> bool {
     return true;
   }
   if (to->is(BaseType::TY_UNION)) {
+    if (from->is(BaseType::TY_UNION)) {
+      for (Type* fm : from->getUnionMembers()) {
+        bool memberOk = false;
+        for (Type* tm : to->getUnionMembers()) {
+          if (isAssignableTo(fm, tm)) {
+            memberOk = true;
+            break;
+          }
+        }
+        if (!memberOk) {
+          return false;
+        }
+      }
+      return true;
+    }
     for (Type* m : to->getUnionMembers()) {
       if (isAssignableTo(from, m)) {
         return true;
@@ -1900,11 +1915,19 @@ auto Typechecker::resolveType(const TypeExpr* node) -> Type* {
       }
     }
     for (Type* t : unique) {
-      if (!isSupportedUnionMemberType(t)) {
-        throw TypeCheckError(node->getSpan(),
-                             "Union member type `{}` is not supported (only int, float, float32, "
-                             "bool, and class variants are allowed)",
-                             t->toString());
+      if (t->is(BaseType::TY_ARRAY)) {
+        if (!isStdlibSourcePath(mainFilePath)) {
+          throw TypeCheckError(node->getSpan(),
+                               "`__buffer<…>` is not allowed as a union member outside the "
+                               "standard library (use `list<…>` or another class type instead)",
+                               t->toString());
+        }
+      } else if (!isSupportedUnionMemberType(t)) {
+        throw TypeCheckError(
+            node->getSpan(),
+            "Union member type `{}` is not supported (allowed: int, float, float32, bool, and "
+            "class types — e.g. str, list<U>, or your own classes)",
+            t->toString());
       }
     }
     std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1169,22 +1169,48 @@ auto Typechecker::substituteInType(Type* t, const std::unordered_map<std::string
     return cacheType(std::move(tupleType));
   }
   if (t->is(BaseType::TY_UNION)) {
-    std::vector<Type*> members;
-    members.reserve(t->getUnionMembers().size());
+    std::vector<Type*> flat;
+    flat.reserve(t->getUnionMembers().size());
+    auto appendFlattened = [&](Type* cur, auto&& self) -> void {
+      if (cur == nullptr) {
+        return;
+      }
+      if (cur->is(BaseType::TY_UNION)) {
+        for (Type* inner : cur->getUnionMembers()) {
+          self(inner, self);
+        }
+      } else {
+        flat.push_back(cur);
+      }
+    };
     for (Type* m : t->getUnionMembers()) {
-      members.push_back(substituteInType(m, env));
+      Type* substituted = substituteInType(m, env);
+      appendFlattened(substituted, appendFlattened);
     }
-    std::ranges::sort(members, [](Type* a, Type* b) { return a->toString() < b->toString(); });
+    std::vector<Type*> unique;
+    for (Type* arm : flat) {
+      bool dup = false;
+      for (Type* u : unique) {
+        if (arm->isEqual(u)) {
+          dup = true;
+          break;
+        }
+      }
+      if (!dup) {
+        unique.push_back(arm);
+      }
+    }
+    std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
     std::string dn;
-    for (size_t i = 0; i < members.size(); ++i) {
+    for (size_t i = 0; i < unique.size(); ++i) {
       if (i > 0) {
         dn += " | ";
       }
-      dn += members[i]->toString();
+      dn += unique[i]->toString();
     }
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
     u->setDisplayName(dn);
-    u->setUnionMembers(std::move(members));
+    u->setUnionMembers(std::move(unique));
     return cacheType(std::move(u));
   }
   if (t->is(BaseType::TY_CLASS)) {

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1283,6 +1283,48 @@ auto Typechecker::inferGenericBindings(Type* pattern, Type* actual,
     }
     return;
   }
+  if (pattern->is(BaseType::TY_UNION) && actual->is(BaseType::TY_UNION)) {
+    const auto& pmem = pattern->getUnionMembers();
+    const auto& amem = actual->getUnionMembers();
+    if (pmem.size() != amem.size()) {
+      return;
+    }
+    std::vector<bool> used(amem.size(), false);
+    std::unordered_map<std::string, Type*> const emptyAcc;
+    auto tryInfer = [&](auto&& self, size_t fi,
+                        const std::unordered_map<std::string, Type*>& acc) -> bool {
+      if (fi == pmem.size()) {
+        for (const auto& kv : acc) {
+          auto it = bindings.find(kv.first);
+          if (it == bindings.end()) {
+            bindings[kv.first] = kv.second;
+          } else if (!it->second->isEqual(kv.second)) {
+            throw TypeCheckError(span,
+                                 "Conflicting inferred types for generic parameter {}: {} and {}",
+                                 kv.first, it->second->toString(), kv.second->toString());
+          }
+        }
+        return true;
+      }
+      for (size_t aj = 0; aj < amem.size(); ++aj) {
+        if (used[aj]) {
+          continue;
+        }
+        auto probe = acc;
+        inferGenericBindings(pmem[fi], amem[aj], probe, span);
+        used[aj] = true;
+        if (self(self, fi + 1, probe)) {
+          return true;
+        }
+        used[aj] = false;
+      }
+      return false;
+    };
+    if (!tryInfer(tryInfer, 0, emptyAcc)) {
+      return;
+    }
+    return;
+  }
   if (pattern->getBaseType() != actual->getBaseType()) {
     return;
   }
@@ -1922,6 +1964,14 @@ auto Typechecker::resolveType(const TypeExpr* node) -> Type* {
                                "`__buffer<…>` is not allowed as a union member outside the "
                                "standard library (use `list<…>` or another class type instead)",
                                t->toString());
+        }
+      } else if (t->is(BaseType::TY_GENERIC)) {
+        if (!currentGenericTypes.contains(t->getGenericName())) {
+          throw TypeCheckError(
+              node->getSpan(),
+              "Union member `{}` is not a class or primitive; only type parameters of the "
+              "enclosing generic declaration may appear here",
+              t->toString());
         }
       } else if (!isSupportedUnionMemberType(t)) {
         throw TypeCheckError(

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1224,6 +1224,11 @@ auto Typechecker::substituteInType(Type* t, const std::unordered_map<std::string
         unique.push_back(arm);
       }
     }
+    // Match Codegen::substituteTypeForSpecializationEnv: a single arm is the arm type itself, not a
+    // tagged singleton union (avoids reintroducing union layout after specialization).
+    if (unique.size() == 1U) {
+      return unique.front();
+    }
     std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
     std::string dn;
     for (size_t i = 0; i < unique.size(); ++i) {

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -2796,8 +2796,12 @@ auto Typechecker::lookupUnionNarrowedType(Value* sym) const -> Type* {
   if (sym == nullptr) {
     return nullptr;
   }
+  const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+  if (!key.declarationSpan.isValid() && key.fallbackAnchor == nullptr) {
+    return nullptr;
+  }
   for (auto it = unionNarrowingStack.rbegin(); it != unionNarrowingStack.rend(); ++it) {
-    auto j = it->find(sym);
+    auto j = it->find(key);
     if (j != it->end()) {
       return j->second;
     }
@@ -2809,8 +2813,12 @@ void Typechecker::invalidateUnionNarrowingForSymbol(Value* sym) {
   if (sym == nullptr) {
     return;
   }
+  const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+  if (!key.declarationSpan.isValid() && key.fallbackAnchor == nullptr) {
+    return;
+  }
   for (auto& frame : unionNarrowingStack) {
-    frame.erase(sym);
+    frame.erase(key);
   }
 }
 
@@ -2892,8 +2900,10 @@ auto Typechecker::narrowUnionByExcludingMembers(Type* unionTy, const std::vector
   return cacheType(std::move(u));
 }
 
-auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockIndex,
-                                               std::unordered_map<Value*, Type*>& out) -> void {
+auto Typechecker::fillUnionNarrowingForIfBlock(
+    const If* node, unsigned blockIndex,
+    std::unordered_map<UnionNarrowingStableKey, Type*, UnionNarrowingStableKeyHash,
+                       UnionNarrowingStableKeyEq>& out) -> void {
   if (blockIndex >= node->getBlocks().size()) {
     return;
   }
@@ -2928,7 +2938,8 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
       if (isPrev == nullptr || isPrev->getOperator() != TokenType::IS) {
         continue;
       }
-      if (tryGetIsOpVarSymbol(isPrev, scope) != sym) {
+      if (unionNarrowingStableKeyForSymbol(tryGetIsOpVarSymbol(isPrev, scope)) !=
+          unionNarrowingStableKeyForSymbol(sym)) {
         continue;
       }
       Type* rhsPrev = nullptr;
@@ -2944,7 +2955,10 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
     if (!excluded.empty()) {
       Type* narrowed = narrowUnionByExcludingMembers(unionTy, excluded);
       if (narrowed != nullptr) {
-        out[sym] = narrowed;
+        const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+        if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+          out[key] = narrowed;
+        }
       }
       return;
     }
@@ -2955,7 +2969,10 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
       return;
     }
     if (is0->getOperator() == TokenType::IS_NOT && isUnionMember(rhsTy)) {
-      out[sym] = rhsTy;
+      const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+      if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+        out[key] = rhsTy;
+      }
     }
     return;
   }
@@ -2987,7 +3004,10 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
   }
   if (is->getOperator() == TokenType::IS) {
     if (isUnionMember(rhsTy)) {
-      out[sym] = rhsTy;
+      const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+      if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+        out[key] = rhsTy;
+      }
     }
   } else if (is->getOperator() == TokenType::IS_NOT) {
     std::vector<Type*> excluded;
@@ -2996,7 +3016,8 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
       if (isPrev == nullptr || isPrev->getOperator() != TokenType::IS) {
         continue;
       }
-      if (tryGetIsOpVarSymbol(isPrev, scope) != sym) {
+      if (unionNarrowingStableKeyForSymbol(tryGetIsOpVarSymbol(isPrev, scope)) !=
+          unionNarrowingStableKeyForSymbol(sym)) {
         continue;
       }
       Type* rhsPrev = nullptr;
@@ -3015,7 +3036,10 @@ auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockInd
     if (!excluded.empty()) {
       Type* narrowed = narrowUnionByExcludingMembers(unionTy, excluded);
       if (narrowed != nullptr) {
-        out[sym] = narrowed;
+        const UnionNarrowingStableKey key = unionNarrowingStableKeyForSymbol(sym);
+        if (key.declarationSpan.isValid() || key.fallbackAnchor != nullptr) {
+          out[key] = narrowed;
+        }
       }
     }
   }
@@ -3037,7 +3061,9 @@ auto Typechecker::visit(const If* node) -> void {
   }
   std::vector<Compound*> const blocks = node->getBlocks();
   for (unsigned bi = 0; bi < blocks.size(); ++bi) {
-    std::unordered_map<Value*, Type*> narrowMap;
+    std::unordered_map<UnionNarrowingStableKey, Type*, UnionNarrowingStableKeyHash,
+                       UnionNarrowingStableKeyEq>
+        narrowMap;
     fillUnionNarrowingForIfBlock(node, bi, narrowMap);
     bool const pushedNarrowing = !narrowMap.empty();
     if (pushedNarrowing) {

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1042,6 +1042,19 @@ auto Typechecker::materializeImportedType(Type* type) -> Type* {
     importedTypeCopies[type] = copy;
     return copy;
   }
+  if (type->is(BaseType::TY_UNION)) {
+    std::vector<Type*> members;
+    members.reserve(type->getUnionMembers().size());
+    for (Type* m : type->getUnionMembers()) {
+      members.push_back(materializeImportedType(m));
+    }
+    auto u = std::make_unique<Type>(BaseType::TY_UNION);
+    u->setDisplayName(type->getDisplayName());
+    u->setUnionMembers(std::move(members));
+    Type* copy = cacheType(std::move(u));
+    importedTypeCopies[type] = copy;
+    return copy;
+  }
   if (type->is(BaseType::TY_TUPLE)) {
     std::vector<std::unique_ptr<Field>> fields;
     for (Field* field : type->getFields()) {
@@ -1154,6 +1167,25 @@ auto Typechecker::substituteInType(Type* t, const std::unordered_map<std::string
     auto tupleType = std::make_unique<Type>(BaseType::TY_TUPLE, nullptr, std::move(fields));
     tupleType->setDisplayName(t->getDisplayName());
     return cacheType(std::move(tupleType));
+  }
+  if (t->is(BaseType::TY_UNION)) {
+    std::vector<Type*> members;
+    members.reserve(t->getUnionMembers().size());
+    for (Type* m : t->getUnionMembers()) {
+      members.push_back(substituteInType(m, env));
+    }
+    std::ranges::sort(members, [](Type* a, Type* b) { return a->toString() < b->toString(); });
+    std::string dn;
+    for (size_t i = 0; i < members.size(); ++i) {
+      if (i > 0) {
+        dn += " | ";
+      }
+      dn += members[i]->toString();
+    }
+    auto u = std::make_unique<Type>(BaseType::TY_UNION);
+    u->setDisplayName(dn);
+    u->setUnionMembers(std::move(members));
+    return cacheType(std::move(u));
   }
   if (t->is(BaseType::TY_CLASS)) {
     Type* classTemplate = t;
@@ -1657,6 +1689,14 @@ auto Typechecker::isAssignableTo(Type* from, Type* to) -> bool {
     }
     return true;
   }
+  if (to->is(BaseType::TY_UNION)) {
+    for (Type* m : to->getUnionMembers()) {
+      if (isAssignableTo(from, m)) {
+        return true;
+      }
+    }
+    return false;
+  }
   return false;
 }
 
@@ -1807,6 +1847,52 @@ auto Typechecker::resolveType(const TypeExpr* node) -> Type* {
     auto tup = std::make_unique<Type>(BaseType::TY_TUPLE, nullptr, std::move(fields));
     tup->setDisplayName(displayName);
     return cacheType(std::move(tup));
+  }
+  if (node->getType() == TokenType::UNION_TYPE) {
+    std::vector<Type*> flat;
+    for (TypeExpr* arm : node->getParams()) {
+      Type* t = resolveType(arm);
+      if (t->is(BaseType::TY_UNION)) {
+        for (Type* inner : t->getUnionMembers()) {
+          flat.push_back(inner);
+        }
+      } else {
+        flat.push_back(t);
+      }
+    }
+    std::vector<Type*> unique;
+    for (Type* t : flat) {
+      bool dup = false;
+      for (Type* u : unique) {
+        if (t->isEqual(u)) {
+          dup = true;
+          break;
+        }
+      }
+      if (!dup) {
+        unique.push_back(t);
+      }
+    }
+    for (Type* t : unique) {
+      if (!isSupportedUnionMemberType(t)) {
+        throw TypeCheckError(node->getSpan(),
+                             "Union member type `{}` is not supported (only int, float, float32, "
+                             "bool, and class variants are allowed)",
+                             t->toString());
+      }
+    }
+    std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
+    std::string displayName;
+    for (size_t i = 0; i < unique.size(); ++i) {
+      if (i > 0) {
+        displayName += " | ";
+      }
+      displayName += unique[i]->toString();
+    }
+    auto u = std::make_unique<Type>(BaseType::TY_UNION);
+    u->setUnionMembers(std::move(unique));
+    u->setDisplayName(displayName);
+    return cacheType(std::move(u));
   }
   if (node->getType() == TokenType::CUSTOM_TYPE) {
     const std::string lookupName = node->getLookupName();
@@ -2597,6 +2683,126 @@ auto Typechecker::visit(const VarDecl* node) -> void {
   scope->insertSymbol(std::move(symbol));
 }
 
+auto Typechecker::isSupportedUnionMemberType(Type* t) -> bool {
+  if (t == nullptr) {
+    return false;
+  }
+  return t->is(BaseType::TY_INT) || t->isFloatingPoint() || t->is(BaseType::TY_BOOL) ||
+         t->is(BaseType::TY_CLASS);
+}
+
+auto Typechecker::lookupUnionNarrowedType(Value* sym) const -> Type* {
+  if (sym == nullptr) {
+    return nullptr;
+  }
+  for (auto it = unionNarrowingStack.rbegin(); it != unionNarrowingStack.rend(); ++it) {
+    auto j = it->find(sym);
+    if (j != it->end()) {
+      return j->second;
+    }
+  }
+  return nullptr;
+}
+
+namespace {
+auto unionComplementMember(Type* unionTy, Type* excluded) -> Type* {
+  if (unionTy == nullptr || !unionTy->is(BaseType::TY_UNION) || excluded == nullptr) {
+    return nullptr;
+  }
+  const auto& mem = unionTy->getUnionMembers();
+  if (mem.size() != 2U) {
+    return nullptr;
+  }
+  for (Type* m : mem) {
+    if (!m->isEqual(excluded)) {
+      return m;
+    }
+  }
+  return nullptr;
+}
+
+auto tryGetIsOpVarSymbol(const IsOp* is, SymbolTable* scope) -> Value* {
+  if (is == nullptr) {
+    return nullptr;
+  }
+  auto* lit = dynamic_cast<const Literal*>(is->getLeft());
+  if (lit == nullptr || lit->getType() != TokenType::IDENTIFIER) {
+    return nullptr;
+  }
+  if (Value* rs = lit->getResolvedSymbol()) {
+    return rs;
+  }
+  return scope->lookup(lit->getValue());
+}
+} // namespace
+
+auto Typechecker::fillUnionNarrowingForIfBlock(const If* node, unsigned blockIndex,
+                                               std::unordered_map<Value*, Type*>& out) -> void {
+  if (blockIndex >= node->getBlocks().size()) {
+    return;
+  }
+  Expression* cond = node->getConds()[blockIndex];
+  if (dynamic_cast<const Else*>(cond) != nullptr) {
+    if (blockIndex == 0) {
+      return;
+    }
+    auto* is0 = dynamic_cast<const IsOp*>(node->getConds()[0]);
+    if (is0 == nullptr) {
+      return;
+    }
+    Value* sym = tryGetIsOpVarSymbol(is0, scope);
+    if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
+      return;
+    }
+    Type* rhsTy = nullptr;
+    try {
+      rhsTy = resolveType(is0->getRight());
+    } catch (const TypeCheckError&) {
+      return;
+    }
+    if (is0->getOperator() == TokenType::IS) {
+      Type* narrowed = unionComplementMember(sym->getType(), rhsTy);
+      if (narrowed != nullptr) {
+        out[sym] = narrowed;
+      }
+    } else if (is0->getOperator() == TokenType::IS_NOT) {
+      out[sym] = rhsTy;
+    }
+    return;
+  }
+  auto* is = dynamic_cast<const IsOp*>(cond);
+  if (is == nullptr) {
+    return;
+  }
+  Value* sym = tryGetIsOpVarSymbol(is, scope);
+  if (sym == nullptr || sym->getType() == nullptr || !sym->getType()->is(BaseType::TY_UNION)) {
+    return;
+  }
+  Type* rhsTy = nullptr;
+  try {
+    rhsTy = resolveType(is->getRight());
+  } catch (const TypeCheckError&) {
+    return;
+  }
+  if (is->getOperator() == TokenType::IS) {
+    bool member = false;
+    for (Type* m : sym->getType()->getUnionMembers()) {
+      if (m->isEqual(rhsTy)) {
+        member = true;
+        break;
+      }
+    }
+    if (member) {
+      out[sym] = rhsTy;
+    }
+  } else if (is->getOperator() == TokenType::IS_NOT) {
+    Type* narrowed = unionComplementMember(sym->getType(), rhsTy);
+    if (narrowed != nullptr) {
+      out[sym] = narrowed;
+    }
+  }
+}
+
 auto Typechecker::visit(const If* node) -> void {
   for (Expression* cond : node->getConds()) {
     try {
@@ -2611,12 +2817,22 @@ auto Typechecker::visit(const If* node) -> void {
       recoverFromTypeError(err);
     }
   }
-  for (Compound* block : node->getBlocks()) {
+  std::vector<Compound*> const blocks = node->getBlocks();
+  for (unsigned bi = 0; bi < blocks.size(); ++bi) {
+    std::unordered_map<Value*, Type*> narrowMap;
+    fillUnionNarrowingForIfBlock(node, bi, narrowMap);
+    bool const pushedNarrowing = !narrowMap.empty();
+    if (pushedNarrowing) {
+      unionNarrowingStack.push_back(std::move(narrowMap));
+    }
     try {
-      warnIfEmptyCompoundBody(block, "if/else branch");
-      block->accept(*this);
+      warnIfEmptyCompoundBody(blocks[bi], "if/else branch");
+      blocks[bi]->accept(*this);
     } catch (const TypeCheckError& err) {
       recoverFromTypeError(err);
+    }
+    if (pushedNarrowing) {
+      unionNarrowingStack.pop_back();
     }
   }
 }
@@ -4651,7 +4867,50 @@ auto Typechecker::visit(const DotOp* node) -> void {
       result = std::make_unique<Value>(retType);
       return;
     }
-    throw TypeCheckError(node->getSpan(), "Expected method call after dot on trait value");
+      throw TypeCheckError(node->getSpan(), "Expected method call after dot on trait value");
+  }
+  if (base->is(BaseType::TY_UNION)) {
+    auto* fc = dynamic_cast<FuncCall*>(node->getRight());
+    if (fc == nullptr) {
+      throw TypeCheckError(node->getSpan(),
+                           "Dot on a union requires a method call (fields are not supported)");
+    }
+    if (!fc->getExplicitTypeArgs().empty()) {
+      throw TypeCheckError(node->getSpan(),
+                           "Explicit type arguments are not supported on union method calls");
+    }
+    std::vector<Type*> argTypes;
+    for (Expression* arg : fc->getArguments()) {
+      arg->accept(*this);
+      Type* t = result->getType();
+      if (t != nullptr && t->is(BaseType::TY_CLASS)) {
+        t = cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, t));
+      }
+      argTypes.push_back(t);
+    }
+    Type* commonRet = nullptr;
+    for (Type* mem : base->getUnionMembers()) {
+      if (mem == nullptr || !mem->is(BaseType::TY_CLASS)) {
+        throw TypeCheckError(node->getSpan(),
+                             "Calling a method on a union requires every variant to be a class "
+                             "type");
+      }
+      Type* r = resolveMethodReturnType(mem, fc->getName(), argTypes, node->getSpan());
+      if (r == nullptr) {
+        throw TypeCheckError(node->getSpan(), "Method '{}' is not available on all union members",
+                             fc->getName());
+      }
+      if (commonRet == nullptr) {
+        commonRet = r;
+      } else if (!commonRet->isEqual(r)) {
+        throw TypeCheckError(node->getSpan(),
+                             "Method '{}' has incompatible return types across union members",
+                             fc->getName());
+      }
+    }
+    fc->setResolvedSymbol(nullptr);
+    result = std::make_unique<Value>(commonRet);
+    return;
   }
   if (base->is(BaseType::TY_ARRAY)) {
     if (auto* call = dynamic_cast<FuncCall*>(node->getRight())) {
@@ -4849,7 +5108,21 @@ auto Typechecker::visit(const CastOp* node) -> void {
 
 auto Typechecker::visit(const IsOp* node) -> void {
   node->getLeft()->accept(*this);
-  node->getRight()->accept(*this);
+  Type* lhsTy = result->getType();
+  Type* rhsTy = resolveType(node->getRight());
+  if (lhsTy != nullptr && lhsTy->is(BaseType::TY_UNION)) {
+    bool found = false;
+    for (Type* m : lhsTy->getUnionMembers()) {
+      if (m->isEqual(rhsTy)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      throw TypeCheckError(node->getSpan(), "`is` type {} is not a member of union {}",
+                           rhsTy->toString(), lhsTy->toString());
+    }
+  }
   result = std::make_unique<Value>(cacheType(std::make_unique<Type>(BaseType::TY_BOOL)));
 }
 
@@ -5357,6 +5630,9 @@ auto Typechecker::visit(const Literal* node) -> void {
           markValueRead(sym);
           node->setResolvedSymbol(shadow);
           result = std::make_unique<Value>(*shadow);
+          if (Type* n = lookupUnionNarrowedType(shadow)) {
+            result->setType(n);
+          }
           break;
         }
       }
@@ -5364,6 +5640,9 @@ auto Typechecker::visit(const Literal* node) -> void {
     node->setResolvedSymbol(sym);
     markValueRead(sym);
     result = std::make_unique<Value>(*sym);
+    if (Type* n = lookupUnionNarrowedType(sym)) {
+      result->setType(n);
+    }
     break;
   }
   default:

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -3019,12 +3019,8 @@ auto Typechecker::fillUnionNarrowingForIfBlock(
     if (rhs == nullptr) {
       return false;
     }
-    for (Type* m : unionTy->getUnionMembers()) {
-      if (m->isEqual(rhs)) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(unionTy->getUnionMembers(),
+                               [rhs](Type* m) -> bool { return m->isEqual(rhs); });
   };
   Type* rhsTy = nullptr;
   try {

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1050,6 +1050,7 @@ auto Typechecker::materializeImportedType(Type* type) -> Type* {
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
     u->setDisplayName(type->getDisplayName());
     u->setUnionMembers(std::move(members));
+    u->setDeclarationSpan(type->getDeclarationSpan());
     Type* copy = cacheType(std::move(u));
     importedTypeCopies[type] = copy;
     return copy;
@@ -1210,6 +1211,7 @@ auto Typechecker::substituteInType(Type* t, const std::unordered_map<std::string
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
     u->setDisplayName(dn);
     u->setUnionMembers(std::move(unique));
+    u->setDeclarationSpan(t->getDeclarationSpan());
     return cacheType(std::move(u));
   }
   if (t->is(BaseType::TY_CLASS)) {
@@ -1940,6 +1942,7 @@ auto Typechecker::resolveType(const TypeExpr* node) -> Type* {
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
     u->setUnionMembers(std::move(unique));
     u->setDisplayName(displayName);
+    u->setDeclarationSpan(node->getSpan());
     return cacheType(std::move(u));
   }
   if (node->getType() == TokenType::CUSTOM_TYPE) {
@@ -2835,6 +2838,7 @@ auto Typechecker::narrowUnionByExcludingMembers(Type* unionTy, const std::vector
   auto u = std::make_unique<Type>(BaseType::TY_UNION);
   u->setDisplayName(displayName);
   u->setUnionMembers(std::move(remainder));
+  u->setDeclarationSpan(unionTy->getDeclarationSpan());
   return cacheType(std::move(u));
 }
 

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1071,9 +1071,15 @@ auto Typechecker::materializeImportedType(Type* type) -> Type* {
     for (Type* m : type->getUnionMembers()) {
       members.push_back(materializeImportedType(m));
     }
+    auto [canonical, displayName] = TypeUtils::canonicalizeUnionMembers(std::move(members));
+    if (canonical.size() == 1U) {
+      Type* single = canonical.front();
+      importedTypeCopies[type] = single;
+      return single;
+    }
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
-    u->setDisplayName(type->getDisplayName());
-    u->setUnionMembers(std::move(members));
+    u->setUnionMembers(std::move(canonical));
+    u->setDisplayName(displayName);
     u->setDeclarationSpan(type->getDeclarationSpan());
     Type* copy = cacheType(std::move(u));
     importedTypeCopies[type] = copy;
@@ -1193,49 +1199,16 @@ auto Typechecker::substituteInType(Type* t, const std::unordered_map<std::string
     return cacheType(std::move(tupleType));
   }
   if (t->is(BaseType::TY_UNION)) {
-    std::vector<Type*> flat;
-    flat.reserve(t->getUnionMembers().size());
-    auto appendFlattened = [&](Type* cur, auto&& self) -> void {
-      if (cur == nullptr) {
-        return;
-      }
-      if (cur->is(BaseType::TY_UNION)) {
-        for (Type* inner : cur->getUnionMembers()) {
-          self(inner, self);
-        }
-      } else {
-        flat.push_back(cur);
-      }
-    };
+    std::vector<Type*> arms;
+    arms.reserve(t->getUnionMembers().size());
     for (Type* m : t->getUnionMembers()) {
-      Type* substituted = substituteInType(m, env);
-      appendFlattened(substituted, appendFlattened);
+      arms.push_back(substituteInType(m, env));
     }
-    std::vector<Type*> unique;
-    for (Type* arm : flat) {
-      bool dup = false;
-      for (Type* u : unique) {
-        if (arm->isEqual(u)) {
-          dup = true;
-          break;
-        }
-      }
-      if (!dup) {
-        unique.push_back(arm);
-      }
-    }
+    auto [unique, dn] = TypeUtils::canonicalizeUnionMembers(std::move(arms));
     // Match Codegen::substituteTypeForSpecializationEnv: a single arm is the arm type itself, not a
     // tagged singleton union (avoids reintroducing union layout after specialization).
     if (unique.size() == 1U) {
       return unique.front();
-    }
-    std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
-    std::string dn;
-    for (size_t i = 0; i < unique.size(); ++i) {
-      if (i > 0) {
-        dn += " | ";
-      }
-      dn += unique[i]->toString();
     }
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
     u->setDisplayName(dn);
@@ -2013,16 +1986,9 @@ auto Typechecker::resolveType(const TypeExpr* node) -> Type* {
             t->toString());
       }
     }
-    std::ranges::sort(unique, [](Type* a, Type* b) { return a->toString() < b->toString(); });
-    std::string displayName;
-    for (size_t i = 0; i < unique.size(); ++i) {
-      if (i > 0) {
-        displayName += " | ";
-      }
-      displayName += unique[i]->toString();
-    }
+    auto [canonicalMembers, displayName] = TypeUtils::canonicalizeUnionMembers(std::move(unique));
     auto u = std::make_unique<Type>(BaseType::TY_UNION);
-    u->setUnionMembers(std::move(unique));
+    u->setUnionMembers(std::move(canonicalMembers));
     u->setDisplayName(displayName);
     u->setDeclarationSpan(node->getSpan());
     return cacheType(std::move(u));
@@ -2914,20 +2880,16 @@ auto Typechecker::narrowUnionByExcludingMembers(Type* unionTy, const std::vector
   if (removed == 0U || remainder.empty()) {
     return nullptr;
   }
-  if (remainder.size() == 1U) {
-    return remainder.front();
+  auto [canonical, displayName] = TypeUtils::canonicalizeUnionMembers(std::move(remainder));
+  if (canonical.size() == 1U) {
+    return canonical.front();
   }
-  std::ranges::sort(remainder, [](Type* a, Type* b) { return a->toString() < b->toString(); });
-  std::string displayName;
-  for (size_t i = 0; i < remainder.size(); ++i) {
-    if (i > 0U) {
-      displayName += " | ";
-    }
-    displayName += remainder[i]->toString();
+  if (canonical.empty()) {
+    return nullptr;
   }
   auto u = std::make_unique<Type>(BaseType::TY_UNION);
   u->setDisplayName(displayName);
-  u->setUnionMembers(std::move(remainder));
+  u->setUnionMembers(std::move(canonical));
   u->setDeclarationSpan(unionTy->getDeclarationSpan());
   return cacheType(std::move(u));
 }

--- a/src/liblesma/Typecheck/Typechecker.h
+++ b/src/liblesma/Typecheck/Typechecker.h
@@ -83,6 +83,8 @@ class Typechecker final : public ASTVisitor {
   /** Imported types materialized into this typechecker's cache so they outlive imported scopes. */
   std::unordered_map<Type*, Type*> importedTypeCopies;
   std::vector<Type*> expectedTypes;
+  /** Per `if` branch: symbol → narrowed type when discriminating a union with `is` / `is not`. */
+  std::vector<std::unordered_map<Value*, Type*>> unionNarrowingStack;
 
   /** Registered traits (name → AST) for impl checks and existential method lookup. */
   std::unordered_map<std::string, const TraitDecl*> traitRegistry;
@@ -190,6 +192,10 @@ class Typechecker final : public ASTVisitor {
   auto getExtendedType(Type* left, Type* right) -> Type*;
   /** Whether a value of type 'from' can be assigned/cast to type 'to'. */
   auto isAssignableTo(Type* from, Type* to) -> bool;
+  [[nodiscard]] static auto isSupportedUnionMemberType(Type* t) -> bool;
+  [[nodiscard]] auto lookupUnionNarrowedType(Value* sym) const -> Type*;
+  auto fillUnionNarrowingForIfBlock(const If* node, unsigned blockIndex,
+                                    std::unordered_map<Value*, Type*>& out) -> void;
   [[nodiscard]] auto functionTypesMatchForTraitImpl(Type* actualFn, Type* expectedFn) -> bool;
   [[nodiscard]] auto wrapReturnTypeIfNominal(Type* returnType) -> Type*;
   /** Result type of a binary operator (arithmetic, comparison, logical). Throws on unsupported op.

--- a/src/liblesma/Typecheck/Typechecker.h
+++ b/src/liblesma/Typecheck/Typechecker.h
@@ -29,6 +29,13 @@ class TypeCheckError;
 using GetExportsFn =
     std::function<ExportDiscoveryResult(const std::string&, bool, const std::string&)>;
 
+/** Concrete return type plus callee and substitution map for generic trait bound checks. */
+struct ResolvedMethodCallInfo {
+  Type* returnType = nullptr;
+  Value* method = nullptr;
+  std::unordered_map<std::string, Type*> traitBoundSubs;
+};
+
 /**
  * Semantic typecheck pass. Runs after parsing, before codegen.
  * Resolves types (without LLVM), builds symbol table, and checks:
@@ -217,6 +224,9 @@ class Typechecker final : public ASTVisitor {
       -> Type*;
   auto visitExprWithExpectedType(const Expression* node, Type* expected) -> void;
   [[nodiscard]] auto currentExpectedType() const -> Type*;
+  [[nodiscard]] auto resolveMethodWithTraitEnv(Type* baseType, const std::string& methodName,
+                                               const std::vector<Type*>& argTypes,
+                                               llvm::SMRange span) -> ResolvedMethodCallInfo;
   auto resolveMethodReturnType(Type* baseType, const std::string& methodName,
                                const std::vector<Type*>& argTypes, llvm::SMRange span) -> Type*;
   auto isMutableListReceiver(const Expression* expr) -> bool;

--- a/src/liblesma/Typecheck/Typechecker.h
+++ b/src/liblesma/Typecheck/Typechecker.h
@@ -196,6 +196,9 @@ class Typechecker final : public ASTVisitor {
   [[nodiscard]] auto lookupUnionNarrowedType(Value* sym) const -> Type*;
   auto fillUnionNarrowingForIfBlock(const If* node, unsigned blockIndex,
                                     std::unordered_map<Value*, Type*>& out) -> void;
+  /** Remove union arms equal to types in \p toExclude (each match removes at most one arm).
+   *  Returns nullptr if no arm was removed or no arm would remain. */
+  auto narrowUnionByExcludingMembers(Type* unionTy, const std::vector<Type*>& toExclude) -> Type*;
   [[nodiscard]] auto functionTypesMatchForTraitImpl(Type* actualFn, Type* expectedFn) -> bool;
   [[nodiscard]] auto wrapReturnTypeIfNominal(Type* returnType) -> Type*;
   /** Result type of a binary operator (arithmetic, comparison, logical). Throws on unsupported op.

--- a/src/liblesma/Typecheck/Typechecker.h
+++ b/src/liblesma/Typecheck/Typechecker.h
@@ -196,6 +196,11 @@ class Typechecker final : public ASTVisitor {
   [[nodiscard]] auto lookupUnionNarrowedType(Value* sym) const -> Type*;
   auto fillUnionNarrowingForIfBlock(const If* node, unsigned blockIndex,
                                     std::unordered_map<Value*, Type*>& out) -> void;
+  /** Drop \p sym from every active union-narrowing frame (e.g. after assignment through it). */
+  void invalidateUnionNarrowingForSymbol(Value* sym);
+  /** Outermost identifier-like storage for an assignment LHS (for invalidating narrowing on `a.b`
+   *  or `a[i]`). */
+  [[nodiscard]] auto rootStorageSymbolForAssignmentLhs(Expression* lhs) -> Value*;
   /** Remove union arms equal to types in \p toExclude (each match removes at most one arm).
    *  Returns nullptr if no arm was removed or no arm would remain. */
   auto narrowUnionByExcludingMembers(Type* unionTy, const std::vector<Type*>& toExclude) -> Type*;

--- a/src/liblesma/Typecheck/Typechecker.h
+++ b/src/liblesma/Typecheck/Typechecker.h
@@ -15,6 +15,7 @@
 #include "liblesma/Driver/AnalysisResult.h"
 #include "liblesma/Symbol/SymbolTable.h"
 #include "liblesma/Symbol/Type.h"
+#include "liblesma/Symbol/UnionNarrowingStableKey.h"
 #include "liblesma/Symbol/Value.h"
 #include "liblesma/Token/TokenType.h"
 
@@ -83,8 +84,10 @@ class Typechecker final : public ASTVisitor {
   /** Imported types materialized into this typechecker's cache so they outlive imported scopes. */
   std::unordered_map<Type*, Type*> importedTypeCopies;
   std::vector<Type*> expectedTypes;
-  /** Per `if` branch: symbol → narrowed type when discriminating a union with `is` / `is not`. */
-  std::vector<std::unordered_map<Value*, Type*>> unionNarrowingStack;
+  /** Per `if` branch: stable storage identity → narrowed type for `is` / `is not` on unions. */
+  std::vector<std::unordered_map<UnionNarrowingStableKey, Type*, UnionNarrowingStableKeyHash,
+                                 UnionNarrowingStableKeyEq>>
+      unionNarrowingStack;
 
   /** Registered traits (name → AST) for impl checks and existential method lookup. */
   std::unordered_map<std::string, const TraitDecl*> traitRegistry;
@@ -194,8 +197,10 @@ class Typechecker final : public ASTVisitor {
   auto isAssignableTo(Type* from, Type* to) -> bool;
   [[nodiscard]] static auto isSupportedUnionMemberType(Type* t) -> bool;
   [[nodiscard]] auto lookupUnionNarrowedType(Value* sym) const -> Type*;
-  auto fillUnionNarrowingForIfBlock(const If* node, unsigned blockIndex,
-                                    std::unordered_map<Value*, Type*>& out) -> void;
+  auto fillUnionNarrowingForIfBlock(
+      const If* node, unsigned blockIndex,
+      std::unordered_map<UnionNarrowingStableKey, Type*, UnionNarrowingStableKeyHash,
+                         UnionNarrowingStableKeyEq>& out) -> void;
   /** Drop \p sym from every active union-narrowing frame (e.g. after assignment through it). */
   void invalidateUnionNarrowingForSymbol(Value* sym);
   /** Outermost identifier-like storage for an assignment LHS (for invalidating narrowing on `a.b`

--- a/src/lsp/main.cpp
+++ b/src/lsp/main.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
@@ -2649,44 +2650,48 @@ auto tryResolveUnionMultiMethodDefinitionLocations(AnalysisResult& result, unsig
   if (receiverType == nullptr || !receiverType->is(lesma::BaseType::TY_UNION)) {
     return {};
   }
-  std::vector<::lsp::Location> out;
-  std::unordered_set<std::string> seen;
+  std::vector<std::pair<CallableCandidate, AnalysisView>> aggregated;
   for (const AnalysisView& candidateAnalysis : collectAnalysisViews(result)) {
     if (!isUsableAnalysis(candidateAnalysis) || candidateAnalysis.rootScope == nullptr) {
       continue;
     }
-    std::vector<CallableCandidate> candidates = collectCallableCandidates(
+    std::vector<CallableCandidate> perView = collectCallableCandidates(
         candidateAnalysis.rootScope, id->name, receiverType, argTypes);
-    if (candidates.size() <= 1U) {
+    for (const CallableCandidate& cand : perView) {
+      aggregated.emplace_back(cand, candidateAnalysis);
+    }
+  }
+  if (aggregated.size() <= 1U) {
+    return {};
+  }
+  std::vector<::lsp::Location> out;
+  std::unordered_set<std::string> seen;
+  for (const auto& [cand, candidateAnalysis] : aggregated) {
+    if (cand.value == nullptr) {
       continue;
     }
-    for (const CallableCandidate& cand : candidates) {
-      if (cand.value == nullptr) {
-        continue;
-      }
-      std::string declPath = cand.value->getDeclarationFilePath();
-      if (declPath.empty() && candidateAnalysis.mainFilePath != nullptr) {
-        declPath = *candidateAnalysis.mainFilePath;
-      }
-      if (declPath.empty()) {
-        continue;
-      }
-      std::optional<::lsp::Range> mappedRange =
-          lspRangeForValueDeclaration(result, cand.value, candidateAnalysis);
-      if (!mappedRange) {
-        continue;
-      }
-      std::string const key = normalizePath(declPath) + "#" +
-                              std::to_string(mappedRange->start.line) + ":" +
-                              std::to_string(mappedRange->start.character);
-      if (!seen.insert(key).second) {
-        continue;
-      }
-      out.push_back(::lsp::Location{
-          .uri = uriFromPath(declPath),
-          .range = *mappedRange,
-      });
+    std::string declPath = cand.value->getDeclarationFilePath();
+    if (declPath.empty() && candidateAnalysis.mainFilePath != nullptr) {
+      declPath = *candidateAnalysis.mainFilePath;
     }
+    if (declPath.empty()) {
+      continue;
+    }
+    std::optional<::lsp::Range> mappedRange =
+        lspRangeForValueDeclaration(result, cand.value, candidateAnalysis);
+    if (!mappedRange) {
+      continue;
+    }
+    std::string const key = normalizePath(declPath) + "#" +
+                            std::to_string(mappedRange->start.line) + ":" +
+                            std::to_string(mappedRange->start.character);
+    if (!seen.insert(key).second) {
+      continue;
+    }
+    out.push_back(::lsp::Location{
+        .uri = uriFromPath(declPath),
+        .range = *mappedRange,
+    });
   }
   return out;
 }

--- a/src/lsp/main.cpp
+++ b/src/lsp/main.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>
@@ -378,11 +379,12 @@ auto formatCallableHoverType(lesma::Type* type, lesma::SymbolTable* rootScope) -
 }
 
 /** Build hover text from a symbol: name, kind, and type in readable Markdown. */
-auto formatHoverContent(lesma::Value* value, lesma::SymbolTable* rootScope) -> std::string {
+auto formatHoverContent(lesma::Value* value, lesma::SymbolTable* rootScope,
+                        lesma::Type* typeDisplayOverride = nullptr) -> std::string {
   if (value == nullptr) {
     return "";
   }
-  lesma::Type* type = value->getType();
+  lesma::Type* type = typeDisplayOverride != nullptr ? typeDisplayOverride : value->getType();
   std::string typeStr = type != nullptr ? type->toString() : "?";
   std::string const& name = value->getName();
 
@@ -1384,6 +1386,14 @@ struct CallableCandidate {
 
 auto receiverMatchesSelf(lesma::Type* receiverType, lesma::Type* selfType) -> bool {
   if (receiverType == nullptr || selfType == nullptr) {
+    return false;
+  }
+  if (receiverType->is(lesma::BaseType::TY_UNION)) {
+    for (lesma::Type* m : receiverType->getUnionMembers()) {
+      if (receiverMatchesSelf(m, selfType)) {
+        return true;
+      }
+    }
     return false;
   }
   if (receiverType->isEqual(selfType)) {
@@ -2598,6 +2608,89 @@ auto collectDocumentSymbols(const AnalysisResult& result) -> std::vector<::lsp::
   return symbols;
 }
 
+/** When the receiver is a class union and multiple methods match, return every definition. */
+auto tryResolveUnionMultiMethodDefinitionLocations(AnalysisResult& result, unsigned line,
+                                                 unsigned character)
+    -> std::vector<::lsp::Location> {
+  if (result.parser == nullptr || result.sourceMgr == nullptr) {
+    return {};
+  }
+  AnalysisView analysis = makeAnalysisView(result);
+  if (!isUsableAnalysis(analysis) || analysis.ast == nullptr || analysis.rootScope == nullptr) {
+    return {};
+  }
+  std::optional<CursorIdentifier> id = findIdentifierAtCursor(analysis, line, character);
+  if (!id) {
+    return {};
+  }
+  std::optional<ActiveCallSite> activeCall = findActiveCallSite(analysis, line, character);
+  if (!activeCall || activeCall->call == nullptr || activeCall->receiver == nullptr ||
+      activeCall->call->getName() != id->name) {
+    return {};
+  }
+  auto const* buf = analysis.sourceMgr->getMemoryBuffer(analysis.bufferId);
+  if (buf == nullptr) {
+    return {};
+  }
+  unsigned const targetOffset = static_cast<unsigned>(
+      lesma::lsp_srv::bufferByteOffsetFromLspUtf8Position(buf->getBuffer(), line, character));
+  std::vector<lesma::Type*> argTypes;
+  for (lesma::Expression* arg : activeCall->call->getArguments()) {
+    lesma::Type* argType = resolveExpressionTypeAtOffset(
+        arg, analysis.ast, analysis.rootScope, analysis.sourceMgr, analysis.bufferId, targetOffset);
+    if (argType == nullptr) {
+      return {};
+    }
+    argTypes.push_back(argType);
+  }
+  lesma::Type* receiverType =
+      resolveExpressionTypeAtOffset(activeCall->receiver, analysis.ast, analysis.rootScope,
+                                    analysis.sourceMgr, analysis.bufferId, targetOffset);
+  if (receiverType == nullptr || !receiverType->is(lesma::BaseType::TY_UNION)) {
+    return {};
+  }
+  std::vector<::lsp::Location> out;
+  std::unordered_set<std::string> seen;
+  for (const AnalysisView& candidateAnalysis : collectAnalysisViews(result)) {
+    if (!isUsableAnalysis(candidateAnalysis) || candidateAnalysis.rootScope == nullptr) {
+      continue;
+    }
+    std::vector<CallableCandidate> candidates = collectCallableCandidates(
+        candidateAnalysis.rootScope, id->name, receiverType, argTypes);
+    if (candidates.size() <= 1U) {
+      continue;
+    }
+    for (const CallableCandidate& cand : candidates) {
+      if (cand.value == nullptr) {
+        continue;
+      }
+      std::string declPath = cand.value->getDeclarationFilePath();
+      if (declPath.empty() && candidateAnalysis.mainFilePath != nullptr) {
+        declPath = *candidateAnalysis.mainFilePath;
+      }
+      if (declPath.empty()) {
+        continue;
+      }
+      std::optional<::lsp::Range> mappedRange =
+          lspRangeForValueDeclaration(result, cand.value, candidateAnalysis);
+      if (!mappedRange) {
+        continue;
+      }
+      std::string const key = normalizePath(declPath) + "#" +
+                              std::to_string(mappedRange->start.line) + ":" +
+                              std::to_string(mappedRange->start.character);
+      if (!seen.insert(key).second) {
+        continue;
+      }
+      out.push_back(::lsp::Location{
+          .uri = uriFromPath(declPath),
+          .range = *mappedRange,
+      });
+    }
+  }
+  return out;
+}
+
 /** Resolve definition location using compiler metadata from Value. */
 auto tryResolveDefinitionLocation(AnalysisResult& result, unsigned line, unsigned character)
     -> std::optional<::lsp::Location> {
@@ -2855,8 +2948,14 @@ auto main() -> int {
                     resolveCanonicalSymbolAtCursor(result, line, character, *id);
                 if (resolved && resolved->value != nullptr &&
                     resolved->value->getType() != nullptr) {
+                  lesma::Type* flowTy = nullptr;
+                  if (const lesma::IndexedSymbolOccurrence* occ =
+                          findIndexedSymbolOccurrenceAtCursor(analysis, line, character);
+                      occ != nullptr && occ->flowSensitiveType != nullptr) {
+                    flowTy = occ->flowSensitiveType;
+                  }
                   std::string hoverText =
-                      formatHoverContent(resolved->value, resolved->owner.rootScope);
+                      formatHoverContent(resolved->value, resolved->owner.rootScope, flowTy);
                   if (std::string doc = documentationCommentAboveDeclaration(
                           result, resolved->value, resolved->owner);
                       !doc.empty()) {
@@ -3006,6 +3105,12 @@ auto main() -> int {
           return withAnalyzedDocument<::lsp::TextDocument_DefinitionResult>(
               params.textDocument.uri, docStore, analysisCache,
               [&](AnalysisResult& result) -> ::lsp::TextDocument_DefinitionResult {
+                std::vector<::lsp::Location> const multiLocs = tryResolveUnionMultiMethodDefinitionLocations(
+                    result, params.position.line, params.position.character);
+                if (multiLocs.size() > 1U) {
+                  return {::lsp::Definition(
+                      ::lsp::Array<::lsp::Location>(multiLocs.begin(), multiLocs.end()))};
+                }
                 auto loc = tryResolveDefinitionLocation(result, params.position.line,
                                                         params.position.character);
                 if (!loc) {
@@ -3021,6 +3126,12 @@ auto main() -> int {
           return withAnalyzedDocument<::lsp::TextDocument_DeclarationResult>(
               params.textDocument.uri, docStore, analysisCache,
               [&](AnalysisResult& result) -> ::lsp::TextDocument_DeclarationResult {
+                std::vector<::lsp::Location> const multiDecls = tryResolveUnionMultiMethodDefinitionLocations(
+                    result, params.position.line, params.position.character);
+                if (multiDecls.size() > 1U) {
+                  return {::lsp::Declaration(
+                      ::lsp::Array<::lsp::Location>(multiDecls.begin(), multiDecls.end()))};
+                }
                 auto loc = tryResolveDeclarationLocation(result, params.position.line,
                                                          params.position.character);
                 if (!loc) {

--- a/src/lsp/main.cpp
+++ b/src/lsp/main.cpp
@@ -7,11 +7,11 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <utility>
-#include <vector>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <variant>
+#include <vector>
 
 #include <llvm/Support/SourceMgr.h>
 
@@ -64,15 +64,16 @@ public:
     // Recompute
     std::string implicitPath = docStore.getAnalyzeMainFilePath(uri).value_or("");
     auto options = std::make_unique<Options>(Options{
-        SourceType::STRING,
-        content,
-        Debug::NONE,
-        "output",
-        false,
-        std::move(implicitPath),
+        .sourceType = SourceType::STRING,
+        .source = content,
+        .debug = Debug::NONE,
+        .outputFilename = "output",
+        .timer = false,
+        .implicitFilePath = std::move(implicitPath),
     });
     AnalysisResult result = lesma::analyze(std::move(options));
-    DocumentAnalysisSnapshot snapshot{content, version, std::move(result)};
+    DocumentAnalysisSnapshot snapshot{
+        .content = content, .version = version, .result = std::move(result)};
     cache[key] = std::move(snapshot);
     return cache[key];
   }
@@ -322,8 +323,7 @@ auto runAnalyzeAndPublish(const ::lsp::DocumentUri& uri,
   AnalysisResult& result = snapshot.result;
 
   std::optional<std::string> const analyzedPathOpt = docStore.getPath(uri);
-  std::string const primaryNorm =
-      analyzedPathOpt ? normalizePath(*analyzedPathOpt) : std::string{};
+  std::string const primaryNorm = analyzedPathOpt ? normalizePath(*analyzedPathOpt) : std::string{};
 
   std::vector<::lsp::Diagnostic> primaryDiags;
   std::unordered_map<std::string, std::vector<::lsp::Diagnostic>> otherDiags;
@@ -771,18 +771,11 @@ auto makeCursorIdentifierFromSpan(const std::string& name, llvm::SMRange span,
                               isTypePosition);
 }
 
-auto findIndexedSymbolOccurrenceAtCursor(const AnalysisView& analysis, unsigned line,
-                                         unsigned character)
+auto findIndexedSymbolOccurrenceAtBufferOffset(const AnalysisView& analysis, unsigned targetOffset)
     -> const lesma::IndexedSymbolOccurrence* {
   if (!isUsableAnalysis(analysis) || analysis.index == nullptr) {
     return nullptr;
   }
-  auto const* buf = analysis.sourceMgr->getMemoryBuffer(analysis.bufferId);
-  if (buf == nullptr) {
-    return nullptr;
-  }
-  unsigned const targetOffset = static_cast<unsigned>(
-      lesma::lsp_srv::bufferByteOffsetFromLspUtf8Position(buf->getBuffer(), line, character));
   const lesma::IndexedSymbolOccurrence* best = nullptr;
   unsigned bestLen = 0U;
   bool bestContains = false;
@@ -808,6 +801,21 @@ auto findIndexedSymbolOccurrenceAtCursor(const AnalysisView& analysis, unsigned 
     }
   }
   return best;
+}
+
+auto findIndexedSymbolOccurrenceAtCursor(const AnalysisView& analysis, unsigned line,
+                                         unsigned character)
+    -> const lesma::IndexedSymbolOccurrence* {
+  if (!isUsableAnalysis(analysis) || analysis.index == nullptr) {
+    return nullptr;
+  }
+  auto const* buf = analysis.sourceMgr->getMemoryBuffer(analysis.bufferId);
+  if (buf == nullptr) {
+    return nullptr;
+  }
+  unsigned const targetOffset = static_cast<unsigned>(
+      lesma::lsp_srv::bufferByteOffsetFromLspUtf8Position(buf->getBuffer(), line, character));
+  return findIndexedSymbolOccurrenceAtBufferOffset(analysis, targetOffset);
 }
 
 /** Find identifier at cursor position by walking AST to find the identifier token. */
@@ -1390,12 +1398,9 @@ auto receiverMatchesSelf(lesma::Type* receiverType, lesma::Type* selfType) -> bo
     return false;
   }
   if (receiverType->is(lesma::BaseType::TY_UNION)) {
-    for (lesma::Type* m : receiverType->getUnionMembers()) {
-      if (receiverMatchesSelf(m, selfType)) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(receiverType->getUnionMembers(), [selfType](lesma::Type* m) -> bool {
+      return receiverMatchesSelf(m, selfType);
+    });
   }
   if (receiverType->isEqual(selfType)) {
     return true;
@@ -2611,7 +2616,7 @@ auto collectDocumentSymbols(const AnalysisResult& result) -> std::vector<::lsp::
 
 /** When the receiver is a class union and multiple methods match, return every definition. */
 auto tryResolveUnionMultiMethodDefinitionLocations(AnalysisResult& result, unsigned line,
-                                                 unsigned character)
+                                                   unsigned character)
     -> std::vector<::lsp::Location> {
   if (result.parser == nullptr || result.sourceMgr == nullptr) {
     return {};
@@ -2647,6 +2652,24 @@ auto tryResolveUnionMultiMethodDefinitionLocations(AnalysisResult& result, unsig
   lesma::Type* receiverType =
       resolveExpressionTypeAtOffset(activeCall->receiver, analysis.ast, analysis.rootScope,
                                     analysis.sourceMgr, analysis.bufferId, targetOffset);
+  llvm::SMRange const receiverSpan = activeCall->receiver->getSpan();
+  if (receiverSpan.isValid()) {
+    unsigned const recvStart =
+        getOffsetFromSMLoc(analysis.sourceMgr, analysis.bufferId, receiverSpan.Start);
+    unsigned const recvEnd =
+        getOffsetFromSMLoc(analysis.sourceMgr, analysis.bufferId, receiverSpan.End);
+    if (const lesma::IndexedSymbolOccurrence* recvOcc =
+            findIndexedSymbolOccurrenceAtBufferOffset(analysis, recvStart);
+        recvOcc != nullptr && recvOcc->flowSensitiveType != nullptr) {
+      unsigned const occStart =
+          getOffsetFromSMLoc(analysis.sourceMgr, analysis.bufferId, recvOcc->span.Start);
+      unsigned const occEnd =
+          getOffsetFromSMLoc(analysis.sourceMgr, analysis.bufferId, recvOcc->span.End);
+      if (occStart >= recvStart && occEnd <= recvEnd) {
+        receiverType = recvOcc->flowSensitiveType;
+      }
+    }
+  }
   if (receiverType == nullptr || !receiverType->is(lesma::BaseType::TY_UNION)) {
     return {};
   }
@@ -2655,8 +2678,8 @@ auto tryResolveUnionMultiMethodDefinitionLocations(AnalysisResult& result, unsig
     if (!isUsableAnalysis(candidateAnalysis) || candidateAnalysis.rootScope == nullptr) {
       continue;
     }
-    std::vector<CallableCandidate> perView = collectCallableCandidates(
-        candidateAnalysis.rootScope, id->name, receiverType, argTypes);
+    std::vector<CallableCandidate> perView =
+        collectCallableCandidates(candidateAnalysis.rootScope, id->name, receiverType, argTypes);
     for (const CallableCandidate& cand : perView) {
       aggregated.emplace_back(cand, candidateAnalysis);
     }
@@ -2857,9 +2880,9 @@ auto main() -> int {
               .legend =
                   ::lsp::SemanticTokensLegend{
                       .tokenTypes =
-                          ::lsp::Array<::lsp::String>{
-                              "namespace", "class", "enum", "enumMember", "type", "typeParameter",
-                              "function", "method", "parameter", "variable", "property"},
+                          ::lsp::Array<::lsp::String>{"namespace", "class", "enum", "enumMember",
+                                                      "type", "typeParameter", "function", "method",
+                                                      "parameter", "variable", "property"},
                       .tokenModifiers =
                           ::lsp::Array<::lsp::String>{"declaration", "defaultLibrary"},
                   },
@@ -3110,8 +3133,9 @@ auto main() -> int {
           return withAnalyzedDocument<::lsp::TextDocument_DefinitionResult>(
               params.textDocument.uri, docStore, analysisCache,
               [&](AnalysisResult& result) -> ::lsp::TextDocument_DefinitionResult {
-                std::vector<::lsp::Location> const multiLocs = tryResolveUnionMultiMethodDefinitionLocations(
-                    result, params.position.line, params.position.character);
+                std::vector<::lsp::Location> const multiLocs =
+                    tryResolveUnionMultiMethodDefinitionLocations(result, params.position.line,
+                                                                  params.position.character);
                 if (multiLocs.size() > 1U) {
                   return {::lsp::Definition(
                       ::lsp::Array<::lsp::Location>(multiLocs.begin(), multiLocs.end()))};
@@ -3131,8 +3155,9 @@ auto main() -> int {
           return withAnalyzedDocument<::lsp::TextDocument_DeclarationResult>(
               params.textDocument.uri, docStore, analysisCache,
               [&](AnalysisResult& result) -> ::lsp::TextDocument_DeclarationResult {
-                std::vector<::lsp::Location> const multiDecls = tryResolveUnionMultiMethodDefinitionLocations(
-                    result, params.position.line, params.position.character);
+                std::vector<::lsp::Location> const multiDecls =
+                    tryResolveUnionMultiMethodDefinitionLocations(result, params.position.line,
+                                                                  params.position.character);
                 if (multiDecls.size() > 1U) {
                   return {::lsp::Declaration(
                       ::lsp::Array<::lsp::Location>(multiDecls.begin(), multiDecls.end()))};

--- a/tests/lesma/failure/union_assign_incompatible.les
+++ b/tests/lesma/failure/union_assign_incompatible.les
@@ -1,0 +1,2 @@
+# Values must be assignable to at least one union member.
+var x: int | float = "nope"

--- a/tests/lesma/failure/union_assign_union_incompatible.les
+++ b/tests/lesma/failure/union_assign_union_incompatible.les
@@ -1,0 +1,3 @@
+# Union-to-union assignment requires every member of the RHS to match some LHS arm.
+var x: int | float = 1.0
+var y: int | bool = x

--- a/tests/lesma/failure/union_generic_param_mismatch.les
+++ b/tests/lesma/failure/union_generic_param_mismatch.les
@@ -1,0 +1,8 @@
+# No pairing binds `T` for `T | int` vs `str | bool`.
+
+func g<T>(x: T | int) -> int {
+    return 0
+}
+
+var bad: str | bool = true
+var _ = g(bad)

--- a/tests/lesma/failure/union_generic_param_pair_conflict.les
+++ b/tests/lesma/failure/union_generic_param_pair_conflict.les
@@ -1,0 +1,10 @@
+# Same `T` in two `T | int` parameters: `u` fixes `T` = str; `v` is `int | float` so the second
+# argument cannot match the same `T` (overload resolution fails: no viable `pairTag`).
+
+func pairTag<T>(a: T | int, b: T | int) -> int {
+    return 0
+}
+
+var u: str | int = "a"
+var v: int | float = 1.0
+var _ = pairTag(u, v)

--- a/tests/lesma/failure/union_generic_typevar_outside_scope.les
+++ b/tests/lesma/failure/union_generic_typevar_outside_scope.les
@@ -1,0 +1,7 @@
+# Type parameter `T` is not in scope on a non-generic class method.
+
+class C {
+    func m(x: T | int) -> int {
+        return 0
+    }
+}

--- a/tests/lesma/failure/union_is_not_member.les
+++ b/tests/lesma/failure/union_is_not_member.les
@@ -1,0 +1,5 @@
+# `is` RHS must be a member of the union.
+var x: int | bool = 1
+if x is float {
+    pass
+}

--- a/tests/lesma/failure/union_member_buffer_outside_stdlib.les
+++ b/tests/lesma/failure/union_member_buffer_outside_stdlib.les
@@ -1,0 +1,2 @@
+# __buffer may not appear as a union member outside the standard library.
+var x: int | __buffer<int> = 1

--- a/tests/lesma/failure/union_method_generic_trait_bound_violation.les
+++ b/tests/lesma/failure/union_method_generic_trait_bound_violation.les
@@ -1,0 +1,36 @@
+# Union dot-calls must run verifyGenericTraitBounds per member; inferred type args must satisfy
+# each generic method's trait bounds (same as a non-union dot call).
+trait NeedVal {
+    func val() -> int
+
+}
+class Plain {
+    var x: int
+    func new(v: int) {
+        self.x = v
+
+    }
+}
+class A {
+    func new() {
+        pass
+
+    }
+    func take<T: NeedVal>(o: T) -> int {
+        return o.val()
+
+    }
+}
+class B {
+    func new() {
+        pass
+
+    }
+    func take<T: NeedVal>(o: T) -> int {
+        return o.val()
+
+    }
+}
+var u: A | B = A()
+var p = Plain(1)
+var _ = u.take(p)

--- a/tests/lesma/failure/union_narrowing_after_reassign.les
+++ b/tests/lesma/failure/union_narrowing_after_reassign.les
@@ -1,0 +1,8 @@
+# After assigning into a mutable union local, flow narrowing must not still treat it as the old arm.
+# (Otherwise `x` would still look like `int` here and this would incorrectly typecheck.)
+
+var x: int | str = 1
+if x is int {
+    x = "hello"
+    var bad: int = x
+}

--- a/tests/lesma/success/union_assign_subset.les
+++ b/tests/lesma/success/union_assign_subset.les
@@ -1,0 +1,14 @@
+# A narrower union is assignable to a wider union when each member fits some arm.
+# str and list<T> are classes.
+
+var narrow: int | str = 1
+var wide: int | str | bool = narrow
+if wide is not int {
+    exit(1)
+}
+
+var xs: int | list<int> = 1
+var xsWide: int | list<int> | bool = xs
+if xsWide is not int {
+    exit(1)
+}

--- a/tests/lesma/success/union_class_shared_method.les
+++ b/tests/lesma/success/union_class_shared_method.les
@@ -1,0 +1,37 @@
+# Call the same method on every class variant without narrowing when signatures match.
+
+class BoxA {
+    var v: int
+
+    func new() {
+        self.v = 10
+
+    }
+    func id() -> int {
+        return self.v
+    }
+}
+class BoxB {
+    var v: int
+
+    func new() {
+        self.v = 20
+
+    }
+    func id() -> int {
+        return self.v + 1
+    }
+}
+
+export func callId(x: BoxA | BoxB) -> int {
+    return x.id()
+}
+
+var a = BoxA()
+var b = BoxB()
+if callId(a) != 10 {
+    exit(1)
+}
+if callId(b) != 21 {
+    exit(1)
+}

--- a/tests/lesma/success/union_class_trait_shared_method.les
+++ b/tests/lesma/success/union_class_trait_shared_method.les
@@ -1,0 +1,36 @@
+# Two classes implement the same trait; shared trait method on the union needs no narrowing.
+
+trait Speaker {
+    func say() -> int
+
+}
+class Frog impl Speaker {
+    func new() {
+
+    }
+    func say() -> int {
+        return 3
+
+    }
+}
+class Toad impl Speaker {
+    func new() {
+
+    }
+    func say() -> int {
+        return 5
+
+    }
+}
+export func speakEither(x: Frog | Toad) -> int {
+    return x.say()
+}
+
+var f = Frog()
+var t = Toad()
+if speakEither(f) != 3 {
+    exit(1)
+}
+if speakEither(t) != 5 {
+    exit(1)
+}

--- a/tests/lesma/success/union_generic_param_match.les
+++ b/tests/lesma/success/union_generic_param_match.les
@@ -1,0 +1,35 @@
+# Generic union formal `T | int` vs concrete unions: overload resolution pairs arms (canonical
+# sort) and binds `T` consistently.
+
+func nonIntArm<T>(x: T | int) -> int {
+    if x is int {
+        return 0
+    }
+    return 1
+}
+
+func pairBothNonInt<T>(a: T | int, b: T | int) -> int {
+    if a is int {
+        return 0
+    }
+    if b is int {
+        return 1
+    }
+    return 2
+}
+
+var uStrFirst: str | int = "ab"
+var uIntFirst: int | str = 99
+
+if nonIntArm(uStrFirst) != 1 {
+    exit(1)
+}
+if nonIntArm(uIntFirst) != 0 {
+    exit(1)
+}
+
+var s1: str | int = "a"
+var s2: int | str = "b"
+if pairBothNonInt(s1, s2) != 2 {
+    exit(1)
+}

--- a/tests/lesma/success/union_narrowing.les
+++ b/tests/lesma/success/union_narrowing.les
@@ -1,0 +1,38 @@
+# Union types, runtime `is`, and flow narrowing in branches.
+
+export func kind(x: int | float) -> int {
+    if x is int {
+        return x + 1
+    }
+    return 2
+}
+
+if kind(10) != 11 {
+    exit(1)
+}
+if kind(3.5) != 2 {
+    exit(1)
+}
+
+var u: float | int = 7
+if u is float {
+    exit(1)
+}
+if u is not int {
+    exit(1)
+}
+
+export func onlyIntElse(x: int | float) -> int {
+    if x is float {
+        return 0
+    } else {
+        return x + 1
+    }
+}
+
+if onlyIntElse(1.0) != 0 {
+    exit(1)
+}
+if onlyIntElse(3) != 4 {
+    exit(1)
+}

--- a/tests/lesma/success/union_narrowing_invalidate_on_assign.les
+++ b/tests/lesma/success/union_narrowing_invalidate_on_assign.les
@@ -1,0 +1,12 @@
+# Mutable locals still narrow under `is`; reassignment clears narrowing (see failure
+# `union_narrowing_after_reassign.les` if that were skipped). Here we only check narrow-then-assign.
+
+var x: int | float = 1
+if x is int {
+    if x + 1 != 2 {
+        exit(1)
+    }
+    x = 3.5
+} else {
+    exit(1)
+}

--- a/tests/lesma/success/union_narrowing_lambda_capture.les
+++ b/tests/lesma/success/union_narrowing_lambda_capture.les
@@ -1,0 +1,100 @@
+# Union narrowing inside a lambda that captures the discriminated variable.
+# The capture shadow is a different `Value*` than the outer binding; typecheck and codegen must
+# key narrowing by stable storage identity (declaration site), not the shadow pointer.
+#
+# Variants: (1) local var + arithmetic (2) parameter + arithmetic (3) local var + idInt(u)
+#           (4) class union + method only on one arm
+
+# --- Variant 1: `var` binding, `u + 1` in the lambda ---
+
+func narrowedCaptureVarArithmetic() -> int {
+    var u: int | float = 41
+    if u is int {
+        let g = func() -> int {
+            return u + 1
+        }
+        return g()
+    }
+    return 0
+}
+
+# --- Variant 2: function parameter, `u + 1` in the lambda ---
+
+func narrowedCaptureParamArithmetic(u: int | float) -> int {
+    if u is int {
+        let g = func() -> int {
+            return u + 1
+        }
+        return g()
+    }
+    return 0
+}
+
+# --- Variant 3: `var` binding, narrowed `u` passed where `int` is required ---
+
+func idInt(x: int) -> int {
+    return x
+}
+
+func narrowedCaptureVarIdInt() -> int {
+    var u: int | float = 41
+    if u is int {
+        let g = func() -> int {
+            return idInt(u)
+        }
+        return g()
+    }
+    return 0
+}
+
+# --- Variant 4: class union; call method that exists only on `BoxA` ---
+
+class BoxA {
+    func new() {}
+
+    func onlyA() -> int {
+        return 7
+    }
+}
+
+class BoxB {
+    func new() {}
+}
+
+func narrowedCaptureClassUnion(u: BoxA | BoxB) -> int {
+    if u is BoxA {
+        let g = func() -> int {
+            return u.onlyA()
+        }
+        return g()
+    }
+    return 0
+}
+
+# --- Assertions ---
+
+if narrowedCaptureVarArithmetic() != 42 {
+    exit(1)
+}
+
+if narrowedCaptureParamArithmetic(41) != 42 {
+    exit(1)
+}
+
+if narrowedCaptureParamArithmetic(3.5) != 0 {
+    exit(1)
+}
+
+if narrowedCaptureVarIdInt() != 41 {
+    exit(1)
+}
+
+var ba = BoxA()
+if narrowedCaptureClassUnion(ba) != 7 {
+    exit(1)
+}
+
+var bb = BoxB()
+if narrowedCaptureClassUnion(bb) != 0 {
+    exit(1)
+}

--- a/tools/docs/content/docs/language/control-flow.mdx
+++ b/tools/docs/content/docs/language/control-flow.mdx
@@ -7,7 +7,9 @@ category: Language
 
 ## Conditionals
 
-`if` / `else` chains pick a branch. You can return early from a function:
+`if` / `else` chains pick a branch. You can return early from a function.
+
+When the condition uses **`x is SomeType`** on a **union** variable, the checker **narrows** the type of **`x`** inside the matching branch; see [Types](/docs/language/types) (sections *Union types* and *Flow narrowing*).
 
 ```les
 func sign(n: int) -> str {

--- a/tools/docs/content/docs/language/reference.mdx
+++ b/tools/docs/content/docs/language/reference.mdx
@@ -58,7 +58,7 @@ Common prelude items include: **`print`** (overloads), **`input`**, **`exit`**, 
 
 **`range`:** **`range(stop)`** is **`range(1, stop, 1)`** (default start is **1**). Two- and three-argument forms use an **exclusive** stop and optional step; **step 0** yields no iterations.
 
-Some list and string behavior lowers to **compiler intrinsics** (`__buffer_*`, `__str_*`, …). Prefer **`list`** and **`str`** APIs in normal code.
+Some list and string behavior lowers to **compiler intrinsics** that are not part of the everyday language surface. Prefer **`list`** and **`str`** APIs in normal code.
 
 ## Imports
 

--- a/tools/docs/content/docs/language/types.mdx
+++ b/tools/docs/content/docs/language/types.mdx
@@ -80,7 +80,7 @@ var v: float | int = 3.5
 
 The compiler **normalizes** unions: member types are **deduplicated** and sorted into a **canonical order** (stable in a given compiler version). So **`int | float`** and **`float | int`** are the **same** type, with the same tag assignment and layout.
 
-**Supported members** today are the scalar primitives **`int`**, **`float`**, **`float32`**, **`bool`**, and **class** types (classes are passed by value in the ABI; the union stores the class layout). Other forms (generic unions, arbitrary pointer unions as a single tagged union, etc.) may be rejected.
+**Supported members** in normal code are the scalar primitives **`int`**, **`float`**, **`float32`**, **`bool`**, and **class** types — including stdlib **`str`**, generic classes like **`list<T>`**, and your own classes (classes are passed by value in the ABI; the union stores the class layout). Other forms (arbitrary pointer unions as a single tagged union, tuples in unions, stdlib-internal type forms in unions, etc.) may be rejected.
 
 A value of type **`T`** is assignable to **`T | U | …`** when it is assignable to **at least one** member: the compiler **wraps** it with the correct tag. Calls and assignments use the same rules.
 

--- a/tools/docs/content/docs/language/types.mdx
+++ b/tools/docs/content/docs/language/types.mdx
@@ -1,7 +1,7 @@
 ---
 title: Types
 description: |
-  Static typing, type annotations, inference, runtime checks, casts, and common built-in types in Lesma.
+  Static typing, annotations, inference, unions, narrowing, casts, built-ins, and runtime `is` checks.
 category: Language
 ---
 
@@ -69,9 +69,73 @@ let printer: func(int) = func(n: int) {
 
 Use **`func(T1, T2) -> R`** in annotations; [lambda expressions](/docs/language/functions#lambdas) produce values of these types.
 
+## Union types (`|`)
+
+A **union type** **`T1 | T2 | …`** is a single value type: at runtime each value remembers which variant it holds (a tag) and stores a payload large enough for the largest member. Use **`|`** between types in annotations (and anywhere a type is written):
+
+```les
+var u: int | float = 7
+var v: float | int = 3.5
+```
+
+The compiler **normalizes** unions: member types are **deduplicated** and sorted into a **canonical order** (stable in a given compiler version). So **`int | float`** and **`float | int`** are the **same** type, with the same tag assignment and layout.
+
+**Supported members** today are the scalar primitives **`int`**, **`float`**, **`float32`**, **`bool`**, and **class** types (classes are passed by value in the ABI; the union stores the class layout). Other forms (generic unions, arbitrary pointer unions as a single tagged union, etc.) may be rejected.
+
+A value of type **`T`** is assignable to **`T | U | …`** when it is assignable to **at least one** member: the compiler **wraps** it with the correct tag. Calls and assignments use the same rules.
+
+## Flow narrowing (`if` + `is`)
+
+When a variable’s static type is a **union** and you branch on **`x is SomeType`** or **`x is not SomeType`**, the checker **narrows** the type of **`x`** inside certain blocks:
+
+- **`if x is T { … }`**: inside the **then** block, **`x`** has type **`T`** (when **`T`** is a member of the union).
+- **`else`** attached to **`if x is T`** when the union has **exactly two** members: in the **else** block, **`x`** has the **other** member type.
+- After the full **`if`** (or when code is **not** inside such a branch), **`x`** is again the **full** union.
+
+Narrowing applies to **simple variable references** (locals and parameters) the checker can tie to storage.
+
+**Important:** narrowing applies to code **inside** the **`if` / `else` blocks**. A statement that comes **after** the closing brace of **`if x is T { … }`** but is **not** inside an **`else { … }`** is still in the outer scope, so **`x`** is **not** narrowed there. Use an explicit **`else { … }`** when you need the complement type:
+
+```les
+func f(x: int | float) -> int {
+    if x is float {
+        return 0
+    } else {
+        return x + 1
+    }
+}
+```
+
+For **`is not`** with a two-member union, the checker narrows analogously (then-branch to “not that member”, else-branch to that member when applicable).
+
+## Shared methods on class unions
+
+If **every** class member of a union defines a method with the **same name** and **compatible** signatures (including the same return type), you can call that method **without** narrowing:
+
+```les
+class A {
+    func new() {}
+    func id() -> int { return 1 }
+}
+class B {
+    func new() {}
+    func id() -> int { return 2 }
+}
+
+func pick() -> int {
+    var x: A | B = A()
+    return x.id()
+}
+```
+
+The same idea applies when both classes **implement a trait** and you call a **required** method: **`x.say()`** can type-check on **`Frog | Toad`** when both implement **`Speaker`**.
+
 ## `is` and `is not`
 
-**`is`** and **`is not`** compare a value’s **runtime type** to a type expression. They are useful after generic or pointer-heavy code where you need a clear type check.
+**`is`** and **`is not`** compare a value to a type and produce **`bool`**.
+
+- If the left-hand expression has a **union** type, the check uses the **runtime tag**: **`x is int`** is true exactly when the stored variant is **`int`** (per the canonical member list).
+- For **non-union** values (for example pointers and classes in the usual **`p is *T`** style), the compiler keeps the existing **static** comparison behavior.
 
 ```les
 var x: int = 5
@@ -82,7 +146,7 @@ if p is not *int {
 }
 ```
 
-You can test built-ins, generics, and other type forms the compiler accepts in that position (for example **`list<int>`**).
+The right-hand side must be a **type** the compiler accepts in that position. For a union **`x`**, **`x is U`** requires **`U`** to be one of the union’s members (after normalization). You can still test other type forms where the checker allows them (for example **`list<int>`**) when the left-hand type is not a union.
 
 ## `as` casts
 
@@ -93,9 +157,17 @@ let y: float = 101.5
 let z: int = y as int
 ```
 
+## IDE support (LSP)
+
+When **`lesma-lsp`** is enabled, **hover** on an identifier can show the **flow-narrowed** type (for example **`int`** on **`x`** inside an **`else`** branch after **`x is float`**), not only the declared **`int | float`**.
+
+**Go to definition** on a method name called on a **class union** (for example **`x.id()`** on **`A | B`**) may return **multiple locations**—one per implementing class—so you can jump to **`A::id`** or **`B::id`**.
+
 ## Next steps
 
+- [Control flow](/docs/language/control-flow) for **`if` / `else`** structure used with narrowing.
 - [Enums](/docs/language/enums) and [Tuples](/docs/language/tuples) for more type forms.
 - [Foreign Function Interface](/docs/language/ffi) for `func extern` and C-compatible types.
 - [Functions](/docs/language/functions)
 - [Classes](/docs/language/classes)
+- [Traits & Generics](/docs/language/traits-generics) for trait methods on union receivers.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class union types (T1 | T2): branch-based flow narrowing, union-aware method calls, improved generics/assignability, LSP hover showing flow-narrowed types, and multi-location “go to definition” for union method calls.

* **Documentation**
  * Added in-repo union docs and control-flow note; README now links to internal docs; removed outdated UTF‑8 positions and unsupported-syntax docs; ROADMAP checklist updated.

* **Tests**
  * Many new success/failure tests covering unions, narrowing, generics, method calls, assignments, and invalid cases.

* **Chores**
  * Test runner: configurable per-run timeout, timeout reporting, and quieter output modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->