### PR TITLE
Static Methods

### DIFF
--- a/src/liblesma/AST/AST.h
+++ b/src/liblesma/AST/AST.h
@@ -377,15 +377,17 @@ class VarDecl : public Statement {
   bool exported = false;
   /** Class body only: field is visible only inside methods of the declaring class. */
   bool isPrivate = false;
+  /** Class body only: one shared storage for the class (`static let` / `static var`). */
+  bool isStatic = false;
   /** Set by typechecker: one entry per `vars` (unpack) or one for a simple `let`. */
   mutable std::vector<Value*> resolvedSymbols;
 
 public:
   VarDecl(llvm::SMRange loc, std::vector<std::unique_ptr<Literal>> vars,
           std::unique_ptr<TypeExpr> type, std::unique_ptr<Expression> expr, bool isMutable,
-          bool exportedArg = false, bool privateField = false)
+          bool exportedArg = false, bool privateField = false, bool staticField = false)
       : Statement(loc), vars(std::move(vars)), type(std::move(type)), expr(std::move(expr)),
-        isMutable(isMutable), exported(exportedArg), isPrivate(privateField) {}
+        isMutable(isMutable), exported(exportedArg), isPrivate(privateField), isStatic(staticField) {}
   void accept(ASTVisitor& visitor) const override { visitor.visit(this); }
 
   [[nodiscard]] [[maybe_unused]] auto getIdentifier() const -> Literal* {
@@ -408,6 +410,7 @@ public:
   [[nodiscard]] [[maybe_unused]] auto getMutability() const -> bool { return isMutable; }
   [[nodiscard]] auto isExported() const -> bool { return exported; }
   [[nodiscard]] auto getIsPrivate() const -> bool { return isPrivate; }
+  [[nodiscard]] auto getIsStatic() const -> bool { return isStatic; }
   [[nodiscard]] auto getResolvedSymbol() const -> Value* {
     if (resolvedSymbols.empty()) {
       return nullptr;
@@ -585,6 +588,8 @@ class FuncDecl : public Statement {
   bool isPrivate = false;
   /** Class body: must be true to override an inherited instance method (same name + parameters). */
   bool declaresOverload = false;
+  /** Class body: no implicit `self` (`static func`). */
+  bool isStatic = false;
   /** Set by typechecker: the symbol for this overload (used by LSP for hover/definition). */
   mutable Value* resolvedSymbol = nullptr;
   mutable SymbolTable* genericScope = nullptr;
@@ -594,18 +599,19 @@ public:
            llvm::SMRange overloadGlyphSpan, std::vector<GenericParamDecl> genericParams,
            std::unique_ptr<TypeExpr> returnType, std::vector<std::unique_ptr<Parameter>> parameters,
            std::unique_ptr<Compound> body, bool varargs, bool exported, bool methodPrivate = false,
-           bool inheritanceOverload = false)
+           bool inheritanceOverload = false, bool methodStatic = false)
       : Statement(loc), name(std::move(name)), nameSpan(nameSpan),
         overloadGlyphSpan(overloadGlyphSpan), genericParams(std::move(genericParams)),
         returnType(std::move(returnType)), parameters(std::move(parameters)), body(std::move(body)),
         varargs(varargs), exported(exported), isPrivate(methodPrivate),
-        declaresOverload(inheritanceOverload) {}
+        declaresOverload(inheritanceOverload), isStatic(methodStatic) {}
   void accept(ASTVisitor& visitor) const override { visitor.visit(this); }
 
   [[nodiscard]] [[maybe_unused]] auto getName() const -> std::string { return name; }
   [[nodiscard]] [[maybe_unused]] auto getNameSpan() const -> llvm::SMRange { return nameSpan; }
   [[nodiscard]] auto getIsPrivate() const -> bool { return isPrivate; }
   [[nodiscard]] auto getDeclaresOverload() const -> bool { return declaresOverload; }
+  [[nodiscard]] auto getIsStatic() const -> bool { return isStatic; }
   [[nodiscard]] auto getOverloadGlyphSpan() const -> llvm::SMRange { return overloadGlyphSpan; }
   [[nodiscard]] [[maybe_unused]] auto getGenericParams() const -> std::vector<std::string> {
     std::vector<std::string> result;

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -161,9 +161,8 @@ class Codegen final : public ASTVisitor {
   /** Pushes a non-empty narrow map onto \c unionNarrowVariantStack in the ctor and pops in the
    * dtor so the stack stays balanced if nested codegen throws (e.g. \c CodegenError). */
   struct UnionNarrowingScope {
-    using MapTy =
-        std::unordered_map<UnionNarrowingStableKey, unsigned, UnionNarrowingStableKeyHash,
-                           UnionNarrowingStableKeyEq>;
+    using MapTy = std::unordered_map<UnionNarrowingStableKey, unsigned, UnionNarrowingStableKeyHash,
+                                     UnionNarrowingStableKeyEq>;
     UnionNarrowingScope(std::vector<MapTy>& stackRef, MapTy&& map)
         : stack(stackRef), pushed(!map.empty()) {
       if (pushed) {
@@ -381,9 +380,10 @@ protected:
                         const FuncCall* callSiteForGenericEnv = nullptr)
       -> std::unique_ptr<lesma::Value>;
   auto emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* astNode) -> void;
-  /** LLVM global for a static field; uses the class template symbol when \p classTy is specialized. */
-  [[nodiscard]] auto llvmGlobalForClassStaticField(lesma::Type* classTy, const std::string& fieldName)
-      -> llvm::Value*;
+  /** LLVM global for a static field; uses the class template symbol when \p classTy is specialized.
+   */
+  [[nodiscard]] auto llvmGlobalForClassStaticField(lesma::Type* classTy,
+                                                   const std::string& fieldName) -> llvm::Value*;
   auto defineFunction(lesma::Value* value, const FuncDecl* node, Value* clsSymbol) -> void;
   auto declareSynthesizedClassConstructor(const Class* astNode, lesma::Type* classType,
                                           lesma::Value* classStructSym) -> lesma::Value*;
@@ -418,9 +418,10 @@ protected:
       -> lesma::Value*;
   auto defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) -> void;
   [[nodiscard]] auto getFuncValuePairLlvmType() -> llvm::StructType*;
-  auto specializeClass(const Class* node, const std::vector<lesma::Type*>& constructorArgTypes,
-                       const std::vector<lesma::Type*>& explicitTypeArgs = {},
-                       const std::unordered_map<std::string, lesma::Type*>* prebuiltClassEnv = nullptr)
+  auto
+  specializeClass(const Class* node, const std::vector<lesma::Type*>& constructorArgTypes,
+                  const std::vector<lesma::Type*>& explicitTypeArgs = {},
+                  const std::unordered_map<std::string, lesma::Type*>* prebuiltClassEnv = nullptr)
       -> lesma::Value*;
   auto emitClassMonomorph(lesma::Type* specialized, const Class* templateAst) -> lesma::Value*;
   [[nodiscard]] auto wrapNominalReturnAsPointer(Type* t) -> Type*;
@@ -558,6 +559,14 @@ protected:
   auto typeWithSingletonUnionsCollapsed(lesma::Type* t) -> lesma::Type*;
 
 private:
+  [[nodiscard]] auto classStaticFieldGlobalName(lesma::Type* classTy, const std::string& fieldName,
+                                                llvm::SMRange reportSpan) const -> std::string;
+  [[nodiscard]] auto llvmStorageTypeForClassStaticField(lesma::Type* fieldTy, Value* fieldSym)
+      -> llvm::Type*;
+  [[nodiscard]] auto materializeClassStaticFieldGlobalInCurrentModule(lesma::Type* templateClassTy,
+                                                                      Field* tf)
+      -> llvm::GlobalVariable*;
+
   /** Minimum tag bits: ceil(log2(memberCount)), at least 1 (memberCount must be > 0). */
   [[nodiscard]] static auto unionDiscriminantMinBits(std::size_t memberCount) -> unsigned;
   /** Round up to a whole number of bytes (8, 16, 32, 64); 0 if \p minBits > 64. */

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -381,6 +381,9 @@ protected:
                         const FuncCall* callSiteForGenericEnv = nullptr)
       -> std::unique_ptr<lesma::Value>;
   auto emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* astNode) -> void;
+  /** LLVM global for a static field; uses the class template symbol when \p classTy is specialized. */
+  [[nodiscard]] auto llvmGlobalForClassStaticField(lesma::Type* classTy, const std::string& fieldName)
+      -> llvm::Value*;
   auto defineFunction(lesma::Value* value, const FuncDecl* node, Value* clsSymbol) -> void;
   auto declareSynthesizedClassConstructor(const Class* astNode, lesma::Type* classType,
                                           lesma::Value* classStructSym) -> lesma::Value*;

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -56,6 +56,7 @@ using MainFnTy = int();
 class Class;
 class TraitDecl;
 class FuncDecl;
+class FuncCall;
 class LambdaExpr;
 
 struct ImportedSpecializationState {
@@ -376,7 +377,9 @@ protected:
   auto callMethodByName(llvm::SMRange span, lesma::Value* receiver, const std::string& methodName,
                         const std::vector<lesma::Value*>& args = {},
                         const std::vector<lesma::Type*>& explicitTypeArgs = {},
-                        lesma::Value* resolvedCallee = nullptr) -> std::unique_ptr<lesma::Value>;
+                        lesma::Value* resolvedCallee = nullptr,
+                        const FuncCall* callSiteForGenericEnv = nullptr)
+      -> std::unique_ptr<lesma::Value>;
   auto emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* astNode) -> void;
   auto defineFunction(lesma::Value* value, const FuncDecl* node, Value* clsSymbol) -> void;
   auto declareSynthesizedClassConstructor(const Class* astNode, lesma::Type* classType,
@@ -413,7 +416,9 @@ protected:
   auto defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) -> void;
   [[nodiscard]] auto getFuncValuePairLlvmType() -> llvm::StructType*;
   auto specializeClass(const Class* node, const std::vector<lesma::Type*>& constructorArgTypes,
-                       const std::vector<lesma::Type*>& explicitTypeArgs = {}) -> lesma::Value*;
+                       const std::vector<lesma::Type*>& explicitTypeArgs = {},
+                       const std::unordered_map<std::string, lesma::Type*>* prebuiltClassEnv = nullptr)
+      -> lesma::Value*;
   auto emitClassMonomorph(lesma::Type* specialized, const Class* templateAst) -> lesma::Value*;
   [[nodiscard]] auto wrapNominalReturnAsPointer(Type* t) -> Type*;
   /** Match `super` callee receiver type (mirrors Typechecker::superMethodReceiverMatchesFormal). */

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -375,8 +375,9 @@ protected:
       -> std::unique_ptr<lesma::Value>;
   auto callMethodByName(llvm::SMRange span, lesma::Value* receiver, const std::string& methodName,
                         const std::vector<lesma::Value*>& args = {},
-                        const std::vector<lesma::Type*>& explicitTypeArgs = {})
-      -> std::unique_ptr<lesma::Value>;
+                        const std::vector<lesma::Type*>& explicitTypeArgs = {},
+                        lesma::Value* resolvedCallee = nullptr) -> std::unique_ptr<lesma::Value>;
+  auto emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* astNode) -> void;
   auto defineFunction(lesma::Value* value, const FuncDecl* node, Value* clsSymbol) -> void;
   auto declareSynthesizedClassConstructor(const Class* astNode, lesma::Type* classType,
                                           lesma::Value* classStructSym) -> lesma::Value*;

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -121,6 +121,9 @@ class Codegen final : public ASTVisitor {
   std::unordered_map<std::string, std::unordered_map<std::string, const FuncDecl*>> genericMethods;
   std::unordered_map<std::string, const Class*> genericClasses;
   std::unordered_map<std::string, lesma::Type*> currentGenericTypes;
+  /** Stack of call-site binding maps for `getOrCreateLlvmType` when `currentGenericTypes` is empty
+   * (e.g. `Cell.of(7)` nested inside `main`). */
+  std::vector<const std::unordered_map<std::string, lesma::Type*>*> genericTypeFallbackStack;
   std::unordered_map<std::string, lesma::Value*> specializedFunctions;
   std::unordered_map<std::string, lesma::Value*> specializedClasses;
   std::unordered_map<lesma::Type*, lesma::Value*> specializedClassSymbolsByType;
@@ -495,6 +498,9 @@ protected:
 
   /** Ensure \p type has an LLVM type (fill in when from typechecker). */
   auto getOrCreateLlvmType(lesma::Type* type) -> llvm::Type*;
+  auto pushGenericTypeFallback(const std::unordered_map<std::string, lesma::Type*>* env) -> void;
+  auto popGenericTypeFallback() -> void;
+  [[nodiscard]] auto lookupGenericTypeFallback(const std::string& name) const -> lesma::Type*;
   /** LLVM integer tag type for \c TY_UNION (first struct field); requires \p unionTy to be a union.
    */
   [[nodiscard]] auto getOrCreateUnionTagLlvmType(lesma::Type* unionTy) -> llvm::Type*;

--- a/src/liblesma/Backend/CodegenPipeline.cpp
+++ b/src/liblesma/Backend/CodegenPipeline.cpp
@@ -647,10 +647,34 @@ auto Codegen::run() -> void {
         }
       }
     }
-    // Prototypes store the owning class symbol in slot 2. Instance methods get `self` as the first
-    // LLVM parameter, but static methods do not—yet nested codegen (e.g. `Cell(v)` inside
-    // `static func of`) still needs that symbol on `selfSymbol` so constructor lookup and
-    // `genericBindingHint`-driven paths in `callNamedFunction` see the monomorphized class.
+    // `specializationEnvs` may only store a function's own generic parameters; merge class type
+    // params (e.g. `T` on `Cell<T>`) from the formal receiver (`self` or `cls`) for method bodies.
+    Type* mergeClassTy = nullptr;
+    if (auto* clsSym = std::get<2>(prototypes[pi]);
+        clsSym != nullptr && clsSym->getType() != nullptr && clsSym->getType()->is(BaseType::TY_PTR) &&
+        clsSym->getType()->getElementType() != nullptr) {
+      mergeClassTy = clsSym->getType()->getElementType();
+    }
+    if (mergeClassTy == nullptr) {
+      auto fields = fn->getType()->getFields();
+      if (!fields.empty() && fields.front()->type != nullptr &&
+          fields.front()->type->is(BaseType::TY_PTR) &&
+          fields.front()->type->getElementType() != nullptr) {
+        mergeClassTy = fields.front()->type->getElementType();
+      }
+    }
+    if (mergeClassTy != nullptr) {
+      if (auto clsEnv = specializedClassTypeEnvs.find(mergeClassTy);
+          clsEnv != specializedClassTypeEnvs.end()) {
+        for (const auto& kv : clsEnv->second) {
+          currentGenericTypes[kv.first] = kv.second;
+        }
+      }
+    }
+    // Prototypes store the owning class symbol in slot 2. Instance methods use `self` as the first
+    // LLVM parameter; static methods use `cls` for overload identity—nested codegen still needs
+    // `selfSymbol` set to the owning class so constructor lookup and `genericBindingHint` paths in
+    // `callNamedFunction` see the monomorphized class.
     if (auto* cls = std::get<2>(prototypes[pi]); cls != nullptr) {
       selfSymbol = cls;
     }

--- a/src/liblesma/Backend/CodegenPipeline.cpp
+++ b/src/liblesma/Backend/CodegenPipeline.cpp
@@ -625,6 +625,7 @@ auto Codegen::run() -> void {
   for (size_t pi = 0; pi < prototypes.size(); ++pi) {
     auto* fn = std::get<0>(prototypes[pi]);
     auto savedGenerics = currentGenericTypes;
+    auto* savedSelfForFnBody = selfSymbol;
     if (auto env = specializationEnvs.find(fn); env != specializationEnvs.end()) {
       currentGenericTypes = env->second;
     } else if (auto* cls = std::get<2>(prototypes[pi]);
@@ -646,7 +647,15 @@ auto Codegen::run() -> void {
         }
       }
     }
+    // Prototypes store the owning class symbol in slot 2. Instance methods get `self` as the first
+    // LLVM parameter, but static methods do not—yet nested codegen (e.g. `Cell(v)` inside
+    // `static func of`) still needs that symbol on `selfSymbol` so constructor lookup and
+    // `genericBindingHint`-driven paths in `callNamedFunction` see the monomorphized class.
+    if (auto* cls = std::get<2>(prototypes[pi]); cls != nullptr) {
+      selfSymbol = cls;
+    }
     defineFunction(fn, std::get<1>(prototypes[pi]), std::get<2>(prototypes[pi]));
+    selfSymbol = savedSelfForFnBody;
     currentGenericTypes = std::move(savedGenerics);
   }
 

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -720,8 +720,8 @@ auto Codegen::specializeFunction(
       getOrCreateLlvmType(explicitTypeArg);
     }
   }
-  std::string key =
-      getMangledName(node->getSpan(), node->getName(), paramTypes, selfSymbol != nullptr);
+  std::string key = getMangledName(node->getSpan(), node->getName(), paramTypes,
+                                   selfSymbol != nullptr && !node->getIsStatic());
   appendGenericBindingSuffix(node->getSpan(), key, genericNames, env);
   if (auto it = specializedFunctions.find(key); it != specializedFunctions.end()) {
     currentGenericTypes = std::move(saved);
@@ -730,7 +730,7 @@ auto Codegen::specializeFunction(
 
   std::vector<std::unique_ptr<Field>> fields;
   std::vector<lesma::Type*> concreteParamTypes;
-  if (selfSymbol != nullptr) {
+  if (selfSymbol != nullptr && !node->getIsStatic()) {
     Type* selfType = selfSymbol->getType();
     if (selfType != nullptr && selfType->is(BaseType::TY_CLASS)) {
       selfType = cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, selfType));
@@ -760,8 +760,8 @@ auto Codegen::specializeFunction(
   funcType->setReturnType(returnType);
   funcType->setVarArgs(node->getVarArgs());
   auto* typePtr = cacheType(std::move(funcType));
-  auto mangledName =
-      getMangledName(node->getSpan(), node->getName(), concreteParamTypes, selfSymbol != nullptr);
+  auto mangledName = getMangledName(node->getSpan(), node->getName(), concreteParamTypes,
+                                     selfSymbol != nullptr && !node->getIsStatic());
   appendGenericBindingSuffix(node->getSpan(), mangledName, genericNames, env);
   const bool specializationKeysMatch = (mangledName == key);
   auto func = std::make_unique<Value>(node->getName(), typePtr);
@@ -773,6 +773,7 @@ auto Codegen::specializeFunction(
     func->setDeclarationKind(selfSymbol != nullptr ? ValueDeclarationKind::METHOD
                                                    : ValueDeclarationKind::FUNCTION);
   }
+  func->setStaticMethod(node->getIsStatic());
   func->setMangledName(mangledName);
   func->setExported(node->isExported());
   auto linkage = node->isExported() ? Function::ExternalLinkage : Function::PrivateLinkage;
@@ -993,6 +994,9 @@ auto Codegen::specializeClass(const Class* node,
   if (!constructorEnvResolved && needsConstructorInference && constructorDecl == nullptr) {
     std::vector<VarDecl*> requiredFields;
     for (VarDecl* fd : node->getFields()) {
+      if (fd->getIsStatic()) {
+        continue;
+      }
       if (fd->getValue() == nullptr) {
         requiredFields.push_back(fd);
       }
@@ -1126,6 +1130,9 @@ auto Codegen::specializeClass(const Class* node,
     }
   } else {
     for (auto* field : node->getFields()) {
+      if (field->getIsStatic()) {
+        continue;
+      }
       if (field->getType() != nullptr) {
         field->getType()->accept(*this);
       } else {

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -920,7 +920,9 @@ auto Codegen::specializeLambda(const LambdaExpr* node, const std::vector<lesma::
 
 auto Codegen::specializeClass(const Class* node,
                               const std::vector<lesma::Type*>& constructorArgTypes,
-                              const std::vector<lesma::Type*>& explicitTypeArgs) -> lesma::Value* {
+                              const std::vector<lesma::Type*>& explicitTypeArgs,
+                              const std::unordered_map<std::string, lesma::Type*>* prebuiltClassEnv)
+    -> lesma::Value* {
   auto genericNames = node->getGenericParams();
 
   const FuncDecl* constructorDecl = nullptr;
@@ -932,7 +934,19 @@ auto Codegen::specializeClass(const Class* node,
   }
 
   std::unordered_map<std::string, lesma::Type*> env;
-  if (!explicitTypeArgs.empty()) {
+  std::unordered_set<std::string> genericNameSet(genericNames.begin(), genericNames.end());
+
+  if (prebuiltClassEnv != nullptr) {
+    env = *prebuiltClassEnv;
+    for (const auto& gn : genericNames) {
+      auto it = env.find(gn);
+      if (it == env.end() || it->second == nullptr) {
+        throw CodegenError(node->getSpan(),
+                           "Internal error: incomplete specialization env for class {} parameter {}",
+                           node->getIdentifier(), gn);
+      }
+    }
+  } else if (!explicitTypeArgs.empty()) {
     if (explicitTypeArgs.size() != genericNames.size()) {
       throw CodegenError(node->getSpan(),
                          "Explicit type argument count {} does not match generic class parameter "
@@ -942,8 +956,15 @@ auto Codegen::specializeClass(const Class* node,
     for (size_t i = 0; i < genericNames.size(); ++i) {
       env[genericNames[i]] = explicitTypeArgs[i];
     }
-  }
-  std::unordered_set<std::string> genericNameSet(genericNames.begin(), genericNames.end());
+    for (const auto& gn : genericNames) {
+      if (!env.contains(gn)) {
+        throw CodegenError(node->getSpan(),
+                           "Generic class {} requires type arguments for all parameters; "
+                           "could not infer {} from constructor",
+                           node->getIdentifier(), gn);
+      }
+    }
+  } else {
   const bool needsConstructorInference = explicitTypeArgs.empty();
   bool constructorEnvResolved = false;
   if (needsConstructorInference && constructorDecl != nullptr) {
@@ -1023,6 +1044,7 @@ auto Codegen::specializeClass(const Class* node,
                          "could not infer {} from constructor",
                          node->getIdentifier(), gn);
     }
+  }
   }
 
   auto envIsFullyConcrete =

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -674,7 +674,7 @@ auto Codegen::computeGenericFunctionBindingEnv(const FuncDecl* node,
   }
   std::unordered_set<std::string> genericNameSet(genericNames.begin(), genericNames.end());
   auto templateParams = node->getParameters();
-  size_t offset = (selfSymbol != nullptr) ? 1U : 0U;
+  size_t offset = (selfSymbol != nullptr && !node->getIsStatic()) ? 1U : 0U;
   for (size_t i = 0; i < templateParams.size() && (i + offset) < paramTypes.size(); ++i) {
     TypeExpr* declType = templateParams[i]->type.get();
     if (declType != nullptr) {

--- a/src/liblesma/Backend/CodegenSpecialize.cpp
+++ b/src/liblesma/Backend/CodegenSpecialize.cpp
@@ -731,12 +731,12 @@ auto Codegen::specializeFunction(
   std::vector<std::unique_ptr<Field>> fields;
   std::vector<lesma::Type*> concreteParamTypes;
   if (selfSymbol != nullptr && !node->getIsStatic()) {
-    Type* selfType = selfSymbol->getType();
-    if (selfType != nullptr && selfType->is(BaseType::TY_CLASS)) {
-      selfType = cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, selfType));
+    Type* recvType = selfSymbol->getType();
+    if (recvType != nullptr && recvType->is(BaseType::TY_CLASS)) {
+      recvType = cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, recvType));
     }
-    fields.push_back(std::make_unique<Field>("self", selfType));
-    concreteParamTypes.push_back(selfType);
+    fields.push_back(std::make_unique<Field>("self", recvType));
+    concreteParamTypes.push_back(recvType);
   }
   for (auto* param : node->getParameters()) {
     param->type->accept(*this);
@@ -761,7 +761,7 @@ auto Codegen::specializeFunction(
   funcType->setVarArgs(node->getVarArgs());
   auto* typePtr = cacheType(std::move(funcType));
   auto mangledName = getMangledName(node->getSpan(), node->getName(), concreteParamTypes,
-                                     selfSymbol != nullptr && !node->getIsStatic());
+                                    selfSymbol != nullptr && !node->getIsStatic());
   appendGenericBindingSuffix(node->getSpan(), mangledName, genericNames, env);
   const bool specializationKeysMatch = (mangledName == key);
   auto func = std::make_unique<Value>(node->getName(), typePtr);

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -248,6 +248,32 @@ auto Codegen::visit(const TypeExpr* node) -> void {
   }
 }
 
+auto Codegen::pushGenericTypeFallback(const std::unordered_map<std::string, lesma::Type*>* env)
+    -> void {
+  if (env != nullptr && !env->empty()) {
+    genericTypeFallbackStack.push_back(env);
+  }
+}
+
+auto Codegen::popGenericTypeFallback() -> void {
+  if (!genericTypeFallbackStack.empty()) {
+    genericTypeFallbackStack.pop_back();
+  }
+}
+
+auto Codegen::lookupGenericTypeFallback(const std::string& name) const -> lesma::Type* {
+  for (auto it = genericTypeFallbackStack.rbegin(); it != genericTypeFallbackStack.rend(); ++it) {
+    if (*it == nullptr) {
+      continue;
+    }
+    auto found = (*it)->find(name);
+    if (found != (*it)->end()) {
+      return found->second;
+    }
+  }
+  return nullptr;
+}
+
 auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
   if (type->getLlvmType() != nullptr) {
     return type->getLlvmType();
@@ -256,6 +282,9 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
   case BaseType::TY_GENERIC: {
     auto it = currentGenericTypes.find(type->getGenericName());
     if (it == currentGenericTypes.end()) {
+      if (lesma::Type* fb = lookupGenericTypeFallback(type->getGenericName()); fb != nullptr) {
+        return getOrCreateLlvmType(fb);
+      }
       throw CodegenError({}, "Unknown generic type {}", type->getGenericName());
     }
     return getOrCreateLlvmType(it->second);

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -2374,6 +2374,9 @@ auto Codegen::visit(const Class* node) -> void {
     auto* genericSymbol = scope->lookupStruct(node->getIdentifier());
     if (genericSymbol != nullptr) {
       genericSymbol->setGenericClassTemplate(node);
+      if (genericSymbol->getType() != nullptr) {
+        emitClassStaticFieldGlobals(genericSymbol->getType(), node);
+      }
     }
     return;
   }
@@ -2464,8 +2467,18 @@ auto Codegen::emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* ast
                fieldTy->getElementType()->is(BaseType::TY_CLASS)) {
       storageTy = builder->getPtrTy();
     }
-    std::string const gvName = std::string{"lesma.sfs."} +
-                               MangleUtils::getTypeMangledName(span, classTy) + "." + sym->getName();
+    std::string classManglePart;
+    if (classTy->is(BaseType::TY_CLASS) && !classTy->getGenericParams().empty()) {
+      std::string const& dn = classTy->getDisplayName();
+      if (dn.empty()) {
+        throw CodegenError(span, "Internal error: generic class template missing display name");
+      }
+      classManglePart = "(tmpl_" + dn + ")";
+    } else {
+      classManglePart = MangleUtils::getTypeMangledName(span, classTy);
+    }
+    std::string const gvName =
+        std::string{"lesma.sfs."} + classManglePart + "." + sym->getName();
     if (theModule->getGlobalVariable(gvName, true) != nullptr) {
       continue;
     }
@@ -2480,6 +2493,21 @@ auto Codegen::emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* ast
       builder->CreateStore(rhs->getLlvmValue(), gv);
     }
   }
+}
+
+auto Codegen::llvmGlobalForClassStaticField(lesma::Type* classTy, const std::string& fieldName)
+    -> llvm::Value* {
+  // Globals are emitted once on the class template; specialized codegen shells may omit static
+  // Field entries, so always resolve storage from the template type.
+  Type* templateTy = classTy;
+  if (auto it = specializedClassTemplateOf.find(classTy); it != specializedClassTemplateOf.end()) {
+    templateTy = it->second;
+  }
+  Field* tf = TypeUtils::findStaticFieldInClass(templateTy, fieldName);
+  if (tf == nullptr || tf->getDeclarationSymbol() == nullptr) {
+    return nullptr;
+  }
+  return tf->getDeclarationSymbol()->getLlvmValue();
 }
 
 auto Codegen::visit(const Enum* node) -> void {
@@ -3407,9 +3435,14 @@ auto Codegen::visit(const DotOp* node) -> void {
       if (leftValue->getCategory() == ValueCategory::TYPE_SYMBOL) {
         if (!field.empty()) {
           Field* sf = TypeUtils::findStaticFieldInClass(receiverType, field);
+          if (sf == nullptr) {
+            if (auto it = specializedClassTemplateOf.find(receiverType);
+                it != specializedClassTemplateOf.end()) {
+              sf = TypeUtils::findStaticFieldInClass(it->second, field);
+            }
+          }
           if (sf != nullptr) {
-            Value* declSym = sf->getDeclarationSymbol();
-            llvm::Value* gv = declSym != nullptr ? declSym->getLlvmValue() : nullptr;
+            llvm::Value* gv = llvmGlobalForClassStaticField(receiverType, field);
             if (gv == nullptr) {
               throw CodegenError(node->getSpan(), "Static field {} has no lowered storage", field);
             }
@@ -3689,9 +3722,14 @@ auto Codegen::visit(const DotOp* node) -> void {
         if (result->getCategory() == ValueCategory::TYPE_SYMBOL) {
           if (!field.empty()) {
             Field* sf = TypeUtils::findStaticFieldInClass(lesmaType, field);
+            if (sf == nullptr) {
+              if (auto it = specializedClassTemplateOf.find(lesmaType);
+                  it != specializedClassTemplateOf.end()) {
+                sf = TypeUtils::findStaticFieldInClass(it->second, field);
+              }
+            }
             if (sf != nullptr) {
-              Value* declSym = sf->getDeclarationSymbol();
-              llvm::Value* gv = declSym != nullptr ? declSym->getLlvmValue() : nullptr;
+              llvm::Value* gv = llvmGlobalForClassStaticField(lesmaType, field);
               if (gv == nullptr) {
                 throw CodegenError(node->getSpan(), "Static field {} has no lowered storage", field);
               }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -254,6 +254,10 @@ Codegen::Codegen(
 
 auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* clsSymbol) -> void {
   bool const isMethod = value->getDeclarationKind() == ValueDeclarationKind::METHOD;
+  auto const fieldsForParams = value->getType()->getFields();
+  bool const usesImplicitSelfParam =
+      isMethod && !value->isStaticMethod() && !fieldsForParams.empty() &&
+      fieldsForParams.front()->name == "self";
   if (clsSymbol == nullptr && isMethod) {
     auto fields = value->getType()->getFields();
     if (!fields.empty() && fields.front()->type != nullptr &&
@@ -273,7 +277,9 @@ auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* c
     scope = savedScope->createChildBlock(node->getName() + ".specialized");
     std::vector<std::string> paramNames;
     paramNames.reserve(node->getParameters().size() + 1U);
-    paramNames.push_back("self");
+    if (usesImplicitSelfParam) {
+      paramNames.push_back("self");
+    }
     for (auto* param : node->getParameters()) {
       paramNames.push_back(param->name);
     }
@@ -333,7 +339,7 @@ auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* c
     if (field->name == "self") {
       paramName = "self";
     } else {
-      size_t const paramIndex = param->getArgNo() - (isMethod ? 1U : 0U);
+      size_t const paramIndex = param->getArgNo() - (usesImplicitSelfParam ? 1U : 0U);
       if (paramIndex < node->getParameters().size()) {
         paramName = node->getParameters()[paramIndex]->name;
       } else {
@@ -611,6 +617,14 @@ namespace {
       if (typeContainsUnboundGenericImpl(f->type, active)) {
         any = true;
         break;
+      }
+    }
+    if (!any) {
+      for (Field* f : type->getStaticFields()) {
+        if (typeContainsUnboundGenericImpl(f->type, active)) {
+          any = true;
+          break;
+        }
       }
     }
     active.erase(type);
@@ -1334,7 +1348,7 @@ auto Codegen::visit(const ForIn* node) -> void {
 auto Codegen::buildClassMethodParamTypesForLookup(const FuncDecl* node)
     -> std::vector<lesma::Type*> {
   std::vector<lesma::Type*> paramTypes;
-  if (selfSymbol != nullptr) {
+  if (selfSymbol != nullptr && !node->getIsStatic()) {
     paramTypes.push_back(selfSymbol->getType());
   }
   for (auto* param : node->getParameters()) {
@@ -1382,6 +1396,9 @@ auto Codegen::declareSynthesizedClassConstructor(const Class* astNode, lesma::Ty
   std::vector<Field*> const typeFields = classType->getFields();
   size_t ti = 0;
   for (VarDecl* v : astNode->getFields()) {
+    if (v->getIsStatic()) {
+      continue;
+    }
     if (ti >= typeFields.size()) {
       break;
     }
@@ -1449,6 +1466,9 @@ auto Codegen::declareSynthesizedClassConstructor(const Class* astNode, lesma::Ty
     bodyScope->insertSymbol(std::move(selfPs));
     unsigned reqIdx = 0;
     for (VarDecl* v : astNode->getFields()) {
+      if (v->getIsStatic()) {
+        continue;
+      }
       if (v->getValue() != nullptr) {
         continue;
       }
@@ -1605,6 +1625,9 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
   std::vector<Field*> const layoutFields = classType->getFields();
   size_t layoutIdx = 0;
   for (VarDecl* v : astNode->getFields()) {
+    if (v->getIsStatic()) {
+      continue;
+    }
     if (layoutIdx >= layoutFields.size()) {
       break;
     }
@@ -1793,7 +1816,7 @@ auto Codegen::visit(const FuncDecl* node) -> void {
   std::vector<llvm::Type*> paramLLVMTypes;
   bool shouldExport = node->isExported();
 
-  if (selfSymbol != nullptr) {
+  if (selfSymbol != nullptr && !node->getIsStatic()) {
     paramTypes.push_back(selfSymbol->getType());
     paramLLVMTypes.push_back(builder->getPtrTy());
     fields.push_back(std::make_unique<Field>("self", selfSymbol->getType()));
@@ -1887,8 +1910,8 @@ auto Codegen::visit(const FuncDecl* node) -> void {
     return;
   }
 
-  auto mangledName =
-      getMangledName(node->getSpan(), node->getName(), paramTypes, selfSymbol != nullptr);
+  auto mangledName = getMangledName(node->getSpan(), node->getName(), paramTypes,
+                                     selfSymbol != nullptr && !node->getIsStatic());
   std::string signatureKey = makeCallableSignatureKey(node->getName(), paramTypes);
   if (!currentGenericTypes.empty()) {
     std::vector<std::string> bindingOrder;
@@ -1948,6 +1971,7 @@ auto Codegen::visit(const FuncDecl* node) -> void {
     existingFunc->setMangledName(mangledName);
     existingFunc->setDeclarationKind(selfSymbol != nullptr ? ValueDeclarationKind::METHOD
                                                            : ValueDeclarationKind::FUNCTION);
+    existingFunc->setStaticMethod(node->getIsStatic());
     if (templateFuncSymbol != nullptr && existingFunc->getBodyScope() == nullptr) {
       existingFunc->setBodyScope(templateFuncSymbol->getBodyScope());
     }
@@ -1965,6 +1989,7 @@ auto Codegen::visit(const FuncDecl* node) -> void {
   funcSymbol->setCategory(ValueCategory::CALLABLE_SYMBOL);
   funcSymbol->setDeclarationKind(selfSymbol != nullptr ? ValueDeclarationKind::METHOD
                                                        : ValueDeclarationKind::FUNCTION);
+  funcSymbol->setStaticMethod(node->getIsStatic());
   funcSymbol->setExported(node->isExported());
   funcSymbol->setMangledName(mangledName);
   if (templateFuncSymbol != nullptr) {
@@ -2368,6 +2393,8 @@ auto Codegen::visit(const Class* node) -> void {
     getOrCreateLlvmType(type);
   }
 
+  emitClassStaticFieldGlobals(type, node);
+
   auto* selfType = cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), type));
   methodSelfSymbols.push_back(std::make_unique<Value>(node->getIdentifier(), selfType));
   methodSelfSymbols.back()->setExported(node->isExported());
@@ -2413,6 +2440,46 @@ auto Codegen::visit(const Class* node) -> void {
   getOrEmitClassVtableGlobal(type, node);
 
   selfSymbol = nullptr;
+}
+
+auto Codegen::emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* astNode) -> void {
+  if (classTy == nullptr || astNode == nullptr) {
+    return;
+  }
+  llvm::SMRange const span = astNode->getSpan();
+  for (VarDecl* vd : astNode->getFields()) {
+    if (!vd->getIsStatic()) {
+      continue;
+    }
+    Value* sym = vd->getResolvedSymbol();
+    if (sym == nullptr) {
+      continue;
+    }
+    lesma::Type* fieldTy = sym->getType();
+    getOrCreateLlvmType(fieldTy);
+    llvm::Type* storageTy = fieldTy->getLlvmType();
+    if (fieldTy->is(BaseType::TY_CLASS)) {
+      storageTy = builder->getPtrTy();
+    } else if (fieldTy->is(BaseType::TY_PTR) && fieldTy->getElementType() != nullptr &&
+               fieldTy->getElementType()->is(BaseType::TY_CLASS)) {
+      storageTy = builder->getPtrTy();
+    }
+    std::string const gvName = std::string{"lesma.sfs."} +
+                               MangleUtils::getTypeMangledName(span, classTy) + "." + sym->getName();
+    if (theModule->getGlobalVariable(gvName, true) != nullptr) {
+      continue;
+    }
+    llvm::Constant* init = llvm::Constant::getNullValue(storageTy);
+    auto* gv = new llvm::GlobalVariable(*theModule, storageTy, false,
+                                         llvm::GlobalValue::PrivateLinkage, init, gvName);
+    sym->setLlvmValue(gv);
+    sym->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+    if (vd->getValue() != nullptr) {
+      vd->getValue()->accept(*this);
+      auto rhs = cast(vd->getValue()->getSpan(), result.get(), fieldTy);
+      builder->CreateStore(rhs->getLlvmValue(), gv);
+    }
+  }
 }
 
 auto Codegen::visit(const Enum* node) -> void {
@@ -3301,7 +3368,7 @@ auto Codegen::visit(const DotOp* node) -> void {
       }
       setDebugLoc(node->getSpan());
       result = callMethodByName(node->getSpan(), leftValue.get(), call->getName(), args,
-                                explicitTypeArgs);
+                                explicitTypeArgs, call->getResolvedSymbol());
       return;
     }
   }
@@ -3336,6 +3403,64 @@ auto Codegen::visit(const DotOp* node) -> void {
         throw CodegenError(node->getLeft()->getSpan(), "Cannot find related class {}",
                            receiverType->getDisplayName().empty() ? "(unknown)"
                                                                   : receiverType->getDisplayName());
+      }
+      if (leftValue->getCategory() == ValueCategory::TYPE_SYMBOL) {
+        if (!field.empty()) {
+          Field* sf = TypeUtils::findStaticFieldInClass(receiverType, field);
+          if (sf != nullptr) {
+            Value* declSym = sf->getDeclarationSymbol();
+            llvm::Value* gv = declSym != nullptr ? declSym->getLlvmValue() : nullptr;
+            if (gv == nullptr) {
+              throw CodegenError(node->getSpan(), "Static field {} has no lowered storage", field);
+            }
+            lesma::Type* ft = sf->type;
+            getOrCreateLlvmType(ft);
+            if (isAssignment) {
+              lesma::Type* ptrToVal = ft;
+              if (ft->is(BaseType::TY_CLASS)) {
+                ptrToVal = cacheType(
+                    std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
+              } else if (ft->is(BaseType::TY_PTR) && ft->getElementType() != nullptr &&
+                         ft->getElementType()->is(BaseType::TY_CLASS)) {
+                ptrToVal = cacheType(
+                    std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
+              }
+              result = std::make_unique<Value>("", ptrToVal, gv);
+              return;
+            }
+            llvm::Type* storageTy = ft->getLlvmType();
+            if (ft->is(BaseType::TY_CLASS)) {
+              storageTy = builder->getPtrTy();
+            } else if (ft->is(BaseType::TY_PTR) && ft->getElementType() != nullptr &&
+                       ft->getElementType()->is(BaseType::TY_CLASS)) {
+              storageTy = builder->getPtrTy();
+            }
+            result = std::make_unique<Value>("", ft, builder->CreateLoad(storageTy, gv));
+            return;
+          }
+          throw CodegenError(node->getRight()->getSpan(), "Unknown static field {} for class {}",
+                             field, receiverType->getDisplayName());
+        }
+        if (method != nullptr) {
+          auto recvHolder =
+              std::make_unique<lesma::Value>("", receiverType, static_cast<llvm::Value*>(nullptr));
+          std::vector<std::unique_ptr<lesma::Value>> argStorage;
+          std::vector<lesma::Value*> args;
+          for (auto* arg : method->getArguments()) {
+            arg->accept(*this);
+            argStorage.push_back(std::move(result));
+            args.push_back(argStorage.back().get());
+          }
+          std::vector<lesma::Type*> explicitTypeArgs;
+          for (auto* ta : method->getExplicitTypeArgs()) {
+            ta->accept(*this);
+            explicitTypeArgs.push_back(result->getType());
+          }
+          setDebugLoc(node->getSpan());
+          result = callMethodByName(node->getSpan(), recvHolder.get(), method->getName(), args,
+                                    explicitTypeArgs, method->getResolvedSymbol());
+          return;
+        }
       }
       if (!field.empty()) {
         auto index = TypeUtils::findIndexInFields(cls->getType(), field);
@@ -3382,7 +3507,7 @@ auto Codegen::visit(const DotOp* node) -> void {
         }
         setDebugLoc(node->getSpan());
         result = callMethodByName(node->getSpan(), receiverValue.get(), method->getName(), args,
-                                  explicitTypeArgs);
+                                  explicitTypeArgs, method->getResolvedSymbol());
         return;
       }
     }
@@ -3561,6 +3686,64 @@ auto Codegen::visit(const DotOp* node) -> void {
                        : lesmaType->getDisplayName());
 
       if (cls->getType()->is(BaseType::TY_CLASS)) {
+        if (result->getCategory() == ValueCategory::TYPE_SYMBOL) {
+          if (!field.empty()) {
+            Field* sf = TypeUtils::findStaticFieldInClass(lesmaType, field);
+            if (sf != nullptr) {
+              Value* declSym = sf->getDeclarationSymbol();
+              llvm::Value* gv = declSym != nullptr ? declSym->getLlvmValue() : nullptr;
+              if (gv == nullptr) {
+                throw CodegenError(node->getSpan(), "Static field {} has no lowered storage", field);
+              }
+              lesma::Type* ft = sf->type;
+              getOrCreateLlvmType(ft);
+              if (isAssignment) {
+                lesma::Type* ptrToVal = ft;
+                if (ft->is(BaseType::TY_CLASS)) {
+                  ptrToVal = cacheType(
+                      std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
+                } else if (ft->is(BaseType::TY_PTR) && ft->getElementType() != nullptr &&
+                           ft->getElementType()->is(BaseType::TY_CLASS)) {
+                  ptrToVal = cacheType(
+                      std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
+                }
+                result = std::make_unique<Value>("", ptrToVal, gv);
+                return;
+              }
+              llvm::Type* storageTy = ft->getLlvmType();
+              if (ft->is(BaseType::TY_CLASS)) {
+                storageTy = builder->getPtrTy();
+              } else if (ft->is(BaseType::TY_PTR) && ft->getElementType() != nullptr &&
+                         ft->getElementType()->is(BaseType::TY_CLASS)) {
+                storageTy = builder->getPtrTy();
+              }
+              result = std::make_unique<Value>("", ft, builder->CreateLoad(storageTy, gv));
+              return;
+            }
+            throw CodegenError(node->getRight()->getSpan(), "Unknown static field {} for class {}",
+                               field, lesmaType->getDisplayName());
+          }
+          if (method != nullptr) {
+            auto recvHolder =
+                std::make_unique<lesma::Value>("", lesmaType, static_cast<llvm::Value*>(nullptr));
+            std::vector<std::unique_ptr<lesma::Value>> argStorage;
+            std::vector<lesma::Value*> args;
+            for (auto* arg : method->getArguments()) {
+              arg->accept(*this);
+              argStorage.push_back(std::move(result));
+              args.push_back(argStorage.back().get());
+            }
+            std::vector<lesma::Type*> explicitTypeArgs;
+            for (auto* ta : method->getExplicitTypeArgs()) {
+              ta->accept(*this);
+              explicitTypeArgs.push_back(result->getType());
+            }
+            setDebugLoc(node->getSpan());
+            result = callMethodByName(node->getSpan(), recvHolder.get(), method->getName(), args,
+                                      explicitTypeArgs, method->getResolvedSymbol());
+            return;
+          }
+        }
         if (!field.empty()) {
           auto index = TypeUtils::findIndexInFields(cls->getType(), field);
           auto* type = TypeUtils::findTypeInFields(cls->getType(), field);
@@ -3600,7 +3783,7 @@ auto Codegen::visit(const DotOp* node) -> void {
           }
           setDebugLoc(node->getSpan());
           result = callMethodByName(node->getSpan(), receiverValue.get(), method->getName(), args,
-                                    explicitTypeArgs);
+                                    explicitTypeArgs, method->getResolvedSymbol());
           return;
         }
       }
@@ -5256,7 +5439,8 @@ auto Codegen::emitUnionClassMethodDispatch(llvm::SMRange span, lesma::Value* uni
 auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
                                const std::string& methodName,
                                const std::vector<lesma::Value*>& args,
-                               const std::vector<lesma::Type*>& explicitTypeArgs)
+                               const std::vector<lesma::Type*>& explicitTypeArgs,
+                               lesma::Value* resolvedCallee)
     -> std::unique_ptr<lesma::Value> {
   if (receiver->getType()->is(BaseType::TY_ARRAY)) {
     return callListMethodByName(span, receiver, methodName, args, explicitTypeArgs);
@@ -5286,40 +5470,49 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
   auto* savedSelfSymbol = selfSymbol;
   std::vector<lesma::Type*> paramTypes;
   std::vector<llvm::Value*> paramsLLVM;
-  // Adapt imported/aliased class pointers to the canonical method-owning class type for overload
-  // lookup only; the underlying LLVM pointer value is unchanged.
   lesma::Value* receiverForCall = receiver;
   std::unique_ptr<lesma::Value> receiverAdapter;
-  if (receiver->getType()->is(BaseType::TY_PTR) &&
-      receiver->getType()->getElementType() != nullptr) {
-    lesma::Type* elemTy = receiver->getType()->getElementType();
-    if (Value* structSym = lookupClassStructSymbol(elemTy);
-        structSym != nullptr && structSym->getType() != nullptr && structSym->getType() != elemTy) {
-      lesma::Type* specClassTy = structSym->getType();
-      lesma::Type* ptrToSpec =
-          cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), specClassTy));
-      receiverAdapter = std::make_unique<lesma::Value>("", ptrToSpec, receiver->getLlvmValue());
-      receiverForCall = receiverAdapter.get();
+  lesma::Value* directMethod = nullptr;
+  if (resolvedCallee != nullptr && resolvedCallee->isStaticMethod()) {
+    for (auto* arg : args) {
+      appendCallableArgument(arg, paramTypes, paramsLLVM);
     }
-  }
-  appendCallableArgument(receiverForCall, paramTypes, paramsLLVM);
-  for (auto* arg : args) {
-    appendCallableArgument(arg, paramTypes, paramsLLVM);
-  }
-  lesma::Value* directMethod = scope->lookupFunction(methodName, paramTypes);
-  if (directMethod == nullptr) {
-    for (const auto& importedScope : *importedScopes) {
-      if (importedScope == nullptr) {
-        continue;
-      }
-      directMethod = importedScope->lookupFunction(methodName, paramTypes);
-      if (directMethod != nullptr) {
-        break;
+    directMethod = resolvedCallee;
+  } else {
+    // Adapt imported/aliased class pointers to the canonical method-owning class type for overload
+    // lookup only; the underlying LLVM pointer value is unchanged.
+    receiverForCall = receiver;
+    if (receiver->getType()->is(BaseType::TY_PTR) &&
+        receiver->getType()->getElementType() != nullptr) {
+      lesma::Type* elemTy = receiver->getType()->getElementType();
+      if (Value* structSym = lookupClassStructSymbol(elemTy);
+          structSym != nullptr && structSym->getType() != nullptr && structSym->getType() != elemTy) {
+        lesma::Type* specClassTy = structSym->getType();
+        lesma::Type* ptrToSpec =
+            cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), specClassTy));
+        receiverAdapter = std::make_unique<lesma::Value>("", ptrToSpec, receiver->getLlvmValue());
+        receiverForCall = receiverAdapter.get();
       }
     }
-  }
-  if (specializedClassEnvFor(receiverType) != nullptr) {
-    directMethod = nullptr;
+    appendCallableArgument(receiverForCall, paramTypes, paramsLLVM);
+    for (auto* arg : args) {
+      appendCallableArgument(arg, paramTypes, paramsLLVM);
+    }
+    directMethod = scope->lookupFunction(methodName, paramTypes);
+    if (directMethod == nullptr) {
+      for (const auto& importedScope : *importedScopes) {
+        if (importedScope == nullptr) {
+          continue;
+        }
+        directMethod = importedScope->lookupFunction(methodName, paramTypes);
+        if (directMethod != nullptr) {
+          break;
+        }
+      }
+    }
+    if (specializedClassEnvFor(receiverType) != nullptr) {
+      directMethod = nullptr;
+    }
   }
   if (directMethod != nullptr && directMethod->getLlvmValue() != nullptr) {
     // Method symbols may retain template types with TY_GENERIC; call sites are not inside
@@ -5363,7 +5556,8 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
       const bool canUseVirtual = methodName != "new" && vtableSlot != ~0U && !vtOrder.empty() &&
                                  vtableSlot < vtableArrayLen &&
                                  (receiverType->getClassSuperclass() != nullptr ||
-                                  receiverType->getClassHasDerivedClass());
+                                  receiverType->getClassHasDerivedClass()) &&
+                                 !directMethod->isStaticMethod();
       if (canUseVirtual) {
         llvm::Type* const ptrTy = builder->getPtrTy();
         auto* st = llvm::cast<llvm::StructType>(getOrCreateLlvmType(receiverType));

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -4887,6 +4887,34 @@ auto Codegen::callNamedFunction(
     -> std::unique_ptr<lesma::Value> {
   std::vector<lesma::Type*> localParamTypes = paramTypes;
   std::vector<llvm::Value*> localParamsLLVM = paramsLLVM;
+  std::unordered_map<std::string, lesma::Type*> callSiteGenericFallbackStorage;
+  if (genericBindingHint != nullptr) {
+    for (const auto& kv : *genericBindingHint) {
+      if (kv.second != nullptr) {
+        callSiteGenericFallbackStorage[kv.first] = kv.second;
+      }
+    }
+  }
+  struct ScopedCallSiteGenericFallback {
+    Codegen* cg;
+    bool const on;
+    ScopedCallSiteGenericFallback(Codegen* code, std::unordered_map<std::string, lesma::Type*>* map)
+        : cg(code), on(map != nullptr && !map->empty()) {
+      if (on) {
+        code->pushGenericTypeFallback(map);
+      }
+    }
+    ~ScopedCallSiteGenericFallback() {
+      if (on) {
+        cg->popGenericTypeFallback();
+      }
+    }
+    ScopedCallSiteGenericFallback(const ScopedCallSiteGenericFallback&) = delete;
+    auto operator=(const ScopedCallSiteGenericFallback&) -> ScopedCallSiteGenericFallback& = delete;
+    ScopedCallSiteGenericFallback(ScopedCallSiteGenericFallback&&) = delete;
+    auto operator=(ScopedCallSiteGenericFallback&&) -> ScopedCallSiteGenericFallback& = delete;
+  } scopedCallSiteFallback(this, &callSiteGenericFallbackStorage);
+
   auto hintedGenericBindings = [&]() -> std::unordered_map<std::string, lesma::Type*> {
     std::unordered_map<std::string, lesma::Type*> env;
     if (genericBindingHint != nullptr) {

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -255,9 +255,9 @@ Codegen::Codegen(
 auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* clsSymbol) -> void {
   bool const isMethod = value->getDeclarationKind() == ValueDeclarationKind::METHOD;
   auto const fieldsForParams = value->getType()->getFields();
-  bool const usesImplicitSelfParam =
-      isMethod && !value->isStaticMethod() && !fieldsForParams.empty() &&
-      fieldsForParams.front()->name == "self";
+  bool const usesImplicitSelfParam = isMethod && !value->isStaticMethod() &&
+                                     !fieldsForParams.empty() &&
+                                     fieldsForParams.front()->name == "self";
   if (clsSymbol == nullptr && isMethod) {
     auto fields = value->getType()->getFields();
     if (!fields.empty() && fields.front()->type != nullptr &&
@@ -1082,9 +1082,8 @@ auto Codegen::emitUnionWrapValueToSlot(llvm::SMRange /*span*/, lesma::Value* val
       throw CodegenError({}, "Internal error: union payload store type mismatch");
     }
   }
-  llvm::Value* typedPayPtr =
-      builder->CreateBitCast(payPtr, llvm::PointerType::get(theModule->getContext(), 0U),
-                             "union.pay.tptr");
+  llvm::Value* typedPayPtr = builder->CreateBitCast(
+      payPtr, llvm::PointerType::get(theModule->getContext(), 0U), "union.pay.tptr");
   builder->CreateStore(v, typedPayPtr);
   llvm::Value* agg = builder->CreateLoad(st, destSlot, "union.val");
   return std::make_unique<lesma::Value>("", unionTy, agg);
@@ -1911,7 +1910,7 @@ auto Codegen::visit(const FuncDecl* node) -> void {
   }
 
   auto mangledName = getMangledName(node->getSpan(), node->getName(), paramTypes,
-                                     selfSymbol != nullptr && !node->getIsStatic());
+                                    selfSymbol != nullptr && !node->getIsStatic());
   std::string signatureKey = makeCallableSignatureKey(node->getName(), paramTypes);
   if (!currentGenericTypes.empty()) {
     std::vector<std::string> bindingOrder;
@@ -2374,6 +2373,7 @@ auto Codegen::visit(const Class* node) -> void {
     auto* genericSymbol = scope->lookupStruct(node->getIdentifier());
     if (genericSymbol != nullptr) {
       genericSymbol->setGenericClassTemplate(node);
+      // Globals must exist before `Box.tag`-style use that precedes any specialization.
       if (genericSymbol->getType() != nullptr) {
         emitClassStaticFieldGlobals(genericSymbol->getType(), node);
       }
@@ -2395,8 +2395,6 @@ auto Codegen::visit(const Class* node) -> void {
   if (type->getLlvmType() == nullptr) {
     getOrCreateLlvmType(type);
   }
-
-  emitClassStaticFieldGlobals(type, node);
 
   auto* selfType = cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), type));
   methodSelfSymbols.push_back(std::make_unique<Value>(node->getIdentifier(), selfType));
@@ -2440,6 +2438,8 @@ auto Codegen::visit(const Class* node) -> void {
     existingStruct->setConstructor(synthCtor);
   }
 
+  emitClassStaticFieldGlobals(type, node);
+
   getOrEmitClassVtableGlobal(type, node);
 
   selfSymbol = nullptr;
@@ -2466,6 +2466,8 @@ auto Codegen::emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* ast
     } else if (fieldTy->is(BaseType::TY_PTR) && fieldTy->getElementType() != nullptr &&
                fieldTy->getElementType()->is(BaseType::TY_CLASS)) {
       storageTy = builder->getPtrTy();
+    } else if (fieldTy->is(BaseType::TY_FUNCTION) && sym->getStoresFuncValuePair()) {
+      storageTy = getFuncValuePairLlvmType();
     }
     std::string classManglePart;
     if (classTy->is(BaseType::TY_CLASS) && !classTy->getGenericParams().empty()) {
@@ -2477,20 +2479,47 @@ auto Codegen::emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* ast
     } else {
       classManglePart = MangleUtils::getTypeMangledName(span, classTy);
     }
-    std::string const gvName =
-        std::string{"lesma.sfs."} + classManglePart + "." + sym->getName();
+    std::string const gvName = std::string{"lesma.sfs."} + classManglePart + "." + sym->getName();
     if (theModule->getGlobalVariable(gvName, true) != nullptr) {
       continue;
     }
     llvm::Constant* init = llvm::Constant::getNullValue(storageTy);
     auto* gv = new llvm::GlobalVariable(*theModule, storageTy, false,
-                                         llvm::GlobalValue::PrivateLinkage, init, gvName);
+                                        llvm::GlobalValue::PrivateLinkage, init, gvName);
     sym->setLlvmValue(gv);
     sym->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
     if (vd->getValue() != nullptr) {
       vd->getValue()->accept(*this);
-      auto rhs = cast(vd->getValue()->getSpan(), result.get(), fieldTy);
-      builder->CreateStore(rhs->getLlvmValue(), gv);
+      auto* valueResult = result.get();
+      const bool funcPairStorage =
+          fieldTy->is(BaseType::TY_FUNCTION) && sym->getStoresFuncValuePair();
+      if (funcPairStorage) {
+        if (valueResult->getLlvmValue() == nullptr && !fieldTy->getGenericParams().empty()) {
+          builder->CreateStore(llvm::ConstantAggregateZero::get(getFuncValuePairLlvmType()), gv);
+        } else if (valueResult->getLlvmValue() != nullptr &&
+                   valueResult->getLlvmValue()->getType() == getFuncValuePairLlvmType()) {
+          builder->CreateStore(valueResult->getLlvmValue(), gv);
+        } else if (valueResult->getStoresFuncValuePair()) {
+          llvm::StructType* pt = getFuncValuePairLlvmType();
+          llvm::Value* loaded = builder->CreateLoad(pt, valueResult->getLlvmValue(),
+                                                    sym->getName() + ".sfnpair.init");
+          builder->CreateStore(loaded, gv);
+        } else {
+          auto rhs = cast(vd->getValue()->getSpan(), valueResult, fieldTy);
+          builder->CreateStore(rhs->getLlvmValue(), gv);
+        }
+        if (auto* le = dynamic_cast<LambdaExpr*>(vd->getValue())) {
+          if (Value* rs = le->getResolvedSymbol(); rs != nullptr) {
+            sym->setClosureCalleeUsesEnvParameter(rs->getClosureCalleeUsesEnvParameter());
+          }
+        } else if (dynamic_cast<FuncCall*>(vd->getValue()) != nullptr &&
+                   fieldTy->is(BaseType::TY_FUNCTION)) {
+          sym->setClosureCalleeUsesEnvParameter(true);
+        }
+      } else {
+        auto rhs = cast(vd->getValue()->getSpan(), valueResult, fieldTy);
+        builder->CreateStore(rhs->getLlvmValue(), gv);
+      }
     }
   }
 }
@@ -3451,14 +3480,30 @@ auto Codegen::visit(const DotOp* node) -> void {
             if (isAssignment) {
               lesma::Type* ptrToVal = ft;
               if (ft->is(BaseType::TY_CLASS)) {
-                ptrToVal = cacheType(
-                    std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
+                ptrToVal =
+                    cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
               } else if (ft->is(BaseType::TY_PTR) && ft->getElementType() != nullptr &&
                          ft->getElementType()->is(BaseType::TY_CLASS)) {
-                ptrToVal = cacheType(
-                    std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
+                ptrToVal =
+                    cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
               }
               result = std::make_unique<Value>("", ptrToVal, gv);
+              if (ft->is(BaseType::TY_FUNCTION) && sf->getDeclarationSymbol() != nullptr &&
+                  sf->getDeclarationSymbol()->getStoresFuncValuePair()) {
+                result->setStoresFuncValuePair(true);
+                result->setClosureCalleeUsesEnvParameter(
+                    sf->getDeclarationSymbol()->getClosureCalleeUsesEnvParameter());
+              }
+              return;
+            }
+            if (ft->is(BaseType::TY_FUNCTION) && sf->getDeclarationSymbol() != nullptr &&
+                sf->getDeclarationSymbol()->getStoresFuncValuePair()) {
+              auto slot = std::make_unique<Value>("", ft, gv);
+              slot->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+              slot->setStoresFuncValuePair(true);
+              slot->setClosureCalleeUsesEnvParameter(
+                  sf->getDeclarationSymbol()->getClosureCalleeUsesEnvParameter());
+              result = std::move(slot);
               return;
             }
             llvm::Type* storageTy = ft->getLlvmType();
@@ -3731,21 +3776,38 @@ auto Codegen::visit(const DotOp* node) -> void {
             if (sf != nullptr) {
               llvm::Value* gv = llvmGlobalForClassStaticField(lesmaType, field);
               if (gv == nullptr) {
-                throw CodegenError(node->getSpan(), "Static field {} has no lowered storage", field);
+                throw CodegenError(node->getSpan(), "Static field {} has no lowered storage",
+                                   field);
               }
               lesma::Type* ft = sf->type;
               getOrCreateLlvmType(ft);
               if (isAssignment) {
                 lesma::Type* ptrToVal = ft;
                 if (ft->is(BaseType::TY_CLASS)) {
-                  ptrToVal = cacheType(
-                      std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
+                  ptrToVal =
+                      cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
                 } else if (ft->is(BaseType::TY_PTR) && ft->getElementType() != nullptr &&
                            ft->getElementType()->is(BaseType::TY_CLASS)) {
-                  ptrToVal = cacheType(
-                      std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
+                  ptrToVal =
+                      cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), ft));
                 }
                 result = std::make_unique<Value>("", ptrToVal, gv);
+                if (ft->is(BaseType::TY_FUNCTION) && sf->getDeclarationSymbol() != nullptr &&
+                    sf->getDeclarationSymbol()->getStoresFuncValuePair()) {
+                  result->setStoresFuncValuePair(true);
+                  result->setClosureCalleeUsesEnvParameter(
+                      sf->getDeclarationSymbol()->getClosureCalleeUsesEnvParameter());
+                }
+                return;
+              }
+              if (ft->is(BaseType::TY_FUNCTION) && sf->getDeclarationSymbol() != nullptr &&
+                  sf->getDeclarationSymbol()->getStoresFuncValuePair()) {
+                auto slot = std::make_unique<Value>("", ft, gv);
+                slot->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+                slot->setStoresFuncValuePair(true);
+                slot->setClosureCalleeUsesEnvParameter(
+                    sf->getDeclarationSymbol()->getClosureCalleeUsesEnvParameter());
+                result = std::move(slot);
                 return;
               }
               llvm::Type* storageTy = ft->getLlvmType();
@@ -4811,10 +4873,11 @@ auto Codegen::appendCallableArgument(lesma::Value* arg, std::vector<lesma::Type*
   paramsLLVM.push_back(llvmArg);
 }
 
-// `genericBindingHint` is the typechecker’s per-call binding list (e.g. class `T` for `Cell.of(7)`).
-// It feeds mangling, class monomorph of the template `selfSymbol`, and lowering of the callee’s
-// Lesma function type. Constructor resolution uses scope → rootScope → `getConstructor()` so normal
-// calls like `list<str>()` still match overloads with defaults before falling back to the struct’s ctor.
+// `genericBindingHint` is the typechecker’s per-call binding list (e.g. class `T` for
+// `Cell.of(7)`). It feeds mangling, class monomorph of the template `selfSymbol`, and lowering of
+// the callee’s Lesma function type. Constructor resolution uses scope → rootScope →
+// `getConstructor()` so normal calls like `list<str>()` still match overloads with defaults before
+// falling back to the struct’s ctor.
 auto Codegen::callNamedFunction(
     llvm::SMRange span, const std::string& functionName,
     const std::vector<lesma::Type*>& paramTypes, const std::vector<llvm::Value*>& paramsLLVM,
@@ -4845,7 +4908,8 @@ auto Codegen::callNamedFunction(
   if (selfSymbol != nullptr && functionName != "new" && genericBindingHint != nullptr &&
       !genericBindingHint->empty()) {
     lesma::Type* recvTy = selfSymbol->getType();
-    if (recvTy != nullptr && recvTy->is(BaseType::TY_CLASS) && !recvTy->getGenericParams().empty()) {
+    if (recvTy != nullptr && recvTy->is(BaseType::TY_CLASS) &&
+        !recvTy->getGenericParams().empty()) {
       if (auto git = genericClasses.find(selfSymbol->getName()); git != genericClasses.end()) {
         std::unordered_map<std::string, lesma::Type*> envFromHint = hintedGenericBindings();
         bool complete = true;
@@ -4944,11 +5008,11 @@ auto Codegen::callNamedFunction(
         if (it == specializedClassTypeEnvs.end()) {
           return false;
         }
-        return std::ranges::all_of(
-            it->second, [](const std::pair<const std::string, lesma::Type*>& e) {
-              lesma::Type* ty = e.second;
-              return ty == nullptr || !ty->is(BaseType::TY_GENERIC);
-            });
+        return std::ranges::all_of(it->second,
+                                   [](const std::pair<const std::string, lesma::Type*>& e) {
+                                     lesma::Type* ty = e.second;
+                                     return ty == nullptr || !ty->is(BaseType::TY_GENERIC);
+                                   });
       };
       if (allocatedClassMonomorph != nullptr && monomorphEnvIsConcrete(allocatedClassMonomorph)) {
         classSym = emitClassMonomorph(allocatedClassMonomorph, templateClass);
@@ -4965,8 +5029,8 @@ auto Codegen::callNamedFunction(
     classPtr = emitMalloc(classSize, functionName + ".obj");
     emitInitClassVtablePointer(classSym->getType(), classPtr);
     localParamsLLVM.insert(localParamsLLVM.begin(), classPtr);
-    lesma::Type* selfArgTy =
-        cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), classSym->getType()));
+    lesma::Type* selfArgTy = cacheType(
+        std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), classSym->getType()));
     localParamTypes.insert(localParamTypes.begin(), selfArgTy);
 
     selfSymbol = classSym;
@@ -5125,7 +5189,8 @@ auto Codegen::callNamedFunction(
       callableLesmaType =
           substituteTypeForSpecializationEnv(callableLesmaType, hintedGenericBindings());
     } else if (!currentGenericTypes.empty() && typeContainsUnboundGeneric(callableLesmaType)) {
-      callableLesmaType = substituteTypeForSpecializationEnv(callableLesmaType, currentGenericTypes);
+      callableLesmaType =
+          substituteTypeForSpecializationEnv(callableLesmaType, currentGenericTypes);
     }
   }
 
@@ -5527,8 +5592,7 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
                                const std::string& methodName,
                                const std::vector<lesma::Value*>& args,
                                const std::vector<lesma::Type*>& explicitTypeArgs,
-                               lesma::Value* resolvedCallee,
-                               const FuncCall* callSiteForGenericEnv)
+                               lesma::Value* resolvedCallee, const FuncCall* callSiteForGenericEnv)
     -> std::unique_ptr<lesma::Value> {
   if (receiver->getType()->is(BaseType::TY_ARRAY)) {
     return callListMethodByName(span, receiver, methodName, args, explicitTypeArgs);
@@ -5578,8 +5642,9 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
     if (receiver->getType()->is(BaseType::TY_PTR) &&
         receiver->getType()->getElementType() != nullptr) {
       lesma::Type* elemTy = receiver->getType()->getElementType();
-      if (Value* structSym = lookupClassStructSymbol(elemTy);
-          structSym != nullptr && structSym->getType() != nullptr && structSym->getType() != elemTy) {
+      if (Value* structSym = lookupClassStructSymbol(elemTy); structSym != nullptr &&
+                                                              structSym->getType() != nullptr &&
+                                                              structSym->getType() != elemTy) {
         lesma::Type* specClassTy = structSym->getType();
         lesma::Type* ptrToSpec =
             cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), specClassTy));
@@ -5688,9 +5753,8 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
     }
   }
   selfSymbol = cls;
-  auto resultValue =
-      callNamedFunction(span, methodName, paramTypes, paramsLLVM, explicitTypeArgs, resolvedCallee,
-                        nullptr, callSiteGenericBindings);
+  auto resultValue = callNamedFunction(span, methodName, paramTypes, paramsLLVM, explicitTypeArgs,
+                                       resolvedCallee, nullptr, callSiteGenericBindings);
   selfSymbol = savedSelfSymbol;
   return resultValue;
 }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -3458,7 +3458,7 @@ auto Codegen::visit(const DotOp* node) -> void {
           }
           setDebugLoc(node->getSpan());
           result = callMethodByName(node->getSpan(), recvHolder.get(), method->getName(), args,
-                                    explicitTypeArgs, method->getResolvedSymbol());
+                                    explicitTypeArgs, method->getResolvedSymbol(), method);
           return;
         }
       }
@@ -3740,7 +3740,7 @@ auto Codegen::visit(const DotOp* node) -> void {
             }
             setDebugLoc(node->getSpan());
             result = callMethodByName(node->getSpan(), recvHolder.get(), method->getName(), args,
-                                      explicitTypeArgs, method->getResolvedSymbol());
+                                      explicitTypeArgs, method->getResolvedSymbol(), method);
             return;
           }
         }
@@ -4201,6 +4201,11 @@ auto Codegen::visit(const Literal* node) -> void {
       wrapped->setStoresFuncValuePair(true);
       wrapped->setClosureCalleeUsesEnvParameter(false);
       result = std::move(wrapped);
+    } else if (val->getCategory() == ValueCategory::TYPE_SYMBOL) {
+      // Type names in value position (`Cell.method`, `Foo.bar`) are not storage; avoid lowering a
+      // generic class template to LLVM when materializing.
+      result = std::make_unique<Value>(val->getName(), val->getType(), nullptr);
+      result->setCategory(ValueCategory::TYPE_SYMBOL);
     } else {
       result = materializeSymbolValue(val);
     }
@@ -4768,6 +4773,10 @@ auto Codegen::appendCallableArgument(lesma::Value* arg, std::vector<lesma::Type*
   paramsLLVM.push_back(llvmArg);
 }
 
+// `genericBindingHint` is the typechecker’s per-call binding list (e.g. class `T` for `Cell.of(7)`).
+// It feeds mangling, class monomorph of the template `selfSymbol`, and lowering of the callee’s
+// Lesma function type. Constructor resolution uses scope → rootScope → `getConstructor()` so normal
+// calls like `list<str>()` still match overloads with defaults before falling back to the struct’s ctor.
 auto Codegen::callNamedFunction(
     llvm::SMRange span, const std::string& functionName,
     const std::vector<lesma::Type*>& paramTypes, const std::vector<llvm::Value*>& paramsLLVM,
@@ -4786,6 +4795,35 @@ auto Codegen::callNamedFunction(
     }
     return env;
   };
+  // No `self` at the call site: use the hint for free/generic calls instead of inferring only from
+  // parameter types (mirrors `buildFunctionSpecializationEnv` when there is no class receiver).
+  auto freeCallGenericEnvFromHint = [&]() -> std::unordered_map<std::string, lesma::Type*> {
+    if (selfSymbol != nullptr || genericBindingHint == nullptr || genericBindingHint->empty()) {
+      return {};
+    }
+    return hintedGenericBindings();
+  };
+  // Monomorphize generic class template when typechecker fixed class parameters (e.g. Cell.of(7)).
+  if (selfSymbol != nullptr && functionName != "new" && genericBindingHint != nullptr &&
+      !genericBindingHint->empty()) {
+    lesma::Type* recvTy = selfSymbol->getType();
+    if (recvTy != nullptr && recvTy->is(BaseType::TY_CLASS) && !recvTy->getGenericParams().empty()) {
+      if (auto git = genericClasses.find(selfSymbol->getName()); git != genericClasses.end()) {
+        std::unordered_map<std::string, lesma::Type*> envFromHint = hintedGenericBindings();
+        bool complete = true;
+        for (const auto& gn : git->second->getGenericParams()) {
+          auto it = envFromHint.find(gn);
+          if (it == envFromHint.end() || it->second == nullptr) {
+            complete = false;
+            break;
+          }
+        }
+        if (complete) {
+          selfSymbol = specializeClass(git->second, {}, {}, &envFromHint);
+        }
+      }
+    }
+  }
   for (auto* explicitTypeArg : explicitTypeArgs) {
     if (explicitTypeArg != nullptr) {
       getOrCreateLlvmType(explicitTypeArg);
@@ -4816,10 +4854,11 @@ auto Codegen::callNamedFunction(
     if (genericNames.empty()) {
       return;
     }
-    auto env = (selfSymbol == nullptr && genericBindingHint != nullptr)
-                   ? hintedGenericBindings()
-                   : computeGenericFunctionBindingEnv(genericFuncTemplateForLookup, localParamTypes,
-                                                      genericNames, explicitTypeArgs);
+    std::unordered_map<std::string, lesma::Type*> env = freeCallGenericEnvFromHint();
+    if (env.empty()) {
+      env = computeGenericFunctionBindingEnv(genericFuncTemplateForLookup, localParamTypes,
+                                             genericNames, explicitTypeArgs);
+    }
     appendGenericBindingSuffix(span, out, genericNames, env);
   };
   auto buildFunctionSpecializationEnv = [&](const FuncDecl* templateDecl,
@@ -4849,7 +4888,6 @@ auto Codegen::callNamedFunction(
   auto* selfSymbolTmp = selfSymbol;
   auto* classSym = scope->lookupStruct(functionName);
   llvm::Value* classPtr = nullptr;
-  std::unique_ptr<Type> selfParamType;
 
   if (classSym == nullptr || (classSym->getType()->is(BaseType::TY_CLASS) &&
                               classSym->getType()->getLlvmType() == nullptr)) {
@@ -4889,12 +4927,19 @@ auto Codegen::callNamedFunction(
     classPtr = emitMalloc(classSize, functionName + ".obj");
     emitInitClassVtablePointer(classSym->getType(), classPtr);
     localParamsLLVM.insert(localParamsLLVM.begin(), classPtr);
-    selfParamType =
-        std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), classSym->getType());
-    localParamTypes.insert(localParamTypes.begin(), selfParamType.get());
+    lesma::Type* selfArgTy =
+        cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), classSym->getType()));
+    localParamTypes.insert(localParamTypes.begin(), selfArgTy);
 
     selfSymbol = classSym;
     symbol = scope->lookupFunction("new", localParamTypes);
+    if (symbol == nullptr && rootScope != nullptr) {
+      // Method/template body scopes may not chain to the table where monomorph constructors live.
+      symbol = rootScope->lookupFunction("new", localParamTypes);
+    }
+    if (symbol == nullptr) {
+      symbol = classSym->getConstructor();
+    }
   } else {
     auto directSignatureKey = makeCallableSignatureKey(functionName, localParamTypes);
     std::string directMangledLookup =
@@ -5010,9 +5055,7 @@ auto Codegen::callNamedFunction(
       if (lamSym != nullptr && lamSym->getType() != nullptr &&
           !lamSym->getType()->getGenericParams().empty()) {
         std::vector<std::string> genericNames = lamSym->getType()->getGenericParams();
-        auto bindingEnv = (selfSymbol == nullptr && genericBindingHint != nullptr)
-                              ? hintedGenericBindings()
-                              : std::unordered_map<std::string, lesma::Type*>{};
+        std::unordered_map<std::string, lesma::Type*> bindingEnv = freeCallGenericEnvFromHint();
         symbol = specializeLambda(lamNode, localParamTypes, genericNames, explicitTypeArgs,
                                   bindingEnv.empty() ? nullptr : &bindingEnv);
       }
@@ -5037,9 +5080,15 @@ auto Codegen::callNamedFunction(
   }
 
   Type* callableLesmaType = symbol->getType();
-  if (callableLesmaType != nullptr && !currentGenericTypes.empty() &&
-      typeContainsUnboundGeneric(callableLesmaType)) {
-    callableLesmaType = substituteTypeForSpecializationEnv(callableLesmaType, currentGenericTypes);
+  if (callableLesmaType != nullptr) {
+    if (genericBindingHint != nullptr && !genericBindingHint->empty()) {
+      // Call-site env from typecheck (e.g. `T = int` for `Cell.of(7)`); apply even when the stored
+      // callee type does not trip `typeContainsUnboundGeneric`.
+      callableLesmaType =
+          substituteTypeForSpecializationEnv(callableLesmaType, hintedGenericBindings());
+    } else if (!currentGenericTypes.empty() && typeContainsUnboundGeneric(callableLesmaType)) {
+      callableLesmaType = substituteTypeForSpecializationEnv(callableLesmaType, currentGenericTypes);
+    }
   }
 
   if (callableLesmaType == nullptr ||
@@ -5440,7 +5489,8 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
                                const std::string& methodName,
                                const std::vector<lesma::Value*>& args,
                                const std::vector<lesma::Type*>& explicitTypeArgs,
-                               lesma::Value* resolvedCallee)
+                               lesma::Value* resolvedCallee,
+                               const FuncCall* callSiteForGenericEnv)
     -> std::unique_ptr<lesma::Value> {
   if (receiver->getType()->is(BaseType::TY_ARRAY)) {
     return callListMethodByName(span, receiver, methodName, args, explicitTypeArgs);
@@ -5467,6 +5517,11 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
                        receiverType->getDisplayName().empty() ? "(unknown)"
                                                               : receiverType->getDisplayName());
   }
+  const auto* receiverClassEnv = specializedClassEnvFor(receiverType);
+  const std::vector<std::pair<std::string, lesma::Type*>>* callSiteGenericBindings =
+      (callSiteForGenericEnv != nullptr && !callSiteForGenericEnv->getGenericBindingEnv().empty())
+          ? &callSiteForGenericEnv->getGenericBindingEnv()
+          : nullptr;
   auto* savedSelfSymbol = selfSymbol;
   std::vector<lesma::Type*> paramTypes;
   std::vector<llvm::Value*> paramsLLVM;
@@ -5510,19 +5565,25 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
         }
       }
     }
-    if (specializedClassEnvFor(receiverType) != nullptr) {
+    if (receiverClassEnv != nullptr) {
       directMethod = nullptr;
     }
   }
   if (directMethod != nullptr && directMethod->getLlvmValue() != nullptr) {
     // Method symbols may retain template types with TY_GENERIC; call sites are not inside
-    // defineFunction(), so currentGenericTypes is empty. Restore the specialization env so
-    // getOrCreateLlvmType (e.g. on return types) can resolve T.
+    // defineFunction(), so currentGenericTypes is often empty. Prefer the env recorded for this
+    // specialization, else the receiver’s class env, else the FuncCall’s binding list (static
+    // generic methods), so getOrCreateLlvmType / return substitution see concrete `T`.
     auto savedGenerics = currentGenericTypes;
     if (auto genIt = specializationEnvs.find(directMethod); genIt != specializationEnvs.end()) {
       currentGenericTypes = genIt->second;
-    } else if (const auto* envPtr = specializedClassEnvFor(receiverType); envPtr != nullptr) {
-      currentGenericTypes = *envPtr;
+    } else if (receiverClassEnv != nullptr) {
+      currentGenericTypes = *receiverClassEnv;
+    } else if (callSiteGenericBindings != nullptr) {
+      currentGenericTypes.clear();
+      for (const auto& binding : *callSiteGenericBindings) {
+        currentGenericTypes[binding.first] = binding.second;
+      }
     }
     try {
       std::vector<llvm::Value*> finalParams;
@@ -5589,7 +5650,9 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
     }
   }
   selfSymbol = cls;
-  auto resultValue = callNamedFunction(span, methodName, paramTypes, paramsLLVM, explicitTypeArgs);
+  auto resultValue =
+      callNamedFunction(span, methodName, paramTypes, paramsLLVM, explicitTypeArgs, resolvedCallee,
+                        nullptr, callSiteGenericBindings);
   selfSymbol = savedSelfSymbol;
   return resultValue;
 }

--- a/src/liblesma/Frontend/Parser.cpp
+++ b/src/liblesma/Frontend/Parser.cpp
@@ -863,7 +863,7 @@ auto Parser::parseOr() -> std::unique_ptr<Expression> {
 auto Parser::parseExpression() -> std::unique_ptr<Expression> { return parseOr(); }
 
 // Statements
-auto Parser::parseVarDecl(bool fieldIsPrivate) -> std::unique_ptr<Statement> {
+auto Parser::parseVarDecl(bool fieldIsPrivate, bool fieldIsStatic) -> std::unique_ptr<Statement> {
   bool isMutable = false;
   Token const* startTok = nullptr;
   if (advanceIfMatchAny<TokenType::LET>()) {
@@ -921,7 +921,7 @@ auto Parser::parseVarDecl(bool fieldIsPrivate) -> std::unique_ptr<Statement> {
   }
   return std::make_unique<VarDecl>(llvm::SMRange{startTok->getStart(), endLoc}, std::move(vars),
                                    std::move(type), std::move(expr), isMutable, isExported,
-                                   fieldIsPrivate);
+                                   fieldIsPrivate, fieldIsStatic);
 }
 
 auto Parser::parseIf() -> std::unique_ptr<Statement> {
@@ -1063,6 +1063,9 @@ auto Parser::parseStatement(bool isTopLevel) -> std::unique_ptr<Statement> {
   if (check(TokenType::PRIVATE) || check(TokenType::OVERLOAD)) {
     error(peek(), "`private` and `overload` are only valid on class fields and methods");
   }
+  if (check(TokenType::STATIC)) {
+    error(peek(), "`static` is only valid on class fields and methods");
+  }
   if (check(TokenType::FUNC)) {
     return parseFunctionDeclaration();
   }
@@ -1200,9 +1203,13 @@ auto Parser::parseParameterList(bool allowVarargsEllipsis) -> ParameterListParse
   return result;
 }
 
-auto Parser::parseFunctionDeclaration(bool methodIsPrivate, bool declaresInheritanceOverload)
-    -> std::unique_ptr<Statement> {
+auto Parser::parseFunctionDeclaration(bool methodIsPrivate, bool declaresInheritanceOverload,
+                                      bool methodIsStatic) -> std::unique_ptr<Statement> {
   auto loc = isExported ? previous()->span : peek()->span;
+  if (methodIsStatic && !inClass) {
+    error(peek(), "`static func` is only allowed inside class bodies");
+    return nullptr;
+  }
   consume(TokenType::FUNC);
   // `export class` / `export func` leave isExported set; locals inside the body must not inherit it.
   bool const funcExported = isExported;
@@ -1222,6 +1229,10 @@ auto Parser::parseFunctionDeclaration(bool methodIsPrivate, bool declaresInherit
   llvm::SMRange overloadGlyphSpan{};
   std::optional<TokenType> pendingOverloadOperatorToken;
   if (advanceIfMatchAny<TokenType::OPERATOR>()) {
+    if (methodIsStatic) {
+      error(previous(), "`static` cannot be used with `operator` declarations");
+      return nullptr;
+    }
     if (!inClass) {
       error(previous(), "Operator declarations are only allowed in class definition.");
       return nullptr;
@@ -1319,7 +1330,7 @@ auto Parser::parseFunctionDeclaration(bool methodIsPrivate, bool declaresInherit
   return std::make_unique<FuncDecl>(
       llvm::SMRange{loc.Start, funcEnd}, functionName, functionNameSpan, overloadGlyphSpan,
       std::move(genericParams), std::move(returnType), std::move(parameters), std::move(body),
-      false, funcExported, methodIsPrivate, declaresInheritanceOverload);
+      false, funcExported, methodIsPrivate, declaresInheritanceOverload, methodIsStatic);
 }
 
 auto Parser::parseExport() -> std::unique_ptr<Statement> {
@@ -1494,16 +1505,23 @@ auto Parser::parseClass() -> std::unique_ptr<Statement> {
   inClass = true;
   while (!checkAny<TokenType::RIGHT_BRACE, TokenType::EOF_TOKEN>()) {
     try {
-      if (checkAny<TokenType::PRIVATE, TokenType::OVERLOAD, TokenType::LET, TokenType::VAR,
-                   TokenType::FUNC>()) {
+      if (checkAny<TokenType::PRIVATE, TokenType::OVERLOAD, TokenType::STATIC, TokenType::LET,
+                   TokenType::VAR, TokenType::FUNC>()) {
         bool memberPrivate = false;
         bool inheritanceOverload = false;
-        while (check(TokenType::PRIVATE) || check(TokenType::OVERLOAD)) {
+        bool memberStatic = false;
+        while (check(TokenType::PRIVATE) || check(TokenType::OVERLOAD) ||
+               check(TokenType::STATIC)) {
           if (advanceIfMatchAny<TokenType::PRIVATE>()) {
             if (memberPrivate) {
               error(previous(), "Duplicate `private`");
             }
             memberPrivate = true;
+          } else if (advanceIfMatchAny<TokenType::STATIC>()) {
+            if (memberStatic) {
+              error(previous(), "Duplicate `static`");
+            }
+            memberStatic = true;
           } else {
             if (inheritanceOverload) {
               error(peek(), "Duplicate `overload`");
@@ -1511,6 +1529,9 @@ auto Parser::parseClass() -> std::unique_ptr<Statement> {
             consume(TokenType::OVERLOAD);
             inheritanceOverload = true;
           }
+        }
+        if (inheritanceOverload && memberStatic) {
+          error(peek(), "`overload` cannot be used with `static` methods");
         }
         if (checkAny<TokenType::LET, TokenType::VAR>()) {
           if (inheritanceOverload) {
@@ -1521,7 +1542,7 @@ auto Parser::parseClass() -> std::unique_ptr<Statement> {
           isExported = false;
           auto restoreExported =
               llvm::make_scope_exit([this, savedExported] { isExported = savedExported; });
-          auto stmt = parseVarDecl(memberPrivate);
+          auto stmt = parseVarDecl(memberPrivate, memberStatic);
           auto* varDecl = dynamic_cast<VarDecl*>(stmt.get());
           if (varDecl != nullptr) {
             endLoc = varDecl->getEnd();
@@ -1535,7 +1556,7 @@ auto Parser::parseClass() -> std::unique_ptr<Statement> {
           isExported = false;
           auto restoreExported =
               llvm::make_scope_exit([this, savedExported] { isExported = savedExported; });
-          auto stmt = parseFunctionDeclaration(memberPrivate, inheritanceOverload);
+          auto stmt = parseFunctionDeclaration(memberPrivate, inheritanceOverload, memberStatic);
           auto* funcDecl = dynamic_cast<FuncDecl*>(stmt.get());
           if (funcDecl != nullptr) {
             endLoc = funcDecl->getEnd();
@@ -1543,7 +1564,7 @@ auto Parser::parseClass() -> std::unique_ptr<Statement> {
             methods.push_back(std::unique_ptr<FuncDecl>(funcDecl));
           }
         } else {
-          error(peek(), "Expected field or method after `private` / `overload`");
+          error(peek(), "Expected field or method after `private` / `overload` / `static`");
         }
       } else if (check(TokenType::NEWLINE)) {
         consume(TokenType::NEWLINE);

--- a/src/liblesma/Frontend/Parser.h
+++ b/src/liblesma/Frontend/Parser.h
@@ -112,7 +112,7 @@ private:
   auto parseParameterList(bool allowVarargsEllipsis) -> ParameterListParseResult;
 
   auto parseFunctionDeclaration(bool methodIsPrivate = false,
-                                bool declaresInheritanceOverload = false)
+                                bool declaresInheritanceOverload = false, bool methodIsStatic = false)
       -> std::unique_ptr<Statement>;
   auto parseExport() -> std::unique_ptr<Statement>;
   auto parseImport() -> std::unique_ptr<Statement>;
@@ -126,7 +126,8 @@ private:
   auto parseIf() -> std::unique_ptr<Statement>;
   auto parseWhile() -> std::unique_ptr<Statement>;
   auto parseFor() -> std::unique_ptr<Statement>;
-  auto parseVarDecl(bool fieldIsPrivate = false) -> std::unique_ptr<Statement>;
+  auto parseVarDecl(bool fieldIsPrivate = false, bool fieldIsStatic = false)
+      -> std::unique_ptr<Statement>;
   auto parseAssignment() -> std::unique_ptr<Statement>;
   auto parseBreak() -> std::unique_ptr<Statement>;
   auto parseContinue() -> std::unique_ptr<Statement>;

--- a/src/liblesma/Symbol/Type.h
+++ b/src/liblesma/Symbol/Type.h
@@ -94,6 +94,8 @@ class Type {
   std::vector<std::string> classVtableMethodOrder;
   // Owned collection of Fields
   std::vector<std::unique_ptr<Field>> fields;
+  /** For TY_CLASS: static `let`/`var` (not part of instance layout). */
+  std::vector<std::unique_ptr<Field>> staticFields;
   llvm::SMRange declarationSpan;
   std::string declarationFilePath;
   bool varArgs = false;
@@ -181,6 +183,15 @@ public:
     return result;
   }
 
+  [[nodiscard]] auto getStaticFields() const -> std::vector<Field*> {
+    std::vector<Field*> result;
+    result.reserve(staticFields.size());
+    for (const auto& field : staticFields) {
+      result.push_back(field.get());
+    }
+    return result;
+  }
+
   auto setLlvmType(llvm::Type* type) -> void { llvmType = type; }
   auto setBaseType(BaseType type) -> void { baseType = type; }
   auto setElementType(Type* type) -> void { elementType = type; }
@@ -217,10 +228,16 @@ public:
   auto setDeclarationFilePath(std::string path) -> void { declarationFilePath = std::move(path); }
   auto setVarArgs(bool value) -> void { varArgs = value; }
   auto addField(std::unique_ptr<Field> field) -> void { fields.push_back(std::move(field)); }
+  auto addStaticField(std::unique_ptr<Field> field) -> void {
+    staticFields.push_back(std::move(field));
+  }
   /** Replace all fields (e.g. refresh a placeholder specialization after the template is complete).
    */
   auto replaceFields(std::vector<std::unique_ptr<Field>> newFields) -> void {
     fields = std::move(newFields);
+  }
+  auto replaceStaticFields(std::vector<std::unique_ptr<Field>> newFields) -> void {
+    staticFields = std::move(newFields);
   }
 
   [[nodiscard]] auto getUnionMembers() const -> const std::vector<Type*>& { return unionMembers; }
@@ -338,6 +355,27 @@ private:
         }
         Type* lt = lf[i]->type;
         Type* rt = rf[i]->type;
+        if (lt == nullptr || rt == nullptr) {
+          if (lt != rt) {
+            return false;
+          }
+          continue;
+        }
+        if (!lt->isEqualImpl(rt, active)) {
+          return false;
+        }
+      }
+      auto lsf = getStaticFields();
+      auto rsf = rhs->getStaticFields();
+      if (lsf.size() != rsf.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < lsf.size(); ++i) {
+        if (lsf[i]->name != rsf[i]->name) {
+          return false;
+        }
+        Type* lt = lsf[i]->type;
+        Type* rt = rsf[i]->type;
         if (lt == nullptr || rt == nullptr) {
           if (lt != rt) {
             return false;

--- a/src/liblesma/Symbol/TypeUtils.cpp
+++ b/src/liblesma/Symbol/TypeUtils.cpp
@@ -43,6 +43,18 @@ auto findFieldInFields(Type* structType, const std::string& field) -> Field* {
   return nullptr;
 }
 
+auto findStaticFieldInClass(Type* classType, const std::string& field) -> Field* {
+  if (classType == nullptr || !classType->is(BaseType::TY_CLASS)) {
+    return nullptr;
+  }
+  for (Field* candidate : classType->getStaticFields()) {
+    if (candidate != nullptr && candidate->name == field) {
+      return candidate;
+    }
+  }
+  return nullptr;
+}
+
 auto isNominalTypeForIdentity(Type const* t) -> bool {
   return t != nullptr && (t->isNominal() || t->is(BaseType::TY_ARRAY));
 }

--- a/src/liblesma/Symbol/TypeUtils.h
+++ b/src/liblesma/Symbol/TypeUtils.h
@@ -15,6 +15,8 @@ auto findIndexInFields(Type* structType, const std::string& field) -> int;
 auto classDataFieldStructIndex(Type* classTy, unsigned logicalIndex) -> unsigned;
 auto findTypeInFields(Type* structType, const std::string& field) -> Type*;
 auto findFieldInFields(Type* structType, const std::string& field) -> Field*;
+/** Class static `let`/`var` only (not instance fields). */
+auto findStaticFieldInClass(Type* classType, const std::string& field) -> Field*;
 /** Class, enum, or array (buffer): types compared by `is` using display-name fallback when
  * `isEqual` is false. */
 [[nodiscard]] auto isNominalTypeForIdentity(Type const* t) -> bool;

--- a/src/liblesma/Symbol/Value.h
+++ b/src/liblesma/Symbol/Value.h
@@ -90,7 +90,8 @@ public:
         closureCaptureOuters(other.closureCaptureOuters),
         closureSlotOuter(other.closureSlotOuter), storesFuncValuePair(other.storesFuncValuePair),
         originLambdaExpr(other.originLambdaExpr),
-        closureCalleeUsesEnvParameter(other.closureCalleeUsesEnvParameter) {}
+        closureCalleeUsesEnvParameter(other.closureCalleeUsesEnvParameter),
+        staticMethod(other.staticMethod) {}
 
   ~Value() = default;
   auto operator=(const Value& other) -> Value& {
@@ -119,6 +120,7 @@ public:
       storesFuncValuePair = other.storesFuncValuePair;
       originLambdaExpr = other.originLambdaExpr;
       closureCalleeUsesEnvParameter = other.closureCalleeUsesEnvParameter;
+      staticMethod = other.staticMethod;
     }
     return *this;
   }
@@ -208,6 +210,9 @@ public:
   }
   auto setClosureCalleeUsesEnvParameter(bool v) -> void { closureCalleeUsesEnvParameter = v; }
 
+  [[nodiscard]] auto isStaticMethod() const -> bool { return staticMethod; }
+  auto setStaticMethod(bool v) -> void { staticMethod = v; }
+
   [[nodiscard]] auto toString() const -> std::string {
     std::string typeStr;
     std::string valueStr;
@@ -255,5 +260,6 @@ private:
   bool storesFuncValuePair = false;
   const LambdaExpr* originLambdaExpr = nullptr;
   bool closureCalleeUsesEnvParameter = false;
+  bool staticMethod = false;
 };
 } // namespace lesma

--- a/src/liblesma/Token/Token.cpp
+++ b/src/liblesma/Token/Token.cpp
@@ -58,6 +58,7 @@ static const std::unordered_map<std::string_view, TokenType> KEYWORDS = {
     {"impl", TokenType::IMPL},
     {"private", TokenType::PRIVATE},
     {"overload", TokenType::OVERLOAD},
+    {"static", TokenType::STATIC},
     // Type keywords
     {"int", TokenType::INT_TYPE},
     {"int64", TokenType::INT_TYPE},

--- a/src/liblesma/Token/TokenType.h
+++ b/src/liblesma/Token/TokenType.h
@@ -119,6 +119,7 @@ enum class TokenType : std::uint8_t {
   IMPL,
   PRIVATE,
   OVERLOAD,
+  STATIC,
 
   // Special tokens
   EOF_TOKEN,

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1257,6 +1257,67 @@ auto Typechecker::substituteInType(Type* t, const std::unordered_map<std::string
   return t;
 }
 
+auto Typechecker::typeUsesClassTypeParameter(
+    Type* t, const std::unordered_set<std::string>& classParamNames) const -> bool {
+  if (t == nullptr) {
+    return false;
+  }
+  if (t->is(BaseType::TY_GENERIC)) {
+    return classParamNames.contains(t->getGenericName());
+  }
+  if (t->is(BaseType::TY_PTR) || t->is(BaseType::TY_ARRAY)) {
+    return typeUsesClassTypeParameter(t->getElementType(), classParamNames);
+  }
+  if (t->is(BaseType::TY_FUNCTION)) {
+    for (Field* field : t->getFields()) {
+      if (typeUsesClassTypeParameter(field->type, classParamNames)) {
+        return true;
+      }
+    }
+    return typeUsesClassTypeParameter(t->getReturnType(), classParamNames);
+  }
+  if (t->is(BaseType::TY_TUPLE)) {
+    for (Field* field : t->getFields()) {
+      if (typeUsesClassTypeParameter(field->type, classParamNames)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (t->is(BaseType::TY_UNION)) {
+    for (Type* m : t->getUnionMembers()) {
+      if (typeUsesClassTypeParameter(m, classParamNames)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (t->is(BaseType::TY_CLASS)) {
+    for (Field* f : t->getFields()) {
+      if (typeUsesClassTypeParameter(f->type, classParamNames)) {
+        return true;
+      }
+    }
+    for (Field* f : t->getStaticFields()) {
+      if (typeUsesClassTypeParameter(f->type, classParamNames)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (t->is(BaseType::TY_TRAIT_EXISTENTIAL)) {
+    if (auto it = specializedTraitExistentialEnv.find(t); it != specializedTraitExistentialEnv.end()) {
+      for (const auto& kv : it->second) {
+        if (typeUsesClassTypeParameter(kv.second, classParamNames)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+  return false;
+}
+
 auto Typechecker::inferGenericBindings(Type* pattern, Type* actual,
                                        std::unordered_map<std::string, Type*>& bindings,
                                        llvm::SMRange span) -> void {
@@ -1477,6 +1538,22 @@ auto Typechecker::getOrCreateSpecializedClassType(Type* classTemplate,
     newFields.push_back(std::move(nf));
   }
   ptr->replaceFields(std::move(newFields));
+  {
+    std::vector<std::unique_ptr<Field>> newStaticFields;
+    for (Field* f : classTemplate->getStaticFields()) {
+      Type* subst = substituteInType(f->type, env);
+      auto nf = std::make_unique<Field>(f->name, subst);
+      nf->setDeclarationSpan(f->getDeclarationSpan());
+      nf->setDeclarationFilePath(f->getDeclarationFilePath());
+      if (Value* ds = f->getDeclarationSymbol()) {
+        auto symCopy = std::make_unique<Value>(*ds);
+        symCopy->setType(subst);
+        nf->setDeclarationSymbol(std::move(symCopy));
+      }
+      newStaticFields.push_back(std::move(nf));
+    }
+    ptr->replaceStaticFields(std::move(newStaticFields));
+  }
   return ptr;
 }
 
@@ -1508,6 +1585,22 @@ void Typechecker::finalizeSpecializedTypesForTemplate(Type* classTemplate) {
       newFields.push_back(std::move(nf));
     }
     specPtr->replaceFields(std::move(newFields));
+    {
+      std::vector<std::unique_ptr<Field>> newStaticFields;
+      for (Field* f : classTemplate->getStaticFields()) {
+        Type* subst = substituteInType(f->type, env);
+        auto nf = std::make_unique<Field>(f->name, subst);
+        nf->setDeclarationSpan(f->getDeclarationSpan());
+        nf->setDeclarationFilePath(f->getDeclarationFilePath());
+        if (Value* ds = f->getDeclarationSymbol()) {
+          auto symCopy = std::make_unique<Value>(*ds);
+          symCopy->setType(subst);
+          nf->setDeclarationSymbol(std::move(symCopy));
+        }
+        newStaticFields.push_back(std::move(nf));
+      }
+      specPtr->replaceStaticFields(std::move(newStaticFields));
+    }
     specPtr->setDisplayName(makeSpecializedDisplayName(classTemplate, genericParamNames, env));
     if (classTemplate->getClassSuperclass() != nullptr) {
       specPtr->setClassSuperclass(substituteInType(classTemplate->getClassSuperclass(), env));
@@ -3533,10 +3626,6 @@ auto Typechecker::visit(const Class* node) -> void {
     }
 
     for (VarDecl* field : node->getFields()) {
-      if (!node->getGenericParamDecls().empty() && field->getIsStatic()) {
-        throw TypeCheckError(field->getSpan(),
-                             "Static fields are not supported in generic classes yet");
-      }
       std::string const fname = field->getIdentifier()->getValue();
       for (Field* existing : classTypePtr->getFields()) {
         if (existing->name == fname) {
@@ -3551,13 +3640,14 @@ auto Typechecker::visit(const Class* node) -> void {
         }
       }
       Type* fieldType = nullptr;
+      Type* initType = nullptr;
       if (field->getType() != nullptr) {
         field->getType()->accept(*this);
         fieldType = result->getType();
       }
       if (field->getValue() != nullptr) {
         field->getValue()->accept(*this);
-        Type* initType = result->getType();
+        initType = result->getType();
         if (fieldType != nullptr) {
           if (!isAssignableTo(initType, fieldType)) {
             throw TypeCheckError(
@@ -3571,6 +3661,22 @@ auto Typechecker::visit(const Class* node) -> void {
       }
       if (fieldType == nullptr) {
         throw TypeCheckError(field->getSpan(), "Class field has no type");
+      }
+      if (!node->getGenericParamDecls().empty() && field->getIsStatic()) {
+        std::unordered_set<std::string> classParamNames;
+        classParamNames.reserve(node->getGenericParamDecls().size());
+        for (const auto& p : node->getGenericParamDecls()) {
+          classParamNames.insert(p.name);
+        }
+        if (typeUsesClassTypeParameter(fieldType, classParamNames)) {
+          throw TypeCheckError(field->getSpan(),
+                               "Static field type cannot use the class's generic parameters");
+        }
+        if (initType != nullptr && typeUsesClassTypeParameter(initType, classParamNames)) {
+          throw TypeCheckError(
+              field->getSpan(),
+              "Static field initializer type cannot use the class's generic parameters");
+        }
       }
       auto fieldEntry = std::make_unique<Field>(field->getIdentifier()->getValue(), fieldType);
       fieldEntry->setDeclarationSpan(field->getIdentifier()->getSpan());

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -3423,7 +3423,7 @@ void Typechecker::mergeClassVtableOrder(const Class* node, Type* classTy,
     }
   }
   for (FuncDecl* m : node->getMethods()) {
-    if (m->getName() == "new") {
+    if (m->getName() == "new" || m->getIsStatic()) {
       continue;
     }
     std::string methodKey = vtableMethodKey(m->getResolvedSymbol());
@@ -3525,15 +3525,29 @@ auto Typechecker::visit(const Class* node) -> void {
     }
 
     classTemplateBeingDeclared = classTypePtr;
-    classFieldCountExpected = node->getFields().size();
+    classFieldCountExpected = 0;
+    for (VarDecl* f : node->getFields()) {
+      if (!f->getIsStatic()) {
+        classFieldCountExpected++;
+      }
+    }
 
     for (VarDecl* field : node->getFields()) {
+      if (!node->getGenericParamDecls().empty() && field->getIsStatic()) {
+        throw TypeCheckError(field->getSpan(),
+                             "Static fields are not supported in generic classes yet");
+      }
       std::string const fname = field->getIdentifier()->getValue();
       for (Field* existing : classTypePtr->getFields()) {
         if (existing->name == fname) {
           throw TypeCheckError(
               field->getSpan(),
               "Field '{}' conflicts with a superclass field or duplicate declaration", fname);
+        }
+      }
+      for (Field* existing : classTypePtr->getStaticFields()) {
+        if (existing->name == fname) {
+          throw TypeCheckError(field->getSpan(), "Duplicate static field '{}'", fname);
         }
       }
       Type* fieldType = nullptr;
@@ -3572,7 +3586,11 @@ auto Typechecker::visit(const Class* node) -> void {
       fieldSymbol->setDeclarationFilePath(mainFilePath);
       field->setResolvedSymbol(fieldSymbol.get());
       fieldEntry->setDeclarationSymbol(std::move(fieldSymbol));
-      classTypePtr->addField(std::move(fieldEntry));
+      if (field->getIsStatic()) {
+        classTypePtr->addStaticField(std::move(fieldEntry));
+      } else {
+        classTypePtr->addField(std::move(fieldEntry));
+      }
     }
 
     finalizeSpecializedTypesForTemplate(classTypePtr);
@@ -3595,9 +3613,11 @@ auto Typechecker::visit(const Class* node) -> void {
     currentMethodInsertScope = outerScope;
     SymbolTable* methodScope = scope->createChildBlock("method");
     scope = methodScope;
-    auto selfSymbol = std::make_unique<Value>("self", selfPtrType);
-    selfSymbol->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
-    scope->insertSymbol(std::move(selfSymbol));
+    if (!func->getIsStatic()) {
+      auto selfSym = std::make_unique<Value>("self", selfPtrType);
+      selfSym->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+      scope->insertSymbol(std::move(selfSym));
+    }
     func->accept(*this);
     scope = scope->getParent();
     currentClassType = nullptr;
@@ -3652,11 +3672,14 @@ auto Typechecker::visit(const FuncDecl* node) -> void {
   }
   insertGenericParamSymbols(genericsScope, node->getGenericParamDecls(), currentGenericTypes,
                             mainFilePath);
+  if (node->getIsStatic() && node->getName() == "new") {
+    throw TypeCheckError(node->getNameSpan(), "Constructor `new` cannot be declared `static`");
+  }
   node->getReturnType()->accept(*this);
   Type* returnType = wrapReturnTypeIfNominal(result->getType());
   std::vector<std::unique_ptr<Field>> paramFields;
   std::vector<Type*> paramTypes;
-  if (currentClassType != nullptr) {
+  if (currentClassType != nullptr && !node->getIsStatic()) {
     Type* selfPtr = cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, currentClassType));
     paramFields.push_back(std::make_unique<Field>("self", selfPtr));
     paramTypes.push_back(selfPtr);
@@ -3732,6 +3755,7 @@ auto Typechecker::visit(const FuncDecl* node) -> void {
       }
       declaredFunc->setDeclarationSpan(node->getNameSpan());
       declaredFunc->setDeclarationFilePath(mainFilePath);
+      declaredFunc->setStaticMethod(node->getIsStatic());
       insertScope->insertSymbol(std::move(declaredFunc));
       funcSymbol = insertScope->lookupFunction(node->getName(), paramTypes,
                                                FunctionLookupKind::OVERLOAD_IDENTITY);
@@ -3748,6 +3772,7 @@ auto Typechecker::visit(const FuncDecl* node) -> void {
         funcSymbol->setPrivateMember(node->getIsPrivate());
         funcSymbol->setMemberDeclaredInClass(currentClassType);
       }
+      funcSymbol->setStaticMethod(node->getIsStatic());
       funcSymbol->setDeclarationSpan(node->getNameSpan());
       funcSymbol->setDeclarationFilePath(mainFilePath);
       // Set resolvedSymbol for existing symbol (this exact overload)
@@ -3759,7 +3784,8 @@ auto Typechecker::visit(const FuncDecl* node) -> void {
       funcSymbol->setBodyScope(child);
       SymbolTable* savedScopePtr = scope;
       scope = child;
-      const size_t paramOffset = (currentClassType != nullptr) ? 1U : 0U;
+      const size_t paramOffset =
+          (currentClassType != nullptr) && !node->getIsStatic() ? 1U : 0U;
       for (size_t i = 0; i < node->getParameters().size(); ++i) {
         Parameter* param = node->getParameters()[i];
         auto paramSymbol = std::make_unique<Value>(param->name, paramTypes[paramOffset + i]);
@@ -4902,6 +4928,7 @@ auto Typechecker::visit(const DotOp* node) -> void {
   }
 
   node->getLeft()->accept(*this);
+  bool const dotLeftDenotesTypeName = (result->getCategory() == ValueCategory::TYPE_SYMBOL);
   Type* base = result->getType();
   auto isStdListClassType = [this](Type* type) -> bool {
     if (type == nullptr) {
@@ -5230,12 +5257,19 @@ auto Typechecker::visit(const DotOp* node) -> void {
     if (templateIt != specializedTypeToTemplate.end()) {
       receiverForLookup = templateIt->second;
     }
-    Type* selfType =
-        receiverForLookup->is(BaseType::TY_PTR)
-            ? receiverForLookup
-            : cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, receiverForLookup));
-    std::vector<Type*> methodArgTypes = {selfType};
-    methodArgTypes.insert(methodArgTypes.end(), argTypes.begin(), argTypes.end());
+    std::vector<Type*> methodArgTypes;
+    bool const typeNameReceiver =
+        dotLeftDenotesTypeName && receiverForLookup->is(BaseType::TY_CLASS);
+    if (typeNameReceiver && fc->getName() != "new") {
+      methodArgTypes = argTypes;
+    } else {
+      Type* selfType =
+          receiverForLookup->is(BaseType::TY_PTR)
+              ? receiverForLookup
+              : cacheType(std::make_unique<Type>(BaseType::TY_PTR, nullptr, receiverForLookup));
+      methodArgTypes.push_back(selfType);
+      methodArgTypes.insert(methodArgTypes.end(), argTypes.begin(), argTypes.end());
+    }
     std::unordered_map<std::string, Type*> methodTypeEnv;
     auto specializedIt = specializedTypeEnv.find(base);
     if (specializedIt != specializedTypeEnv.end()) {
@@ -5266,6 +5300,12 @@ auto Typechecker::visit(const DotOp* node) -> void {
     }
     if (method == nullptr) {
       throw TypeCheckError(node->getSpan(), "Function not found: {}", fc->getName());
+    }
+    if (typeNameReceiver && fc->getName() != "new" && !method->isStaticMethod()) {
+      throw TypeCheckError(node->getSpan(),
+                           "Cannot call instance method `{}` on a type name; call it on a value, "
+                           "or declare the method `static`",
+                           fc->getName());
     }
     fc->setResolvedSymbol(method);
     enforcePrivateMemberReadable(node->getSpan(), method);
@@ -5328,9 +5368,22 @@ auto Typechecker::visit(const DotOp* node) -> void {
     throw TypeCheckError(node->getSpan(), "Expected field name or method call after dot");
   }
   auto* rightLit = dynamic_cast<Literal*>(node->getRight());
-  Field* field = TypeUtils::findFieldInFields(base, rightLit->getValue());
+  Field* field = nullptr;
+  if (base->is(BaseType::TY_CLASS) && dotLeftDenotesTypeName) {
+    field = TypeUtils::findStaticFieldInClass(base, rightLit->getValue());
+  }
+  if (field == nullptr) {
+    field = TypeUtils::findFieldInFields(base, rightLit->getValue());
+  }
   if (field == nullptr || field->type == nullptr) {
     throw TypeCheckError(node->getSpan(), "Unknown field: {}", rightLit->getValue());
+  }
+  if (dotLeftDenotesTypeName && base->is(BaseType::TY_CLASS) &&
+      TypeUtils::findStaticFieldInClass(base, rightLit->getValue()) == nullptr) {
+    throw TypeCheckError(node->getSpan(),
+                         "Cannot access instance field `{}` on a type name; use a value, "
+                         "or declare the field `static`",
+                         rightLit->getValue());
   }
   if (field->getDeclarationSymbol() != nullptr) {
     rightLit->setResolvedSymbol(field->getDeclarationSymbol());

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -5339,6 +5339,70 @@ auto Typechecker::visit(const DotOp* node) -> void {
       }
     }
     std::unordered_map<std::string, Type*> traitBoundSubs = methodTypeEnv;
+    // Infer class type parameters for `GenericClass.staticMethod(...)` when the dot receiver is the
+    // unspecialized class template (Swift-style: `Cell.of(7)` fixes `T` to `int`).
+    if (typeNameReceiver && fc->getName() != "new" && method->isStaticMethod() &&
+        receiverForLookup->is(BaseType::TY_CLASS)) {
+      const auto& classGenParams = getDeclaredGenericParams(receiverForLookup);
+      if (!classGenParams.empty()) {
+        std::unordered_map<std::string, Type*> inferredFromArgs;
+        std::vector<Field*> const& mtFields = methodType->getFields();
+        for (size_t i = 0; i < methodArgTypes.size() && i < mtFields.size(); ++i) {
+          inferGenericBindings(mtFields[i]->type, methodArgTypes[i], inferredFromArgs,
+                               node->getSpan());
+        }
+        for (const std::string& gn : classGenParams) {
+          auto inferredIt = inferredFromArgs.find(gn);
+          auto existingIt = traitBoundSubs.find(gn);
+          if (existingIt != traitBoundSubs.end()) {
+            if (inferredIt != inferredFromArgs.end() &&
+                !existingIt->second->isEqual(inferredIt->second)) {
+              throw TypeCheckError(node->getSpan(),
+                                   "Conflicting types for class type parameter `{}`: {} vs {}",
+                                   gn, existingIt->second->toString(),
+                                   inferredIt->second->toString());
+            }
+            continue;
+          }
+          if (inferredIt == inferredFromArgs.end()) {
+            // Swift-style: `var x: Cell<int> = Cell.wrap_int(3)` — args may not mention `T`, but the
+            // enclosing expected type specializes the same class template.
+            Type* ctxClass = nullptr;
+            if (Type* exp = currentExpectedType(); exp != nullptr) {
+              Type* shape = exp;
+              if (shape->is(BaseType::TY_PTR) && shape->getElementType() != nullptr &&
+                  shape->getElementType()->is(BaseType::TY_CLASS)) {
+                shape = shape->getElementType();
+              }
+              if (shape->is(BaseType::TY_CLASS)) {
+                if (auto tit = specializedTypeToTemplate.find(shape);
+                    tit != specializedTypeToTemplate.end() &&
+                    tit->second->isEqual(receiverForLookup)) {
+                  ctxClass = shape;
+                }
+              }
+            }
+            if (ctxClass != nullptr) {
+              if (auto eit = specializedTypeEnv.find(ctxClass);
+                  eit != specializedTypeEnv.end()) {
+                auto cit = eit->second.find(gn);
+                if (cit != eit->second.end()) {
+                  traitBoundSubs[gn] = cit->second;
+                  continue;
+                }
+              }
+            }
+            throw TypeCheckError(
+                node->getSpan(),
+                "Cannot infer class type parameter `{}` from this static method call; use "
+                "arguments that determine `{}`, a contextual type (e.g. variable annotation), or "
+                "call through a specialized type",
+                gn, gn);
+          }
+          traitBoundSubs[gn] = inferredIt->second;
+        }
+      }
+    }
     if (fc->getExplicitTypeArgs().empty()) {
       const auto& methodGenericNames = methodType->getGenericParams();
       if (!methodGenericNames.empty()) {
@@ -5360,6 +5424,9 @@ auto Typechecker::visit(const DotOp* node) -> void {
     Type* retType = methodType->getReturnType();
     if (!traitBoundSubs.empty() && retType != nullptr) {
       retType = substituteInType(retType, traitBoundSubs);
+    }
+    if (!traitBoundSubs.empty()) {
+      fc->setGenericBindingEnv(traitBoundSubs);
     }
     result = std::make_unique<Value>(retType);
     return;

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1003,6 +1003,27 @@ auto Typechecker::materializeImportedType(Type* type) -> Type* {
       copy->addField(std::move(fieldCopy));
     }
     if (type->is(BaseType::TY_CLASS)) {
+      for (Field* field : type->getStaticFields()) {
+        auto fieldCopy =
+            std::make_unique<Field>(field->name, materializeImportedType(field->type));
+        fieldCopy->setDeclarationSpan(field->getDeclarationSpan());
+        fieldCopy->setDeclarationFilePath(field->getDeclarationFilePath());
+        if (Value* declarationSymbol = field->getDeclarationSymbol()) {
+          auto symbolCopy = std::make_unique<Value>(declarationSymbol->getName(),
+                                                    materializeImportedType(field->type));
+          symbolCopy->setCategory(declarationSymbol->getCategory());
+          symbolCopy->setDeclarationKind(declarationSymbol->getDeclarationKind());
+          symbolCopy->setDeclarationSpan(declarationSymbol->getDeclarationSpan());
+          symbolCopy->setDeclarationFilePath(declarationSymbol->getDeclarationFilePath());
+          symbolCopy->setMutable(declarationSymbol->getMutability());
+          symbolCopy->setPrivateMember(declarationSymbol->isPrivateMember());
+          if (Type* declCls = declarationSymbol->getMemberDeclaredInClass(); declCls != nullptr) {
+            symbolCopy->setMemberDeclaredInClass(materializeImportedType(declCls));
+          }
+          fieldCopy->setDeclarationSymbol(std::move(symbolCopy));
+        }
+        copy->addStaticField(std::move(fieldCopy));
+      }
       copy->setClassSuperclass(materializeImportedType(type->getClassSuperclass()));
       copy->setClassVtableMethodOrder(std::vector<std::string>(type->getClassVtableMethodOrder()));
       copy->setClassHasDerivedClass(type->getClassHasDerivedClass());
@@ -1302,7 +1323,13 @@ auto Typechecker::typeUsesClassTypeParameter(
   if (t->is(BaseType::TY_CLASS)) {
     auto envIt = specializedTypeEnv.find(t);
     if (envIt == specializedTypeEnv.end()) {
-      return false;
+      // Unspecialized generic class template (declaration type) is not in specializedTypeEnv;
+      // treat it as using type parameters for static-field / similar restrictions.
+      Type* classTemplate = t;
+      if (auto tmplIt = specializedTypeToTemplate.find(t); tmplIt != specializedTypeToTemplate.end()) {
+        classTemplate = tmplIt->second;
+      }
+      return !classTemplate->getGenericParams().empty();
     }
     if (visitedNominalClasses.contains(t)) {
       return false;
@@ -3631,7 +3658,7 @@ auto Typechecker::visit(const Class* node) -> void {
     }
 
     classTemplateBeingDeclared = classTypePtr;
-    classFieldCountExpected = 0;
+    classFieldCountExpected = classTypePtr->getFields().size();
     for (VarDecl* f : node->getFields()) {
       if (!f->getIsStatic()) {
         classFieldCountExpected++;
@@ -5069,6 +5096,20 @@ auto Typechecker::visit(const DotOp* node) -> void {
           dotLeftDenotesTypeName = true;
         }
       }
+    } else if (auto pathIt = importAliasToPath.find(leftLit->getValue());
+               pathIt != importAliasToPath.end()) {
+      if (SymbolTable* imp = getOrTypecheckImport(pathIt->second)) {
+        if (auto* rightId = dynamic_cast<Literal*>(node->getRight());
+            rightId != nullptr && rightId->getType() == TokenType::IDENTIFIER) {
+          if (Value* exported = imp->lookup(rightId->getValue());
+              exported != nullptr && exported->getType() != nullptr &&
+              exported->getType()->isOneOf(
+                  {BaseType::TY_CLASS, BaseType::TY_ENUM, BaseType::TY_TRAIT_EXISTENTIAL})) {
+            base = materializeImportedType(exported->getType());
+            dotLeftDenotesTypeName = true;
+          }
+        }
+      }
     }
   }
   auto isStdListClassType = [this](Type* type) -> bool {
@@ -5434,6 +5475,11 @@ auto Typechecker::visit(const DotOp* node) -> void {
         if (auto srcIt = importedNameToSource.find(leftLit->getValue());
             srcIt != importedNameToSource.end()) {
           if (SymbolTable* imp = getOrTypecheckImport(srcIt->second.first)) {
+            method = imp->lookupFunction(fc->getName(), methodArgTypes);
+          }
+        } else if (auto ap = importAliasToPath.find(leftLit->getValue());
+                   ap != importAliasToPath.end()) {
+          if (SymbolTable* imp = getOrTypecheckImport(ap->second)) {
             method = imp->lookupFunction(fc->getName(), methodArgTypes);
           }
         }

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1259,6 +1259,13 @@ auto Typechecker::substituteInType(Type* t, const std::unordered_map<std::string
 
 auto Typechecker::typeUsesClassTypeParameter(
     Type* t, const std::unordered_set<std::string>& classParamNames) const -> bool {
+  std::unordered_set<Type*> visitedNominalClasses;
+  return typeUsesClassTypeParameter(t, classParamNames, visitedNominalClasses);
+}
+
+auto Typechecker::typeUsesClassTypeParameter(
+    Type* t, const std::unordered_set<std::string>& classParamNames,
+    std::unordered_set<Type*>& visitedNominalClasses) const -> bool {
   if (t == nullptr) {
     return false;
   }
@@ -1266,19 +1273,19 @@ auto Typechecker::typeUsesClassTypeParameter(
     return classParamNames.contains(t->getGenericName());
   }
   if (t->is(BaseType::TY_PTR) || t->is(BaseType::TY_ARRAY)) {
-    return typeUsesClassTypeParameter(t->getElementType(), classParamNames);
+    return typeUsesClassTypeParameter(t->getElementType(), classParamNames, visitedNominalClasses);
   }
   if (t->is(BaseType::TY_FUNCTION)) {
     for (Field* field : t->getFields()) {
-      if (typeUsesClassTypeParameter(field->type, classParamNames)) {
+      if (typeUsesClassTypeParameter(field->type, classParamNames, visitedNominalClasses)) {
         return true;
       }
     }
-    return typeUsesClassTypeParameter(t->getReturnType(), classParamNames);
+    return typeUsesClassTypeParameter(t->getReturnType(), classParamNames, visitedNominalClasses);
   }
   if (t->is(BaseType::TY_TUPLE)) {
     for (Field* field : t->getFields()) {
-      if (typeUsesClassTypeParameter(field->type, classParamNames)) {
+      if (typeUsesClassTypeParameter(field->type, classParamNames, visitedNominalClasses)) {
         return true;
       }
     }
@@ -1286,30 +1293,35 @@ auto Typechecker::typeUsesClassTypeParameter(
   }
   if (t->is(BaseType::TY_UNION)) {
     for (Type* m : t->getUnionMembers()) {
-      if (typeUsesClassTypeParameter(m, classParamNames)) {
+      if (typeUsesClassTypeParameter(m, classParamNames, visitedNominalClasses)) {
         return true;
       }
     }
     return false;
   }
   if (t->is(BaseType::TY_CLASS)) {
-    for (Field* f : t->getFields()) {
-      if (typeUsesClassTypeParameter(f->type, classParamNames)) {
+    auto envIt = specializedTypeEnv.find(t);
+    if (envIt == specializedTypeEnv.end()) {
+      return false;
+    }
+    if (visitedNominalClasses.contains(t)) {
+      return false;
+    }
+    visitedNominalClasses.insert(t);
+    for (const auto& kv : envIt->second) {
+      if (typeUsesClassTypeParameter(kv.second, classParamNames, visitedNominalClasses)) {
+        visitedNominalClasses.erase(t);
         return true;
       }
     }
-    for (Field* f : t->getStaticFields()) {
-      if (typeUsesClassTypeParameter(f->type, classParamNames)) {
-        return true;
-      }
-    }
+    visitedNominalClasses.erase(t);
     return false;
   }
   if (t->is(BaseType::TY_TRAIT_EXISTENTIAL)) {
     if (auto it = specializedTraitExistentialEnv.find(t);
         it != specializedTraitExistentialEnv.end()) {
       for (const auto& kv : it->second) {
-        if (typeUsesClassTypeParameter(kv.second, classParamNames)) {
+        if (typeUsesClassTypeParameter(kv.second, classParamNames, visitedNominalClasses)) {
           return true;
         }
       }
@@ -5037,8 +5049,28 @@ auto Typechecker::visit(const DotOp* node) -> void {
   }
 
   node->getLeft()->accept(*this);
-  bool const dotLeftDenotesTypeName = (result->getCategory() == ValueCategory::TYPE_SYMBOL);
+  bool dotLeftDenotesTypeName = result->getCategory() == ValueCategory::TYPE_SYMBOL;
   Type* base = result->getType();
+  // `from "m" import C` binds `C` as MODULE_SYMBOL + TY_IMPORT; peel to the nominal type so static
+  // members use the same path as TYPE_SYMBOL receivers (and we do not fall through the module-dot
+  // handler that only keys off importAliasToPath).
+  if (auto* leftLit = dynamic_cast<Literal*>(node->getLeft());
+      leftLit != nullptr && leftLit->getType() == TokenType::IDENTIFIER &&
+      result->getCategory() == ValueCategory::MODULE_SYMBOL && base != nullptr &&
+      base->is(BaseType::TY_IMPORT)) {
+    if (auto srcIt = importedNameToSource.find(leftLit->getValue());
+        srcIt != importedNameToSource.end()) {
+      if (SymbolTable* imp = getOrTypecheckImport(srcIt->second.first)) {
+        if (Value* exported = imp->lookup(srcIt->second.second);
+            exported != nullptr && exported->getType() != nullptr &&
+            exported->getType()->isOneOf(
+                {BaseType::TY_CLASS, BaseType::TY_ENUM, BaseType::TY_TRAIT_EXISTENTIAL})) {
+          base = materializeImportedType(exported->getType());
+          dotLeftDenotesTypeName = true;
+        }
+      }
+    }
+  }
   auto isStdListClassType = [this](Type* type) -> bool {
     if (type == nullptr) {
       return false;

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1306,7 +1306,8 @@ auto Typechecker::typeUsesClassTypeParameter(
     return false;
   }
   if (t->is(BaseType::TY_TRAIT_EXISTENTIAL)) {
-    if (auto it = specializedTraitExistentialEnv.find(t); it != specializedTraitExistentialEnv.end()) {
+    if (auto it = specializedTraitExistentialEnv.find(t);
+        it != specializedTraitExistentialEnv.end()) {
       for (const auto& kv : it->second) {
         if (typeUsesClassTypeParameter(kv.second, classParamNames)) {
           return true;
@@ -3690,6 +3691,9 @@ auto Typechecker::visit(const Class* node) -> void {
       fieldSymbol->setMemberDeclaredInClass(classTypePtr);
       fieldSymbol->setDeclarationSpan(field->getIdentifier()->getSpan());
       fieldSymbol->setDeclarationFilePath(mainFilePath);
+      if (fieldType != nullptr && fieldType->is(BaseType::TY_FUNCTION)) {
+        fieldSymbol->setStoresFuncValuePair(true);
+      }
       field->setResolvedSymbol(fieldSymbol.get());
       fieldEntry->setDeclarationSymbol(std::move(fieldSymbol));
       if (field->getIsStatic()) {
@@ -3890,8 +3894,7 @@ auto Typechecker::visit(const FuncDecl* node) -> void {
       funcSymbol->setBodyScope(child);
       SymbolTable* savedScopePtr = scope;
       scope = child;
-      const size_t paramOffset =
-          (currentClassType != nullptr) && !node->getIsStatic() ? 1U : 0U;
+      const size_t paramOffset = (currentClassType != nullptr) && !node->getIsStatic() ? 1U : 0U;
       for (size_t i = 0; i < node->getParameters().size(); ++i) {
         Parameter* param = node->getParameters()[i];
         auto paramSymbol = std::make_unique<Value>(param->name, paramTypes[paramOffset + i]);
@@ -5464,15 +5467,14 @@ auto Typechecker::visit(const DotOp* node) -> void {
             if (inferredIt != inferredFromArgs.end() &&
                 !existingIt->second->isEqual(inferredIt->second)) {
               throw TypeCheckError(node->getSpan(),
-                                   "Conflicting types for class type parameter `{}`: {} vs {}",
-                                   gn, existingIt->second->toString(),
-                                   inferredIt->second->toString());
+                                   "Conflicting types for class type parameter `{}`: {} vs {}", gn,
+                                   existingIt->second->toString(), inferredIt->second->toString());
             }
             continue;
           }
           if (inferredIt == inferredFromArgs.end()) {
-            // Swift-style: `var x: Cell<int> = Cell.wrap_int(3)` — args may not mention `T`, but the
-            // enclosing expected type specializes the same class template.
+            // Swift-style: `var x: Cell<int> = Cell.wrap_int(3)` — args may not mention `T`, but
+            // the enclosing expected type specializes the same class template.
             Type* ctxClass = nullptr;
             if (Type* exp = currentExpectedType(); exp != nullptr) {
               Type* shape = exp;
@@ -5489,8 +5491,7 @@ auto Typechecker::visit(const DotOp* node) -> void {
               }
             }
             if (ctxClass != nullptr) {
-              if (auto eit = specializedTypeEnv.find(ctxClass);
-                  eit != specializedTypeEnv.end()) {
+              if (auto eit = specializedTypeEnv.find(ctxClass); eit != specializedTypeEnv.end()) {
                 auto cit = eit->second.find(gn);
                 if (cit != eit->second.end()) {
                   traitBoundSubs[gn] = cit->second;

--- a/src/liblesma/Typecheck/Typechecker.h
+++ b/src/liblesma/Typecheck/Typechecker.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "llvm/Support/SMLoc.h"
@@ -190,6 +191,9 @@ class Typechecker final : public ASTVisitor {
       -> Type*;
   /** Substitute env into type (for fields); returns cached type. */
   auto substituteInType(Type* t, const std::unordered_map<std::string, Type*>& env) -> Type*;
+  /** True if \p t mentions any name in \p classParamNames (enclosing class type parameters). */
+  [[nodiscard]] auto typeUsesClassTypeParameter(
+      Type* t, const std::unordered_set<std::string>& classParamNames) const -> bool;
   /** Infer generic bindings from a parameter/argument type pair. */
   auto inferGenericBindings(Type* pattern, Type* actual,
                             std::unordered_map<std::string, Type*>& bindings, llvm::SMRange span)

--- a/src/liblesma/Typecheck/Typechecker.h
+++ b/src/liblesma/Typecheck/Typechecker.h
@@ -194,6 +194,11 @@ class Typechecker final : public ASTVisitor {
   /** True if \p t mentions any name in \p classParamNames (enclosing class type parameters). */
   [[nodiscard]] auto typeUsesClassTypeParameter(
       Type* t, const std::unordered_set<std::string>& classParamNames) const -> bool;
+  /** Same as the 2-arg overload; \p visitedNominalClasses breaks cycles on specialized class types
+   *  (e.g. \c *Node<T> to \c Node<T>) while walking \c specializedTypeEnv argument types. */
+  [[nodiscard]] auto typeUsesClassTypeParameter(
+      Type* t, const std::unordered_set<std::string>& classParamNames,
+      std::unordered_set<Type*>& visitedNominalClasses) const -> bool;
   /** Infer generic bindings from a parameter/argument type pair. */
   auto inferGenericBindings(Type* pattern, Type* actual,
                             std::unordered_map<std::string, Type*>& bindings, llvm::SMRange span)

--- a/src/lsp/LspCompletion.cpp
+++ b/src/lsp/LspCompletion.cpp
@@ -1208,6 +1208,11 @@ auto completionItems(AnalysisResult& result, unsigned line, unsigned character)
   if (activeResult->parser == nullptr || activeResult->rootScope == nullptr) {
     return CompletionOutcome{};
   }
+  llvm::SourceMgr* activeSrcMgr = activeResult->sourceMgr.get();
+  unsigned const activeBufferId = activeResult->mainBufferId;
+  if (activeSrcMgr == nullptr) {
+    return CompletionOutcome{};
+  }
   Compound* ast = activeResult->parser->getAst();
   if (ast == nullptr) {
     return CompletionOutcome{};
@@ -1216,10 +1221,11 @@ auto completionItems(AnalysisResult& result, unsigned line, unsigned character)
   SymbolTable* activeScope = activeScopeForOffset(*activeResult, offset);
   SymbolTable* root = activeResult->rootScope.get();
 
-  InnermostFunc const cursorContext = findInnermostFuncContaining(ast, offset, srcMgr, bufferId);
+  InnermostFunc const cursorContext =
+      findInnermostFuncContaining(ast, offset, activeSrcMgr, activeBufferId);
   Class* const completionEnclosingClass = cursorContext.enclosingClass;
   TraitDecl* const completionEnclosingTrait =
-      findInnermostTraitDeclContaining(ast, offset, srcMgr, bufferId);
+      findInnermostTraitDeclContaining(ast, offset, activeSrcMgr, activeBufferId);
 
   std::vector<CompletionCandidate> candidates;
   std::unordered_set<std::string> seen;
@@ -1228,7 +1234,7 @@ auto completionItems(AnalysisResult& result, unsigned line, unsigned character)
     std::vector<std::string> parts = splitChain(ctx.memberChain);
     Type* baseType = resolveChainType(*activeResult, ctx.memberChain, activeScope, root);
     if (baseType == nullptr && parts.size() == 1U && parts.front() == "self") {
-      baseType = resolveSelfReceiverType(ast, offset, srcMgr, bufferId, root);
+      baseType = resolveSelfReceiverType(ast, offset, activeSrcMgr, activeBufferId, root);
     }
     if (parts.size() == 1U && activeResult->importAliasToPath.contains(parts.front())) {
       appendModuleMembersForAlias(*activeResult, parts.front(), candidates, seen);

--- a/src/lsp/LspCompletion.cpp
+++ b/src/lsp/LspCompletion.cpp
@@ -585,7 +585,27 @@ auto resolveMemberFieldType(Type* baseType, const std::string& name) -> Type* {
   if (!baseType->is(BaseType::TY_CLASS) && !baseType->is(BaseType::TY_ENUM)) {
     return nullptr;
   }
-  return TypeUtils::findTypeInFields(baseType, name);
+  Type* t = TypeUtils::findTypeInFields(baseType, name);
+  if (t != nullptr) {
+    return t;
+  }
+  if (baseType->is(BaseType::TY_CLASS)) {
+    if (Field* sf = TypeUtils::findStaticFieldInClass(baseType, name); sf != nullptr) {
+      return sf->type;
+    }
+  }
+  return nullptr;
+}
+
+/** True when completing after `TypeName.` where `TypeName` is a type symbol (static members). */
+[[nodiscard]] auto memberCompletionUsesTypeNameContext(SymbolTable* scope, SymbolTable* root,
+                                                     const std::string& memberChain) -> bool {
+  std::vector<std::string> parts = splitChain(memberChain);
+  if (parts.size() != 1U) {
+    return false;
+  }
+  Value* leaf = lookupName(scope, root, parts.front());
+  return leaf != nullptr && leaf->getCategory() == ValueCategory::TYPE_SYMBOL;
 }
 
 auto resolveChainType(const AnalysisResult& result, const std::string& chain, SymbolTable* scope,
@@ -822,14 +842,26 @@ auto findClassDeclarationForType(AnalysisResult& result, Type* classType, Compou
 }
 
 void appendMethodsForClass(AnalysisResult& result, Class* klass, SymbolTable* root,
-                           Class* completionEnclosingClass, std::vector<CompletionCandidate>& out,
+                           Class* completionEnclosingClass, bool completingOnTypeName,
+                           std::vector<CompletionCandidate>& out,
                            std::unordered_set<std::string>& seen) {
   if (klass == nullptr) {
     return;
   }
   AnalysisView const mainView = makeAnalysisView(result);
   for (FuncDecl* method : klass->getMethods()) {
-    if (method == nullptr || method->getName() == "new") {
+    if (method == nullptr) {
+      continue;
+    }
+    if (method->getName() == "new") {
+      if (!completingOnTypeName) {
+        continue;
+      }
+    } else if (method->getIsStatic()) {
+      if (!completingOnTypeName) {
+        continue;
+      }
+    } else if (completingOnTypeName) {
       continue;
     }
     if (method->getIsPrivate() && klass != completionEnclosingClass) {
@@ -886,9 +918,13 @@ void addCandidate(std::vector<CompletionCandidate>& out, std::unordered_set<std:
 
 void appendTraitRequirementMethods(AnalysisResult& result, Type* classType, Compound* mainAst,
                                    SymbolTable* root, TraitDecl* completionEnclosingTrait,
+                                   bool completingOnTypeName,
                                    std::vector<CompletionCandidate>& out,
                                    std::unordered_set<std::string>& seen) {
   if (classType == nullptr || root == nullptr) {
+    return;
+  }
+  if (completingOnTypeName) {
     return;
   }
   AnalysisView const mainView = makeAnalysisView(result);
@@ -963,7 +999,8 @@ void appendBuiltinBufferListMethodCandidates(Type* bufferType, SymbolTable* root
 }
 
 void appendMembersForType(AnalysisResult& result, Type* baseType, Compound* ast, SymbolTable* root,
-                          Class* completionEnclosingClass, std::vector<CompletionCandidate>& out,
+                          Class* completionEnclosingClass, bool completingOnTypeName,
+                          std::vector<CompletionCandidate>& out,
                           std::unordered_set<std::string>& seen) {
   if (baseType == nullptr) {
     return;
@@ -979,29 +1016,50 @@ void appendMembersForType(AnalysisResult& result, Type* baseType, Compound* ast,
     return;
   }
 
-  for (Field* field : baseType->getFields()) {
-    if (field == nullptr) {
-      continue;
+  if (!completingOnTypeName) {
+    for (Field* field : baseType->getFields()) {
+      if (field == nullptr) {
+        continue;
+      }
+      if (Value* decl = field->getDeclarationSymbol(); decl != nullptr && decl->isPrivateMember()) {
+        continue;
+      }
+      addCandidate(out, seen,
+                   CompletionCandidate{.label = field->name,
+                                       .kind = baseType->is(BaseType::TY_ENUM)
+                                                   ? ::lsp::CompletionItemKind::EnumMember
+                                                   : ::lsp::CompletionItemKind::Field,
+                                       .detail = formatTypeName(field->type, root),
+                                       .documentation = {}});
     }
-    if (Value* decl = field->getDeclarationSymbol(); decl != nullptr && decl->isPrivateMember()) {
-      continue;
-    }
-    addCandidate(out, seen,
-                 CompletionCandidate{.label = field->name,
-                                     .kind = baseType->is(BaseType::TY_ENUM)
-                                                 ? ::lsp::CompletionItemKind::EnumMember
-                                                 : ::lsp::CompletionItemKind::Field,
-                                     .detail = formatTypeName(field->type, root),
-                                     .documentation = {}});
   }
 
   if (!baseType->is(BaseType::TY_CLASS) || root == nullptr) {
     return;
   }
+  if (completingOnTypeName) {
+    for (Type* ty = baseType; ty != nullptr; ty = ty->getClassSuperclass()) {
+      for (Field* sf : ty->getStaticFields()) {
+        if (sf == nullptr) {
+          continue;
+        }
+        if (Value* decl = sf->getDeclarationSymbol();
+            decl != nullptr && decl->isPrivateMember()) {
+          continue;
+        }
+        addCandidate(out, seen,
+                     CompletionCandidate{.label = sf->name,
+                                         .kind = ::lsp::CompletionItemKind::Field,
+                                         .detail = formatTypeName(sf->type, root),
+                                         .documentation = {}});
+      }
+    }
+  }
   // Walk inheritance chain so subclass completion includes superclass methods (deduped by `seen`).
   for (Type* ty = baseType; ty != nullptr; ty = ty->getClassSuperclass()) {
     if (Class* klass = findClassDeclarationForType(result, ty, ast, root)) {
-      appendMethodsForClass(result, klass, root, completionEnclosingClass, out, seen);
+      appendMethodsForClass(result, klass, root, completionEnclosingClass, completingOnTypeName, out,
+                            seen);
     }
   }
 }
@@ -1028,11 +1086,12 @@ void appendScopeSymbols(AnalysisResult& result, SymbolTable* scope, SymbolTable*
 }
 
 void appendKeywords(std::vector<CompletionCandidate>& out, std::unordered_set<std::string>& seen) {
-  static constexpr std::array<std::string_view, 28> keywords = {
+  static constexpr std::array<std::string_view, 29> keywords = {
       "and",    "as",      "break",  "class", "continue", "defer", "else",
       "enum",   "export",  "extern", "for",   "func",     "from",  "if",
       "import", "in",      "is",     "let",   "not",      "or",    "overload",
-      "pass",   "private", "return", "super", "this",     "var",   "while",
+      "pass",   "private", "return", "static", "super",   "this",  "var",
+      "while",
   };
   static constexpr std::array<std::string_view, 3> literals = {"false", "null", "true"};
   static constexpr std::array<std::string_view, 11> builtinTypes = {
@@ -1153,10 +1212,12 @@ auto completionItems(AnalysisResult& result, unsigned line, unsigned character)
     if (parts.size() == 1U && activeResult->importAliasToPath.contains(parts.front())) {
       appendModuleMembersForAlias(*activeResult, parts.front(), candidates, seen);
     }
-    appendMembersForType(*activeResult, baseType, ast, root, completionEnclosingClass, candidates,
-                         seen);
+    bool const completingOnTypeName =
+        memberCompletionUsesTypeNameContext(activeScope, root, ctx.memberChain);
+    appendMembersForType(*activeResult, baseType, ast, root, completionEnclosingClass,
+                         completingOnTypeName, candidates, seen);
     appendTraitRequirementMethods(*activeResult, baseType, ast, root, completionEnclosingTrait,
-                                  candidates, seen);
+                                  completingOnTypeName, candidates, seen);
   } else {
     appendScopeSymbols(*activeResult, activeScope != nullptr ? activeScope : root, root, candidates,
                        seen);

--- a/src/lsp/LspCompletion.cpp
+++ b/src/lsp/LspCompletion.cpp
@@ -590,48 +590,69 @@ auto resolveMemberFieldType(Type* baseType, const std::string& name) -> Type* {
     return t;
   }
   if (baseType->is(BaseType::TY_CLASS)) {
-    if (Field* sf = TypeUtils::findStaticFieldInClass(baseType, name); sf != nullptr) {
-      return sf->type;
+    for (Type* currentType = baseType; currentType != nullptr;
+         currentType = currentType->getClassSuperclass()) {
+      if (Field* sf = TypeUtils::findStaticFieldInClass(currentType, name); sf != nullptr) {
+        return sf->type;
+      }
     }
   }
   return nullptr;
 }
 
-/** True when completing after `TypeName.` where `TypeName` is a type symbol (static members). */
-[[nodiscard]] auto memberCompletionUsesTypeNameContext(SymbolTable* scope, SymbolTable* root,
-                                                     const std::string& memberChain) -> bool {
-  std::vector<std::string> parts = splitChain(memberChain);
-  if (parts.size() != 1U) {
-    return false;
+/** Resolves the type denoted by `chain` before a member-completion dot: local/root `lookupName`,
+ *  qualified imports (`alias.ExportedName` via \p result), nested type fields, and repeated
+ *  `TY_IMPORT` steps when an import alias is bound in scope. */
+[[nodiscard]] auto resolveCompletionMemberChainType(const AnalysisResult& result,
+                                                  const std::string& chain, SymbolTable* scope,
+                                                  SymbolTable* root) -> Type* {
+  std::vector<std::string> const parts = splitChain(chain);
+  if (parts.empty()) {
+    return nullptr;
   }
-  Value* leaf = lookupName(scope, root, parts.front());
-  return leaf != nullptr && leaf->getCategory() == ValueCategory::TYPE_SYMBOL;
+  Value* v = lookupName(scope, root, parts[0]);
+  size_t idx = 1U;
+  if (v == nullptr && parts.size() >= 2U) {
+    v = lookupImportedModuleSymbol(result, parts[0], parts[1]);
+    if (v != nullptr) {
+      idx = 2U;
+    }
+  }
+  if (v == nullptr) {
+    return nullptr;
+  }
+  Type* ty = v->getType();
+  while (idx < parts.size()) {
+    if (ty != nullptr && ty->is(BaseType::TY_IMPORT)) {
+      v = lookupImportedModuleSymbol(result, v->getName(), parts[idx]);
+      if (v == nullptr) {
+        return nullptr;
+      }
+      ty = v->getType();
+      ++idx;
+      continue;
+    }
+    ty = resolveMemberFieldType(ty, parts[idx]);
+    if (ty == nullptr) {
+      return nullptr;
+    }
+    ++idx;
+  }
+  return ty;
+}
+
+/** True when completing after `ClassName.` / `mod.Class.` where the receiver denotes a class type
+ *  (static members and `new`), not other type symbols (e.g. enums) or instance chains. */
+[[nodiscard]] auto memberCompletionUsesTypeNameContext(const AnalysisResult& result,
+                                                       SymbolTable* scope, SymbolTable* root,
+                                                       const std::string& memberChain) -> bool {
+  Type* const ty = resolveCompletionMemberChainType(result, memberChain, scope, root);
+  return ty != nullptr && ty->is(BaseType::TY_CLASS);
 }
 
 auto resolveChainType(const AnalysisResult& result, const std::string& chain, SymbolTable* scope,
                       SymbolTable* root) -> Type* {
-  std::vector<std::string> parts = splitChain(chain);
-  if (parts.empty()) {
-    return nullptr;
-  }
-  Value* current = lookupName(scope, root, parts.front());
-  size_t nextPartIdx = 1U;
-  if (current == nullptr) {
-    current = lookupImportedModuleSymbol(result, parts.front(),
-                                         parts.size() > 1U ? parts[1U] : std::string{});
-    nextPartIdx = current != nullptr ? 2U : 1U;
-  }
-  if (current == nullptr) {
-    return nullptr;
-  }
-  Type* type = current->getType();
-  for (size_t i = nextPartIdx; i < parts.size(); ++i) {
-    type = resolveMemberFieldType(type, parts[i]);
-    if (type == nullptr) {
-      return nullptr;
-    }
-  }
-  return type;
+  return resolveCompletionMemberChainType(result, chain, scope, root);
 }
 
 /** When the receiver is `self`, resolve the class instance type from the innermost enclosing
@@ -1213,7 +1234,7 @@ auto completionItems(AnalysisResult& result, unsigned line, unsigned character)
       appendModuleMembersForAlias(*activeResult, parts.front(), candidates, seen);
     }
     bool const completingOnTypeName =
-        memberCompletionUsesTypeNameContext(activeScope, root, ctx.memberChain);
+        memberCompletionUsesTypeNameContext(*activeResult, activeScope, root, ctx.memberChain);
     appendMembersForType(*activeResult, baseType, ast, root, completionEnclosingClass,
                          completingOnTypeName, candidates, seen);
     appendTraitRequirementMethods(*activeResult, baseType, ast, root, completionEnclosingTrait,

--- a/src/lsp/main.cpp
+++ b/src/lsp/main.cpp
@@ -2115,6 +2115,7 @@ enum class SemanticTokenType : std::uint8_t {
 namespace semantic_token_modifier {
 constexpr unsigned DECLARATION = 1U << 0U;
 constexpr unsigned DEFAULT_LIBRARY = 1U << 1U;
+constexpr unsigned STATIC = 1U << 2U;
 } // namespace semantic_token_modifier
 
 struct RawSemanticToken {
@@ -2270,6 +2271,14 @@ auto collectSemanticTokens(AnalysisResult& analysisResult, unsigned bufferId)
     }
     if (isDefaultLibraryType(resolved.value->getType())) {
       modifiers |= semantic_token_modifier::DEFAULT_LIBRARY;
+    }
+    if (resolved.value->isStaticMethod()) {
+      modifiers |= semantic_token_modifier::STATIC;
+    } else if (lesma::Type* declCls = resolved.value->getMemberDeclaredInClass();
+               declCls != nullptr &&
+               lesma::TypeUtils::findStaticFieldInClass(declCls, resolved.value->getName()) !=
+                   nullptr) {
+      modifiers |= semantic_token_modifier::STATIC;
     }
     return modifiers;
   };
@@ -2579,14 +2588,23 @@ auto collectDocumentSymbols(const AnalysisResult& result) -> std::vector<::lsp::
       std::vector<::lsp::DocumentSymbol> children;
       for (lesma::VarDecl* field : klass->getFields()) {
         lesma::Value* value = field->getResolvedSymbol();
+        std::optional<std::string> fieldDetail = std::nullopt;
+        if (value != nullptr) {
+          fieldDetail = formatTypeName(value->getType(), result.rootScope.get());
+          if (field->getIsStatic()) {
+            fieldDetail = fieldDetail.has_value() && !fieldDetail->empty()
+                              ? *fieldDetail + " (static)"
+                              : std::optional<std::string>("static");
+          }
+        } else if (field->getIsStatic()) {
+          fieldDetail = "static";
+        }
         children.push_back(makeDocumentSymbol(
             field->getIdentifier()->getValue(), ::lsp::SymbolKind::Field,
             smRangeToLspRange(result.sourceMgr.get(), result.mainBufferId, field->getSpan()),
             smRangeToLspRange(result.sourceMgr.get(), result.mainBufferId,
                               field->getIdentifier()->getSpan()),
-            value != nullptr ? std::optional<std::string>(
-                                   formatTypeName(value->getType(), result.rootScope.get()))
-                             : std::nullopt));
+            fieldDetail));
       }
       for (lesma::FuncDecl* method : klass->getMethods()) {
         lesma::Value* value = method->getResolvedSymbol();
@@ -2594,16 +2612,23 @@ auto collectDocumentSymbols(const AnalysisResult& result) -> std::vector<::lsp::
         if (auto spell = lesma::OperatorUtils::surfaceSpellingForMangledOperator(methodName)) {
           methodName = std::string(*spell);
         }
+        std::optional<std::string> methodDetail =
+            value != nullptr && value->getType() != nullptr &&
+                    value->getType()->getReturnType() != nullptr
+                ? std::optional<std::string>(
+                      formatTypeName(value->getType()->getReturnType(), result.rootScope.get()))
+                : std::nullopt;
+        if (method->getIsStatic()) {
+          methodDetail = methodDetail.has_value() && !methodDetail->empty()
+                             ? *methodDetail + " (static)"
+                             : std::optional<std::string>("static");
+        }
         children.push_back(makeDocumentSymbol(
             methodName, ::lsp::SymbolKind::Method,
             smRangeToLspRange(result.sourceMgr.get(), result.mainBufferId,
                               funcDeclFullSpan(method)),
             smRangeToLspRange(result.sourceMgr.get(), result.mainBufferId, method->getNameSpan()),
-            value != nullptr && value->getType() != nullptr &&
-                    value->getType()->getReturnType() != nullptr
-                ? std::optional<std::string>(
-                      formatTypeName(value->getType()->getReturnType(), result.rootScope.get()))
-                : std::nullopt));
+            methodDetail));
       }
       symbol.children = ::lsp::Opt<::lsp::Array<::lsp::DocumentSymbol>>(
           ::lsp::Array<::lsp::DocumentSymbol>(children.begin(), children.end()));
@@ -2884,7 +2909,7 @@ auto main() -> int {
                                                       "type", "typeParameter", "function", "method",
                                                       "parameter", "variable", "property"},
                       .tokenModifiers =
-                          ::lsp::Array<::lsp::String>{"declaration", "defaultLibrary"},
+                          ::lsp::Array<::lsp::String>{"declaration", "defaultLibrary", "static"},
                   },
               .full = ::lsp::Opt<::lsp::OneOf<bool, ::lsp::SemanticTokensOptionsFull>>(true),
           });

--- a/src/stdlib/base.les
+++ b/src/stdlib/base.les
@@ -596,8 +596,7 @@ export class file {
         return result
 
     }
-    # Static-style: file.write(path, data). self is unused (null this at call site).
-    func write(path: cstr, data: str) {
+    static func write(path: cstr, data: str) {
         var fp: *int8 = fopen(path, "wb")
         if fp == 0 {
             return
@@ -609,8 +608,8 @@ export class file {
         fclose(fp)
 
     }
-    func write(path: cstr, src: file) {
-        self.write(path, src.text())
+    static func write(path: cstr, src: file) {
+        file.write(path, src.text())
 
     }
     func delete() {

--- a/tests/lesma/failure/static_field_in_generic_class.les
+++ b/tests/lesma/failure/static_field_in_generic_class.les
@@ -1,7 +1,0 @@
-class Box<T> {
-  static let tag: int = 1
-}
-
-func main() -> int {
-  return 0
-}

--- a/tests/lesma/failure/static_field_in_generic_class.les
+++ b/tests/lesma/failure/static_field_in_generic_class.les
@@ -1,0 +1,7 @@
+class Box<T> {
+  static let tag: int = 1
+}
+
+func main() -> int {
+  return 0
+}

--- a/tests/lesma/failure/static_field_uses_class_type_parameter.les
+++ b/tests/lesma/failure/static_field_uses_class_type_parameter.les
@@ -1,0 +1,7 @@
+class G<T> {
+  static var buf: list<T>
+}
+
+func main() -> int {
+  return 0
+}

--- a/tests/lesma/failure/static_new_not_allowed.les
+++ b/tests/lesma/failure/static_new_not_allowed.les
@@ -1,0 +1,8 @@
+class C {
+  static func new() -> void {
+  }
+}
+
+func main() -> int {
+  return 0
+}

--- a/tests/lesma/success/generic_class_static_field_non_generic_type.les
+++ b/tests/lesma/success/generic_class_static_field_non_generic_type.les
@@ -1,0 +1,35 @@
+# Static fields on a generic class are allowed when their type (and initializer type) does not use
+# the class type parameters; storage is shared for all specializations (one global per template).
+class Box<T> {
+  static let tag: int = 42
+  static var hits: int = 0
+
+  var x: T
+
+  func new(v: T) {
+    self.x = v
+  }
+}
+
+func main() -> int {
+  # `Box<int>.tag` would parse as `Box < int` (comparison); use the template name for static access.
+  if Box.tag != 42 {
+    return 1
+  }
+  if Box.hits != 0 {
+    return 2
+  }
+  Box.hits = Box.hits + 1
+  if Box.hits != 1 {
+    return 3
+  }
+  Box.hits = Box.hits + 1
+  if Box.hits != 2 {
+    return 4
+  }
+  var a = Box<int>(7)
+  if a.x != 7 {
+    return 5
+  }
+  return 0
+}

--- a/tests/lesma/success/generic_class_static_method.les
+++ b/tests/lesma/success/generic_class_static_method.les
@@ -1,0 +1,29 @@
+# Swift-style static methods on a generic class: T is the class type parameter.
+class Cell<T> {
+  var x: T
+
+  func new(v: T) {
+    self.x = v
+  }
+
+  static func of(v: T) -> Cell<T> {
+    return Cell(v)
+  }
+
+  static func wrap_int(n: int) -> Cell<int> {
+    return Cell(n)
+  }
+}
+
+
+func main() -> int {
+  var a = Cell.of(7)
+  if a.x != 7 {
+    return 1
+  }
+  var b: Cell<int> = Cell.wrap_int(3)
+  if b.x != 3 {
+    return 2
+  }
+  return 0
+}

--- a/tests/lesma/success/static_field_callable_closure.les
+++ b/tests/lesma/success/static_field_callable_closure.les
@@ -1,0 +1,27 @@
+# Static field stores a callable value as `{ code*, env* }` like other addressable slots.
+class Holder {
+  static var dbl: func(int) -> int = func(x: int) -> int => x * 2
+
+  static func init_adder(base: int) -> void {
+    Holder.adder = func(x: int) -> int => x + base
+  }
+
+  static var adder: func(int) -> int
+}
+
+func main() -> int {
+  var d: func(int) -> int = Holder.dbl
+  if d(4) != 8 {
+    return 1
+  }
+  Holder.init_adder(5)
+  var a: func(int) -> int = Holder.adder
+  if a(10) != 15 {
+    return 2
+  }
+  var g: func(int) -> int = Holder.dbl
+  if g(3) != 6 {
+    return 3
+  }
+  return 0
+}

--- a/tests/lesma/success/static_fields_as_constants.les
+++ b/tests/lesma/success/static_fields_as_constants.les
@@ -1,0 +1,44 @@
+# Static `let` fields are read-only class-scoped values; use them like named constants.
+class Limits {
+  static let min: int = 0
+  static let max: int = 100
+  static let step: int = 5
+
+  static func clamp(v: int) -> int {
+    if v < Limits.min {
+      return Limits.min
+    }
+    if v > Limits.max {
+      return Limits.max
+    }
+    return v
+  }
+}
+
+class Offsets {
+  static let a: int = 10
+  static let b: int = 20
+}
+
+func main() -> int {
+  if Limits.min != 0 {
+    return 1
+  }
+  if Limits.max != 100 {
+    return 2
+  }
+  if Limits.clamp(150) != 100 {
+    return 3
+  }
+  if Limits.clamp(-5) != 0 {
+    return 4
+  }
+  if Limits.clamp(42) != 42 {
+    return 5
+  }
+  var s: int = Offsets.a + Offsets.b + Limits.step
+  if s != 35 {
+    return 6
+  }
+  return 0
+}

--- a/tests/lesma/success/static_methods_and_fields_class.les
+++ b/tests/lesma/success/static_methods_and_fields_class.les
@@ -1,0 +1,47 @@
+class Counter {
+  var n: int
+  static var hits: int = 0
+
+  func new() {
+    self.n = 0
+  }
+
+  static func zero() -> Counter {
+    var c: Counter = Counter()
+    return c
+  }
+
+  static func from_value(x: int) -> Counter {
+    var c: Counter = Counter()
+    c.n = x
+    return c
+  }
+
+  static func bump_hits() -> void {
+    Counter.hits = Counter.hits + 1
+  }
+
+  func bump() -> void {
+    self.n = self.n + 1
+  }
+}
+
+func main() -> int {
+  var a: Counter = Counter.zero()
+  var b: Counter = Counter.from_value(3)
+  a.bump()
+  Counter.bump_hits()
+  if a.n != 1 {
+    return 1
+  }
+  if b.n != 3 {
+    return 2
+  }
+  if Counter.from_value(10).n != 10 {
+    return 3
+  }
+  if Counter.hits != 1 {
+    return 4
+  }
+  return 0
+}

--- a/tools/vscode/syntaxes/lesma.tmLanguage.json
+++ b/tools/vscode/syntaxes/lesma.tmLanguage.json
@@ -51,6 +51,10 @@
           "match": "\\b(from|import)\\b"
         },
         {
+          "name": "storage.modifier.static.lesma",
+          "match": "\\bstatic\\b"
+        },
+        {
           "name": "keyword.other.lesma",
           "match": "\\b(export|class|enum|type|extern|trait|impl|private|overload)\\b"
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class static class members: `static` fields and `static` methods accessible as `ClassName.field` / `ClassName.method(...)`
  * Standard library and tooling updated (e.g. `file.write` made static); editor completions, semantic highlighting, and outline show/static-aware info

* **Bug Fixes**
  * Rejects static fields that reference their class’s generic parameters
  * `static new` (static constructors) are disallowed; static methods are treated non-virtual

* **Tests**
  * Added tests exercising static fields, static methods, generics, and related error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->