### PR TITLE
Any type

### DIFF
--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -142,6 +142,7 @@ class Codegen final : public ASTVisitor {
   std::unordered_map<std::string, std::vector<std::string>> traitRequirementMethodOrder;
   std::unordered_map<std::string, const TraitDecl*> traitDeclByName;
   std::unordered_map<std::string, llvm::GlobalVariable*> witnessGlobalCache;
+  std::unordered_map<std::string, llvm::GlobalVariable*> anyTypeInfoGlobals;
   std::unordered_map<lesma::Type*, llvm::GlobalVariable*> classVtableGlobals;
   std::unordered_map<lesma::Type*, const Class*> codegenClassAstByType;
   std::unordered_map<std::string, const Class*> codegenClassAstByDisplayName;
@@ -278,7 +279,14 @@ protected:
                                     lesma::Type* memberTy) -> llvm::Value*;
   [[nodiscard]] auto getOptionalPayloadType(lesma::Type* type) const -> lesma::Type*;
   auto materializeNarrowedUnionValue(lesma::Value* value, lesma::Type* narrowedType,
-                                     const std::string& tempName)
+                                     const std::string& tempName) -> std::unique_ptr<lesma::Value>;
+  auto getOrCreateAnyTypeInfoGlobal(lesma::Type* type) -> llvm::GlobalVariable*;
+  auto emitAnyTypeInfoPtr(lesma::Type* type) -> llvm::Value*;
+  auto emitBoxToAny(llvm::SMRange span, lesma::Value* value, lesma::Type* anyType)
+      -> std::unique_ptr<lesma::Value>;
+  auto emitUnboxFromAny(llvm::SMRange span, lesma::Value* value, lesma::Type* targetType)
+      -> std::unique_ptr<lesma::Value>;
+  auto emitAnyIsCheck(llvm::SMRange span, lesma::Value* value, lesma::Type* testType, bool negate)
       -> std::unique_ptr<lesma::Value>;
 
   auto linkObjectFileWithLld(const std::string& objFilename) -> void;
@@ -614,8 +622,8 @@ private:
                                          std::unique_ptr<lesma::Value>& right,
                                          lesma::Type* finalType) -> std::unique_ptr<lesma::Value>;
   [[nodiscard]] auto emitPowerOperation(llvm::SMRange span, std::unique_ptr<lesma::Value>& left,
-                                        std::unique_ptr<lesma::Value>& right, lesma::Type* finalType)
-      -> std::unique_ptr<lesma::Value>;
+                                        std::unique_ptr<lesma::Value>& right,
+                                        lesma::Type* finalType) -> std::unique_ptr<lesma::Value>;
   void emitForInLoopIteration(llvm::Function* parentFct, const ForIn* node, SymbolTable* outerScope,
                               SymbolTable* loopBodyScope, llvm::BasicBlock* bLoop,
                               llvm::BasicBlock* bInc,

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -498,6 +498,7 @@ protected:
   auto emitRealloc(llvm::Value* ptr, llvm::Value* size, const llvm::Twine& name = "realloc.tmp")
       -> llvm::Value*;
   auto emitFree(llvm::Value* ptr) -> void;
+  auto emitRuntimeStderrMessage(std::string_view message) -> void;
   auto emitExit(int code) -> void;
   auto emitListLength(lesma::Type* listType, llvm::Value* listHandle) -> llvm::Value*;
   auto emitListCapacity(lesma::Type* listType, llvm::Value* listHandle) -> llvm::Value*;

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -282,6 +282,8 @@ protected:
                                      const std::string& tempName) -> std::unique_ptr<lesma::Value>;
   auto getOrCreateAnyTypeInfoGlobal(lesma::Type* type) -> llvm::GlobalVariable*;
   auto emitAnyTypeInfoPtr(lesma::Type* type) -> llvm::Value*;
+  auto emitAnyTypeInfoMatches(llvm::Value* typeInfo, lesma::Type* candidate,
+                              const llvm::Twine& name = "any.type.match") -> llvm::Value*;
   auto emitBoxToAny(llvm::SMRange span, lesma::Value* value, lesma::Type* anyType)
       -> std::unique_ptr<lesma::Value>;
   auto emitUnboxFromAny(llvm::SMRange span, lesma::Value* value, lesma::Type* targetType)

--- a/src/liblesma/Backend/CodegenBufferHelpers.cpp
+++ b/src/liblesma/Backend/CodegenBufferHelpers.cpp
@@ -83,6 +83,17 @@ auto Codegen::emitFree(llvm::Value* ptr) -> void {
   builder->CreateCall(freeFn, {ptr});
 }
 
+auto Codegen::emitRuntimeStderrMessage(std::string_view message) -> void {
+  auto writeFn = theModule->getOrInsertFunction(
+      "write", llvm::FunctionType::get(
+                   builder->getInt64Ty(),
+                   {builder->getInt32Ty(), builder->getPtrTy(), builder->getInt64Ty()}, false));
+  llvm::GlobalVariable* messageGlobal = builder->CreateGlobalString(message, "runtime.errmsg");
+  builder->CreateCall(writeFn, {builder->getInt32(2),
+                                builder->CreateBitCast(messageGlobal, builder->getPtrTy()),
+                                builder->getInt64(message.size())});
+}
+
 auto Codegen::emitExit(int code) -> void {
   auto exitFn = theModule->getOrInsertFunction(
       std::string{codegen::runtime::EXIT},
@@ -297,10 +308,12 @@ auto Codegen::lookupClassStructSymbol(lesma::Type* classTy) -> Value* {
   if (classTy == nullptr || !classTy->is(BaseType::TY_CLASS)) {
     return nullptr;
   }
-  if (auto it = specializedClassSymbolsByType.find(classTy); it != specializedClassSymbolsByType.end()) {
+  if (auto it = specializedClassSymbolsByType.find(classTy);
+      it != specializedClassSymbolsByType.end()) {
     return it->second;
   }
-  if (auto envIt = specializedClassTypeEnvs.find(classTy); envIt != specializedClassTypeEnvs.end()) {
+  if (auto envIt = specializedClassTypeEnvs.find(classTy);
+      envIt != specializedClassTypeEnvs.end()) {
     bool isConcrete = true;
     for (const auto& [name, ty] : envIt->second) {
       (void) name;
@@ -311,7 +324,8 @@ auto Codegen::lookupClassStructSymbol(lesma::Type* classTy) -> Value* {
     }
     if (isConcrete) {
       Type* templateTy = classTy;
-      if (auto it = specializedClassTemplateOf.find(classTy); it != specializedClassTemplateOf.end()) {
+      if (auto it = specializedClassTemplateOf.find(classTy);
+          it != specializedClassTemplateOf.end()) {
         templateTy = it->second;
       }
       if (const Class* templateAst = findGenericClassAstForTemplateType(templateTy);
@@ -357,7 +371,8 @@ auto Codegen::specializedClassEnvFor(lesma::Type* classTy)
     return &it->second;
   }
   if (Value* sym = lookupClassStructSymbol(classTy); sym != nullptr && sym->getType() != nullptr) {
-    if (auto it = specializedClassTypeEnvs.find(sym->getType()); it != specializedClassTypeEnvs.end()) {
+    if (auto it = specializedClassTypeEnvs.find(sym->getType());
+        it != specializedClassTypeEnvs.end()) {
       return &it->second;
     }
   }
@@ -369,7 +384,8 @@ auto Codegen::specializedTraitExistentialEnvFor(lesma::Type* existentialTy)
   if (existentialTy == nullptr || !existentialTy->is(BaseType::TY_TRAIT_EXISTENTIAL)) {
     return nullptr;
   }
-  if (auto it = specializedClassTypeEnvs.find(existentialTy); it != specializedClassTypeEnvs.end()) {
+  if (auto it = specializedClassTypeEnvs.find(existentialTy);
+      it != specializedClassTypeEnvs.end()) {
     return &it->second;
   }
   return nullptr;

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -187,6 +187,10 @@ auto Codegen::visit(const TypeExpr* node) -> void {
       getOrCreateLlvmType(cached);
       result = std::make_unique<Value>(cached);
     }
+  } else if (node->getType() == TokenType::ANY_TYPE) {
+    auto* type = cacheType(std::make_unique<Type>(BaseType::TY_ANY));
+    getOrCreateLlvmType(type);
+    result = std::make_unique<Value>(type);
   } else if (node->getType() == TokenType::CUSTOM_TYPE) {
     const std::string lookupName = node->getLookupName();
     auto git = currentGenericTypes.find(lookupName);
@@ -323,6 +327,15 @@ auto Codegen::getOrCreateLlvmType(lesma::Type* type) -> llvm::Type* {
   case BaseType::TY_STRING:
     type->setLlvmType(builder->getPtrTy());
     break;
+  case BaseType::TY_ANY: {
+    llvm::StructType* st = llvm::StructType::getTypeByName(theModule->getContext(), "lesma.any");
+    if (st == nullptr) {
+      st = llvm::StructType::create(theModule->getContext(),
+                                    {builder->getPtrTy(), builder->getPtrTy()}, "lesma.any");
+    }
+    type->setLlvmType(st);
+    break;
+  }
   case BaseType::TY_VOID:
     type->setLlvmType(builder->getVoidTy());
     break;

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -6116,6 +6116,7 @@ auto Codegen::callNamedFunction(
       }
       return type;
     };
+    Value* anyFallback = nullptr;
     for (auto* candidate : scope->getSymbols()) {
       if (symbol != nullptr) {
         break;
@@ -6130,6 +6131,7 @@ auto Codegen::callNamedFunction(
         continue;
       }
       bool compatible = true;
+      bool usesAnyFallback = false;
       for (size_t i = 0; i < candidateFields.size(); ++i) {
         lesma::Type* formalType = normalizeFunctionParamType(candidateFields[i]->type);
         lesma::Type* actualType = normalizeFunctionParamType(localParamTypes[i]);
@@ -6145,6 +6147,7 @@ auto Codegen::callNamedFunction(
             compatible = false;
             break;
           }
+          usesAnyFallback = true;
           continue;
         }
         if (!formalType->isEqual(actualType)) {
@@ -6153,9 +6156,18 @@ auto Codegen::callNamedFunction(
         }
       }
       if (compatible) {
+        if (usesAnyFallback) {
+          if (anyFallback == nullptr) {
+            anyFallback = candidate;
+          }
+          continue;
+        }
         symbol = candidate;
         break;
       }
+    }
+    if (symbol == nullptr && anyFallback != nullptr) {
+      symbol = anyFallback;
     }
     if (symbol == nullptr) {
       if (auto directIt = specializedFunctions.find(directMangledLookup);

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1481,7 +1481,6 @@ auto Codegen::getOrCreateAnyTypeInfoGlobal(lesma::Type* type) -> llvm::GlobalVar
   auto* gv = new llvm::GlobalVariable(*theModule, builder->getInt8Ty(), true,
                                       llvm::GlobalValue::LinkOnceODRLinkage, builder->getInt8(0),
                                       globalName);
-  gv->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
   gv->setAlignment(llvm::MaybeAlign(1));
   anyTypeInfoGlobals[typeName] = gv;
   return gv;

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1396,8 +1396,7 @@ auto Codegen::materializeNarrowedUnionValue(lesma::Value* value, lesma::Type* na
       if (memberTy->is(BaseType::TY_FUNCTION)) {
         memberValue->setStoresFuncValuePair(true);
         memberValue->setCategory(ValueCategory::DIRECT_VALUE);
-        memberValue->setClosureCalleeUsesEnvParameter(
-            value->getClosureCalleeUsesEnvParameter());
+        memberValue->setClosureCalleeUsesEnvParameter(value->getClosureCalleeUsesEnvParameter());
       }
       emitUnionWrapValueToSlot({}, memberValue.get(), narrowedType, *narrowedIndex, narrowedSlot);
       builder->CreateBr(mergeBlock);
@@ -1458,6 +1457,177 @@ auto Codegen::emitUnionWrapValue(llvm::SMRange span, lesma::Value* val, lesma::T
   llvm::Function* f = builder->GetInsertBlock()->getParent();
   llvm::AllocaInst* slot = createAllocaInEntry(f, st, "union.wrap.slot");
   return emitUnionWrapValueToSlot(span, val, unionTy, variantIndex, slot);
+}
+
+auto Codegen::getOrCreateAnyTypeInfoGlobal(lesma::Type* type) -> llvm::GlobalVariable* {
+  if (type == nullptr) {
+    throw CodegenError({}, "Cannot create type info for null type");
+  }
+  getOrCreateLlvmType(type);
+  std::string const typeName = MangleUtils::getTypeMangledName({}, type);
+  if (auto it = anyTypeInfoGlobals.find(typeName); it != anyTypeInfoGlobals.end()) {
+    return it->second;
+  }
+  std::string globalName = "__lesma_any_ti_";
+  for (char ch : typeName) {
+    globalName.push_back(std::isalnum(static_cast<unsigned char>(ch)) ? ch : '_');
+  }
+  if (llvm::GlobalVariable* existing = theModule->getGlobalVariable(globalName, true);
+      existing != nullptr) {
+    anyTypeInfoGlobals[typeName] = existing;
+    return existing;
+  }
+  auto* gv = new llvm::GlobalVariable(*theModule, builder->getInt8Ty(), true,
+                                      llvm::GlobalValue::LinkOnceODRLinkage, builder->getInt8(0),
+                                      globalName);
+  gv->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+  gv->setAlignment(llvm::MaybeAlign(1));
+  anyTypeInfoGlobals[typeName] = gv;
+  return gv;
+}
+
+auto Codegen::emitAnyTypeInfoPtr(lesma::Type* type) -> llvm::Value* {
+  return builder->CreateBitCast(getOrCreateAnyTypeInfoGlobal(type), builder->getPtrTy(),
+                                "any.typeinfo");
+}
+
+auto Codegen::emitBoxToAny(llvm::SMRange span, lesma::Value* value, lesma::Type* anyType)
+    -> std::unique_ptr<lesma::Value> {
+  if (value == nullptr || value->getType() == nullptr || anyType == nullptr) {
+    throw CodegenError(span, "Cannot box invalid value as any");
+  }
+  if (value->getType()->is(BaseType::TY_ANY)) {
+    return std::make_unique<Value>(*value);
+  }
+
+  getOrCreateLlvmType(anyType);
+
+  llvm::Type* storageTy = nullptr;
+  llvm::Value* storageValue = value->getLlvmValue();
+  if (value->getType()->is(BaseType::TY_FUNCTION)) {
+    auto* pairTy = getFuncValuePairLlvmType();
+    storageTy = pairTy;
+    if (value->getStoresFuncValuePair()) {
+      if (storageValue != nullptr && storageValue->getType()->isPointerTy()) {
+        storageValue = builder->CreateLoad(pairTy, storageValue, "any.fnpair.load");
+      }
+    } else {
+      llvm::Value* codePtr = storageValue != nullptr
+                                 ? builder->CreateBitCast(storageValue, builder->getPtrTy())
+                                 : llvm::ConstantPointerNull::get(builder->getPtrTy());
+      llvm::Value* pair = llvm::UndefValue::get(pairTy);
+      pair = builder->CreateInsertValue(pair, codePtr, {0U}, "any.fnpair.code");
+      pair = builder->CreateInsertValue(pair, llvm::ConstantPointerNull::get(builder->getPtrTy()),
+                                        {1U}, "any.fnpair.env");
+      storageValue = pair;
+    }
+  } else {
+    storageTy = getStoredAggregateFieldLlvmType(value->getType());
+  }
+
+  if (storageTy == nullptr || storageValue == nullptr) {
+    throw CodegenError(span, "Cannot box value of type {} as any", value->getType()->toString());
+  }
+
+  if (storageValue->getType() != storageTy) {
+    if (storageValue->getType()->isIntegerTy() && storageTy->isIntegerTy()) {
+      storageValue = builder->CreateIntCast(storageValue, storageTy, value->getType()->isSigned(),
+                                            "any.box.ic");
+    } else if (storageValue->getType()->isFloatingPointTy() && storageTy->isFloatingPointTy()) {
+      storageValue = builder->CreateFPCast(storageValue, storageTy, "any.box.fc");
+    } else if (theModule->getDataLayout().getTypeSizeInBits(storageValue->getType()) ==
+               theModule->getDataLayout().getTypeSizeInBits(storageTy)) {
+      storageValue = builder->CreateBitCast(storageValue, storageTy, "any.box.cast");
+    } else {
+      throw CodegenError(span, "Cannot box value of type {} as any", value->getType()->toString());
+    }
+  }
+
+  auto* allocSize =
+      builder->getInt64(theModule->getDataLayout().getTypeAllocSize(storageTy).getFixedValue());
+  llvm::Value* payloadPtr = emitMalloc(allocSize, "any.payload");
+  llvm::Value* typedPayloadPtr = builder->CreateBitCast(
+      payloadPtr, llvm::PointerType::get(theModule->getContext(), 0U), "any.payload.typed");
+  builder->CreateStore(storageValue, typedPayloadPtr);
+
+  llvm::Value* anyAgg = llvm::UndefValue::get(anyType->getLlvmType());
+  anyAgg = builder->CreateInsertValue(anyAgg, emitAnyTypeInfoPtr(value->getType()), {0U},
+                                      "any.box.typeinfo");
+  anyAgg = builder->CreateInsertValue(anyAgg, payloadPtr, {1U}, "any.box.payload");
+  return std::make_unique<Value>("", anyType, anyAgg);
+}
+
+auto Codegen::emitUnboxFromAny(llvm::SMRange span, lesma::Value* value, lesma::Type* targetType)
+    -> std::unique_ptr<lesma::Value> {
+  if (value == nullptr || value->getType() == nullptr || !value->getType()->is(BaseType::TY_ANY) ||
+      targetType == nullptr) {
+    throw CodegenError(span, "Cannot unbox invalid any value");
+  }
+  if (targetType->is(BaseType::TY_ANY)) {
+    return std::make_unique<Value>(*value);
+  }
+
+  llvm::Value* anyValue = value->getLlvmValue();
+  if (anyValue == nullptr) {
+    throw CodegenError(span, "Cannot unbox any without lowered value");
+  }
+  if (anyValue->getType()->isPointerTy()) {
+    anyValue = builder->CreateLoad(value->getType()->getLlvmType(), anyValue, "any.load");
+  }
+
+  llvm::Value* typeInfo = builder->CreateExtractValue(anyValue, {0U}, "any.unbox.typeinfo");
+  llvm::Value* payloadPtr = builder->CreateExtractValue(anyValue, {1U}, "any.unbox.payload");
+  llvm::Value* typeMatch =
+      builder->CreateICmpEQ(typeInfo, emitAnyTypeInfoPtr(targetType), "any.is");
+
+  llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+  auto* okBlock = llvm::BasicBlock::Create(theModule->getContext(), "any.unbox.ok", parentFn);
+  auto* failBlock = llvm::BasicBlock::Create(theModule->getContext(), "any.unbox.fail", parentFn);
+  builder->CreateCondBr(typeMatch, okBlock, failBlock);
+
+  builder->SetInsertPoint(failBlock);
+  emitExit(1);
+  builder->CreateUnreachable();
+
+  builder->SetInsertPoint(okBlock);
+  llvm::Type* storageTy = targetType->is(BaseType::TY_FUNCTION)
+                              ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                              : getStoredAggregateFieldLlvmType(targetType);
+  llvm::Value* typedPayloadPtr = builder->CreateBitCast(
+      payloadPtr, llvm::PointerType::get(theModule->getContext(), 0U), "any.unbox.typed");
+  llvm::Value* loaded = builder->CreateLoad(storageTy, typedPayloadPtr, "any.unbox.value");
+  auto out = std::make_unique<Value>("", targetType, loaded);
+  if (targetType->is(BaseType::TY_FUNCTION)) {
+    out->setStoresFuncValuePair(true);
+    out->setCategory(ValueCategory::DIRECT_VALUE);
+  }
+  return out;
+}
+
+auto Codegen::emitAnyIsCheck(llvm::SMRange span, lesma::Value* value, lesma::Type* testType,
+                             bool negate) -> std::unique_ptr<lesma::Value> {
+  if (value == nullptr || value->getType() == nullptr || !value->getType()->is(BaseType::TY_ANY) ||
+      testType == nullptr) {
+    throw CodegenError(span, "Cannot evaluate `is` on invalid any value");
+  }
+  llvm::Value* cmp = nullptr;
+  if (testType->is(BaseType::TY_ANY)) {
+    cmp = negate ? builder->getFalse() : builder->getTrue();
+  } else {
+    llvm::Value* anyValue = value->getLlvmValue();
+    if (anyValue == nullptr) {
+      throw CodegenError(span, "Cannot evaluate `is` on any without lowered value");
+    }
+    if (anyValue->getType()->isPointerTy()) {
+      anyValue = builder->CreateLoad(value->getType()->getLlvmType(), anyValue, "any.is.load");
+    }
+    llvm::Value* typeInfo = builder->CreateExtractValue(anyValue, {0U}, "any.is.typeinfo");
+    cmp = builder->CreateICmpEQ(typeInfo, emitAnyTypeInfoPtr(testType), "any.is.cmp");
+    if (negate) {
+      cmp = builder->CreateNot(cmp);
+    }
+  }
+  return makeBoolCompareResult(cmp);
 }
 
 auto Codegen::visit(const If* node) -> void {
@@ -4460,6 +4630,12 @@ auto Codegen::visit(const IsOp* node) -> void {
     throw CodegenError(node->getSpan(), "Internal: `is` expression missing resolved RHS type");
   }
 
+  if (leftType != nullptr && leftType->is(BaseType::TY_ANY)) {
+    result = emitAnyIsCheck(node->getSpan(), leftOwner.get(), rightType,
+                            node->getOperator() == TokenType::IS_NOT);
+    return;
+  }
+
   if (leftType != nullptr && leftType->is(BaseType::TY_UNION)) {
     auto idxOpt = unionVariantIndexOf(leftType, rightType);
     if (!idxOpt.has_value()) {
@@ -5142,6 +5318,10 @@ auto Codegen::visit(const Else* /*node*/) -> void {
 
 auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
     -> std::unique_ptr<lesma::Value> {
+  if (type != nullptr && type->is(BaseType::TY_ANY) && val != nullptr &&
+      val->getType() != nullptr) {
+    return emitBoxToAny(span, val, type);
+  }
   if (type != nullptr && type->is(BaseType::TY_UNION) && val != nullptr &&
       val->getType() != nullptr) {
     const auto& mem = type->getUnionMembers();
@@ -5232,7 +5412,16 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
         auto tmp = std::make_unique<lesma::Value>("", memI, val->getLlvmValue());
         return emitUnionWrapValue(span, tmp.get(), type, i);
       }
+      if (memI->is(BaseType::TY_ANY) && val->getType() != nullptr &&
+          !val->getType()->is(BaseType::TY_NULL)) {
+        auto boxed = emitBoxToAny(span, val, memI);
+        return emitUnionWrapValue(span, boxed.get(), type, i);
+      }
     }
+  }
+  if (val != nullptr && val->getType() != nullptr && val->getType()->is(BaseType::TY_ANY) &&
+      type != nullptr && !type->is(BaseType::TY_ANY)) {
+    return emitUnboxFromAny(span, val, type);
   }
   return CodegenTypeUtils::cast(span, val, type, builder.get());
 }
@@ -5855,8 +6044,21 @@ auto Codegen::callNamedFunction(
       for (size_t i = 0; i < candidateFields.size(); ++i) {
         lesma::Type* formalType = normalizeFunctionParamType(candidateFields[i]->type);
         lesma::Type* actualType = normalizeFunctionParamType(localParamTypes[i]);
-        if ((formalType == nullptr) != (actualType == nullptr) ||
-            (formalType != nullptr && !formalType->isEqual(actualType))) {
+        if ((formalType == nullptr) != (actualType == nullptr)) {
+          compatible = false;
+          break;
+        }
+        if (formalType == nullptr) {
+          continue;
+        }
+        if (formalType->is(BaseType::TY_ANY)) {
+          if (actualType == nullptr || actualType->is(BaseType::TY_NULL)) {
+            compatible = false;
+            break;
+          }
+          continue;
+        }
+        if (!formalType->isEqual(actualType)) {
           compatible = false;
           break;
         }
@@ -5896,12 +6098,41 @@ auto Codegen::callNamedFunction(
                        classSym != nullptr ? "Constructor for" : "Function", functionName);
   }
   if (symbol->getLlvmValue() == nullptr) {
+    std::vector<lesma::Type*> moduleLookupParamTypes = localParamTypes;
+    lesma::Type* lookupCallableType = symbol->getType();
+    if (lookupCallableType != nullptr && genericBindingHint != nullptr &&
+        !genericBindingHint->empty()) {
+      lookupCallableType =
+          substituteTypeForSpecializationEnv(lookupCallableType, hintedGenericBindings());
+    } else if (lookupCallableType != nullptr && !currentGenericTypes.empty() &&
+               typeContainsUnboundGeneric(lookupCallableType)) {
+      lookupCallableType =
+          substituteTypeForSpecializationEnv(lookupCallableType, currentGenericTypes);
+    }
+    if (lookupCallableType != nullptr && lookupCallableType->is(BaseType::TY_FUNCTION) &&
+        !typeContainsUnboundGeneric(lookupCallableType)) {
+      moduleLookupParamTypes.clear();
+      for (Field* field : lookupCallableType->getFields()) {
+        moduleLookupParamTypes.push_back(field != nullptr ? field->type : nullptr);
+      }
+    }
+    for (lesma::Type* lookupTy : moduleLookupParamTypes) {
+      if (lookupTy != nullptr) {
+        getOrCreateLlvmType(lookupTy);
+      }
+    }
     std::string moduleLookupName =
-        getMangledName(span, functionName, localParamTypes, selfSymbol != nullptr);
+        getMangledName(span, functionName, moduleLookupParamTypes, selfSymbol != nullptr);
     appendGenericBindingsForTemplate(moduleLookupName);
     if (auto* directFunction = theModule->getFunction(moduleLookupName);
         directFunction != nullptr) {
       symbol->setLlvmValue(directFunction);
+    } else if (!moduleLookupParamTypes.empty()) {
+      if (Value* rebound = scope->lookupFunction(functionName, moduleLookupParamTypes,
+                                                 FunctionLookupKind::OVERLOAD_IDENTITY);
+          rebound != nullptr) {
+        symbol = rebound;
+      }
     }
   }
 
@@ -6245,8 +6476,7 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     if (nullIndex == std::nullopt) {
       throw CodegenError(span, "pop() could not resolve null union arm");
     }
-    auto nullWrapped =
-        emitUnionWrapValue(span, &nullValue, popType, *nullIndex);
+    auto nullWrapped = emitUnionWrapValue(span, &nullValue, popType, *nullIndex);
     builder->CreateBr(mergeBlock);
 
     builder->SetInsertPoint(valueBlock);
@@ -6443,10 +6673,18 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
                                                               : receiverType->getDisplayName());
   }
   const auto* receiverClassEnv = specializedClassEnvFor(receiverType);
+  std::vector<std::pair<std::string, lesma::Type*>> receiverGenericBindingsStorage;
   const std::vector<std::pair<std::string, lesma::Type*>>* callSiteGenericBindings =
       (callSiteForGenericEnv != nullptr && !callSiteForGenericEnv->getGenericBindingEnv().empty())
           ? &callSiteForGenericEnv->getGenericBindingEnv()
           : nullptr;
+  if (callSiteGenericBindings == nullptr && receiverClassEnv != nullptr) {
+    receiverGenericBindingsStorage.reserve(receiverClassEnv->size());
+    for (const auto& [name, type] : *receiverClassEnv) {
+      receiverGenericBindingsStorage.emplace_back(name, type);
+    }
+    callSiteGenericBindings = &receiverGenericBindingsStorage;
+  }
   auto* savedSelfSymbol = selfSymbol;
   std::vector<lesma::Type*> paramTypes;
   std::vector<llvm::Value*> paramsLLVM;
@@ -6490,9 +6728,6 @@ auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,
           break;
         }
       }
-    }
-    if (receiverClassEnv != nullptr) {
-      directMethod = nullptr;
     }
   }
   if (directMethod != nullptr && directMethod->getLlvmValue() != nullptr) {

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1586,6 +1586,7 @@ auto Codegen::emitUnboxFromAny(llvm::SMRange span, lesma::Value* value, lesma::T
   builder->CreateCondBr(typeMatch, okBlock, failBlock);
 
   builder->SetInsertPoint(failBlock);
+  emitRuntimeStderrMessage("Runtime cast from any failed\n");
   emitExit(1);
   builder->CreateUnreachable();
 

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1492,6 +1492,25 @@ auto Codegen::emitAnyTypeInfoPtr(lesma::Type* type) -> llvm::Value* {
                                 "any.typeinfo");
 }
 
+auto Codegen::emitAnyTypeInfoMatches(llvm::Value* typeInfo, lesma::Type* candidate,
+                                     const llvm::Twine& name) -> llvm::Value* {
+  if (candidate == nullptr) {
+    return builder->getFalse();
+  }
+  if (candidate->is(BaseType::TY_UNION)) {
+    llvm::Value* match = builder->getFalse();
+    for (Type* member : candidate->getUnionMembers()) {
+      if (member == nullptr) {
+        continue;
+      }
+      match =
+          builder->CreateOr(match, emitAnyTypeInfoMatches(typeInfo, member, name), name + ".union");
+    }
+    return match;
+  }
+  return builder->CreateICmpEQ(typeInfo, emitAnyTypeInfoPtr(candidate), name);
+}
+
 auto Codegen::emitBoxToAny(llvm::SMRange span, lesma::Value* value, lesma::Type* anyType)
     -> std::unique_ptr<lesma::Value> {
   if (value == nullptr || value->getType() == nullptr || anyType == nullptr) {
@@ -1580,8 +1599,62 @@ auto Codegen::emitUnboxFromAny(llvm::SMRange span, lesma::Value* value, lesma::T
 
   llvm::Value* typeInfo = builder->CreateExtractValue(anyValue, {0U}, "any.unbox.typeinfo");
   llvm::Value* payloadPtr = builder->CreateExtractValue(anyValue, {1U}, "any.unbox.payload");
-  llvm::Value* typeMatch =
-      builder->CreateICmpEQ(typeInfo, emitAnyTypeInfoPtr(targetType), "any.is");
+  if (targetType->is(BaseType::TY_UNION)) {
+    getOrCreateLlvmType(targetType);
+    llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+    auto* unionStructTy = llvm::cast<llvm::StructType>(targetType->getLlvmType());
+    auto* unionSlot = createAllocaInEntry(parentFn, unionStructTy, "any.union.slot");
+    llvm::BasicBlock* failBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), "any.unbox.fail", parentFn);
+    llvm::BasicBlock* mergeBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), "any.unbox.merge", parentFn);
+
+    llvm::BasicBlock* currentBlock = builder->GetInsertBlock();
+    const auto& members = targetType->getUnionMembers();
+    for (unsigned idx = 0; idx < members.size(); ++idx) {
+      Type* member = members[idx];
+      if (member == nullptr) {
+        continue;
+      }
+      llvm::BasicBlock* matchBlock =
+          llvm::BasicBlock::Create(theModule->getContext(), "any.unbox.match", parentFn);
+      llvm::BasicBlock* nextBlock =
+          llvm::BasicBlock::Create(theModule->getContext(), "any.unbox.next", parentFn);
+      builder->SetInsertPoint(currentBlock);
+      llvm::Value* memberMatch = emitAnyTypeInfoMatches(typeInfo, member, "any.union.match");
+      builder->CreateCondBr(memberMatch, matchBlock, nextBlock);
+
+      builder->SetInsertPoint(matchBlock);
+      llvm::Type* storageTy = member->is(BaseType::TY_FUNCTION)
+                                  ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                                  : getStoredAggregateFieldLlvmType(member);
+      llvm::Value* typedPayloadPtr = builder->CreateBitCast(
+          payloadPtr, llvm::PointerType::get(theModule->getContext(), 0U), "any.unbox.typed");
+      llvm::Value* loaded = builder->CreateLoad(storageTy, typedPayloadPtr, "any.unbox.value");
+      auto memberValue = std::make_unique<Value>("", member, loaded);
+      if (member->is(BaseType::TY_FUNCTION)) {
+        memberValue->setStoresFuncValuePair(true);
+        memberValue->setCategory(ValueCategory::DIRECT_VALUE);
+      }
+      emitUnionWrapValueToSlot(span, memberValue.get(), targetType, idx, unionSlot);
+      builder->CreateBr(mergeBlock);
+      currentBlock = nextBlock;
+    }
+
+    builder->SetInsertPoint(currentBlock);
+    builder->CreateBr(failBlock);
+
+    builder->SetInsertPoint(failBlock);
+    emitRuntimeStderrMessage("Runtime cast from any failed\n");
+    emitExit(1);
+    builder->CreateUnreachable();
+
+    builder->SetInsertPoint(mergeBlock);
+    llvm::Value* unionValue = builder->CreateLoad(unionStructTy, unionSlot, "any.union.value");
+    return std::make_unique<Value>("", targetType, unionValue);
+  }
+
+  llvm::Value* typeMatch = emitAnyTypeInfoMatches(typeInfo, targetType, "any.is");
 
   llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
   auto* okBlock = llvm::BasicBlock::Create(theModule->getContext(), "any.unbox.ok", parentFn);
@@ -1631,7 +1704,7 @@ auto Codegen::emitAnyIsCheck(llvm::SMRange span, lesma::Value* value, lesma::Typ
       anyValue = builder->CreateLoad(value->getType()->getLlvmType(), anyValue, "any.is.load");
     }
     llvm::Value* typeInfo = builder->CreateExtractValue(anyValue, {0U}, "any.is.typeinfo");
-    cmp = builder->CreateICmpEQ(typeInfo, emitAnyTypeInfoPtr(testType), "any.is.cmp");
+    cmp = emitAnyTypeInfoMatches(typeInfo, testType, "any.is.cmp");
     if (negate) {
       cmp = builder->CreateNot(cmp);
     }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -577,7 +577,8 @@ auto Codegen::getFuncValuePairLlvmType() -> llvm::StructType* {
   if (funcValuePairLlvmType == nullptr) {
     funcValuePairLlvmType = llvm::StructType::create(
         theModule->getContext(),
-        std::array<llvm::Type*, 2>{builder->getPtrTy(), builder->getPtrTy()}, "lesma.funcval");
+        std::array<llvm::Type*, 3>{builder->getPtrTy(), builder->getPtrTy(), builder->getInt1Ty()},
+        "lesma.funcval");
   }
   return funcValuePairLlvmType;
 }
@@ -1519,6 +1520,8 @@ auto Codegen::emitBoxToAny(llvm::SMRange span, lesma::Value* value, lesma::Type*
       pair = builder->CreateInsertValue(pair, codePtr, {0U}, "any.fnpair.code");
       pair = builder->CreateInsertValue(pair, llvm::ConstantPointerNull::get(builder->getPtrTy()),
                                         {1U}, "any.fnpair.env");
+      pair = builder->CreateInsertValue(pair, llvm::ConstantInt::getFalse(theModule->getContext()),
+                                        {2U}, "any.fnpair.uses_env");
       storageValue = pair;
     }
   } else {
@@ -1601,6 +1604,11 @@ auto Codegen::emitUnboxFromAny(llvm::SMRange span, lesma::Value* value, lesma::T
   if (targetType->is(BaseType::TY_FUNCTION)) {
     out->setStoresFuncValuePair(true);
     out->setCategory(ValueCategory::DIRECT_VALUE);
+    if (auto* flag = llvm::dyn_cast<llvm::ConstantInt>(
+            builder->CreateExtractValue(loaded, {2U}, "any.unbox.fn.uses_env"));
+        flag != nullptr) {
+      out->setClosureCalleeUsesEnvParameter(flag->isOne());
+    }
   }
   return out;
 }
@@ -2820,7 +2828,10 @@ auto Codegen::visit(const Assignment* node) -> void {
   node->getRightHandSide()->accept(*this);
   if (lhs->getStoresFuncValuePair() && result != nullptr && result->getStoresFuncValuePair()) {
     llvm::StructType* pt = getFuncValuePairLlvmType();
-    llvm::Value* rhsAgg = builder->CreateLoad(pt, result->getLlvmValue(), "fnval.assign");
+    llvm::Value* rhsAgg = result->getLlvmValue();
+    if (rhsAgg->getType()->isPointerTy()) {
+      rhsAgg = builder->CreateLoad(pt, rhsAgg, "fnval.assign");
+    }
     builder->CreateStore(rhsAgg, lhs->getLlvmValue());
     lhs->setClosureCalleeUsesEnvParameter(result->getClosureCalleeUsesEnvParameter());
     return;
@@ -3398,6 +3409,8 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
   }
   builder->CreateStore(codePtr, builder->CreateStructGEP(pairTy, pairSlot, 0U));
   builder->CreateStore(envStoreVal, builder->CreateStructGEP(pairTy, pairSlot, 1U));
+  builder->CreateStore(llvm::ConstantInt::get(builder->getInt1Ty(), !caps.empty()),
+                       builder->CreateStructGEP(pairTy, pairSlot, 2U));
 
   auto out = std::make_unique<Value>("", fnType, pairSlot);
   out->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
@@ -5029,6 +5042,8 @@ auto Codegen::visit(const Literal* node) -> void {
       builder->CreateStore(codePtr, builder->CreateStructGEP(pairTy, pairSlot, 0U));
       builder->CreateStore(llvm::ConstantPointerNull::get(builder->getPtrTy()),
                            builder->CreateStructGEP(pairTy, pairSlot, 1U));
+      builder->CreateStore(llvm::ConstantInt::getFalse(theModule->getContext()),
+                           builder->CreateStructGEP(pairTy, pairSlot, 2U));
       auto wrapped = std::make_unique<Value>("", val->getType(), pairSlot);
       wrapped->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
       wrapped->setStoresFuncValuePair(true);
@@ -6239,6 +6254,7 @@ auto Codegen::callNamedFunction(
 
   llvm::Value* callableValue = nullptr;
   llvm::Value* loadedClosureEnv = nullptr;
+  llvm::Value* loadedClosureUsesEnv = nullptr;
   if (callableLesmaType->is(BaseType::TY_CLASS)) {
     if (symbol->getConstructor() == nullptr ||
         symbol->getConstructor()->getLlvmValue() == nullptr) {
@@ -6251,11 +6267,21 @@ auto Codegen::callNamedFunction(
         throw CodegenError(span, "Function value {} is not initialized", functionName);
       }
       llvm::StructType* pairTy = getFuncValuePairLlvmType();
-      llvm::Value* pairPtr = symbol->getLlvmValue();
-      llvm::Value* fnSlot = builder->CreateStructGEP(pairTy, pairPtr, 0U);
-      llvm::Value* envSlot = builder->CreateStructGEP(pairTy, pairPtr, 1U);
-      callableValue = builder->CreateLoad(builder->getPtrTy(), fnSlot, functionName + ".code");
-      loadedClosureEnv = builder->CreateLoad(builder->getPtrTy(), envSlot, functionName + ".env");
+      llvm::Value* pairVal = symbol->getLlvmValue();
+      if (pairVal->getType()->isPointerTy()) {
+        llvm::Value* fnSlot = builder->CreateStructGEP(pairTy, pairVal, 0U);
+        llvm::Value* envSlot = builder->CreateStructGEP(pairTy, pairVal, 1U);
+        llvm::Value* usesEnvSlot = builder->CreateStructGEP(pairTy, pairVal, 2U);
+        callableValue = builder->CreateLoad(builder->getPtrTy(), fnSlot, functionName + ".code");
+        loadedClosureEnv = builder->CreateLoad(builder->getPtrTy(), envSlot, functionName + ".env");
+        loadedClosureUsesEnv =
+            builder->CreateLoad(builder->getInt1Ty(), usesEnvSlot, functionName + ".uses_env");
+      } else {
+        callableValue = builder->CreateExtractValue(pairVal, {0U}, functionName + ".code");
+        loadedClosureEnv = builder->CreateExtractValue(pairVal, {1U}, functionName + ".env");
+        loadedClosureUsesEnv =
+            builder->CreateExtractValue(pairVal, {2U}, functionName + ".uses_env");
+      }
     } else {
       if (symbol->getLlvmValue() == nullptr) {
         throw CodegenError(span, "Function {} is declared but not defined", functionName);
@@ -6263,10 +6289,6 @@ auto Codegen::callNamedFunction(
       callableValue = symbol->getLlvmValue();
     }
   }
-  llvm::Value* const envArgForCall =
-      (symbol->getStoresFuncValuePair() && symbol->getClosureCalleeUsesEnvParameter())
-          ? loadedClosureEnv
-          : nullptr;
 
   auto emitIndirectCall = [&](llvm::Value* calleePtr, llvm::Value* envArg) -> llvm::CallInst* {
     std::vector<llvm::Type*> callParamTypes;
@@ -6311,11 +6333,52 @@ auto Codegen::callNamedFunction(
     return builder->CreateCall(callTy, calleePtr, callArgs);
   };
 
-  llvm::CallInst* callInst = nullptr;
+  auto emitIndirectCallWithPairAbi = [&](llvm::Value* calleePtr, llvm::Value* envArg,
+                                         llvm::Value* usesEnvFlag) -> llvm::Value* {
+    if (usesEnvFlag == nullptr) {
+      return emitIndirectCall(calleePtr, nullptr);
+    }
+    if (auto* constFlag = llvm::dyn_cast<llvm::ConstantInt>(usesEnvFlag); constFlag != nullptr) {
+      return emitIndirectCall(calleePtr, constFlag->isOne() ? envArg : nullptr);
+    }
+    llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+    llvm::BasicBlock* envBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), functionName + ".call.env", parentFn);
+    llvm::BasicBlock* noEnvBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), functionName + ".call.noenv", parentFn);
+    llvm::BasicBlock* mergeBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), functionName + ".call.merge", parentFn);
+    builder->CreateCondBr(usesEnvFlag, envBlock, noEnvBlock);
+
+    builder->SetInsertPoint(envBlock);
+    llvm::Value* withEnvCall = emitIndirectCall(calleePtr, envArg);
+    builder->CreateBr(mergeBlock);
+    llvm::BasicBlock* withEnvDone = builder->GetInsertBlock();
+
+    builder->SetInsertPoint(noEnvBlock);
+    llvm::Value* withoutEnvCall = emitIndirectCall(calleePtr, nullptr);
+    builder->CreateBr(mergeBlock);
+    llvm::BasicBlock* withoutEnvDone = builder->GetInsertBlock();
+
+    builder->SetInsertPoint(mergeBlock);
+    Type* retType = callableLesmaType->getReturnType();
+    if (retType != nullptr && retType->is(BaseType::TY_VOID)) {
+      return nullptr;
+    }
+    llvm::PHINode* phi =
+        builder->CreatePHI(withEnvCall->getType(), 2U, functionName + ".call.result");
+    phi->addIncoming(withEnvCall, withEnvDone);
+    phi->addIncoming(withoutEnvCall, withoutEnvDone);
+    return phi;
+  };
+
+  llvm::Value* callInst = nullptr;
   if (symbol->getStoresFuncValuePair()) {
     llvm::Value* calleePtr = callableValue;
-    callInst = emitIndirectCall(calleePtr, envArgForCall);
+    callInst = emitIndirectCallWithPairAbi(calleePtr, loadedClosureEnv, loadedClosureUsesEnv);
   } else if (auto* func = llvm::dyn_cast<Function>(callableValue)) {
+    llvm::Value* const envArgForCall =
+        symbol->getClosureCalleeUsesEnvParameter() ? loadedClosureEnv : nullptr;
     if (envArgForCall != nullptr) {
       std::vector<llvm::Value*> withEnv;
       withEnv.push_back(envArgForCall);

--- a/src/liblesma/Backend/MangleUtils.cpp
+++ b/src/liblesma/Backend/MangleUtils.cpp
@@ -67,6 +67,9 @@ auto getTypeMangledName(llvm::SMRange span, Type* type) -> std::string {
   if (type->is(BaseType::TY_STRING)) {
     return "str";
   }
+  if (type->is(BaseType::TY_ANY)) {
+    return "any";
+  }
   if (type->is(BaseType::TY_VOID)) {
     return "void";
   }

--- a/src/liblesma/Frontend/Parser.cpp
+++ b/src/liblesma/Frontend/Parser.cpp
@@ -166,9 +166,8 @@ private:
       }
     }
     for (size_t i = 1; i < conds.size() && i < blocks.size(); ++i) {
-      LeadingTriviaBlock block =
-          collectLeadingTrivia(lineOf(srcMgr, blocks[i - 1]->getEnd()),
-                               lineOf(srcMgr, conds[i]->getStart()));
+      LeadingTriviaBlock block = collectLeadingTrivia(lineOf(srcMgr, blocks[i - 1]->getEnd()),
+                                                      lineOf(srcMgr, conds[i]->getStart()));
       node->setBranchTrivia(i, block.extraBlankLinesBefore, std::move(block.comments));
     }
   }
@@ -192,7 +191,8 @@ private:
     if (container == nullptr) {
       return;
     }
-    LeadingTriviaBlock tail = collectLeadingTrivia(previousEndLine, lineOf(srcMgr, container->getEnd()));
+    LeadingTriviaBlock tail =
+        collectLeadingTrivia(previousEndLine, lineOf(srcMgr, container->getEnd()));
     container->setExtraBlankLinesBeforeTrailingDetachedComments(tail.extraBlankLinesBefore);
     container->setTrailingDetachedComments(std::move(tail.comments));
   }
@@ -296,9 +296,9 @@ private:
       for (Parameter* parameter : funcDecl->getParameters()) {
         attachExpression(parameter->defaultVal.get());
       }
-      attachCompound(funcDecl->getBody(),
-                     funcDecl->getBody() != nullptr ? lineOf(srcMgr, funcDecl->getBody()->getStart())
-                                                    : lineOf(srcMgr, funcDecl->getEnd()));
+      attachCompound(funcDecl->getBody(), funcDecl->getBody() != nullptr
+                                              ? lineOf(srcMgr, funcDecl->getBody()->getStart())
+                                              : lineOf(srcMgr, funcDecl->getEnd()));
       return;
     }
     if (auto* traitDecl = dynamic_cast<TraitDecl*>(statement); traitDecl != nullptr) {
@@ -432,7 +432,8 @@ auto Parser::isTypeArgClose(unsigned long off, unsigned short pendingTypeArgClos
           (peek(off)->type == TokenType::GREATER || peek(off)->type == TokenType::SHIFT_RIGHT));
 }
 
-auto Parser::consumeTypeArgClose(unsigned long& off, unsigned short& pendingTypeArgClosers) -> bool {
+auto Parser::consumeTypeArgClose(unsigned long& off, unsigned short& pendingTypeArgClosers)
+    -> bool {
   if (pendingTypeArgClosers > 0U) {
     pendingTypeArgClosers--;
     return true;
@@ -738,11 +739,11 @@ auto Parser::parseTypePrimary() -> std::unique_ptr<TypeExpr> {
                TokenType::BOOL_TYPE, TokenType::INT8_TYPE, TokenType::INT16_TYPE,
                TokenType::INT32_TYPE, TokenType::UINT_TYPE, TokenType::UINT8_TYPE,
                TokenType::UINT16_TYPE, TokenType::UINT32_TYPE, TokenType::FLOAT32_TYPE,
-               TokenType::VOID_TYPE, TokenType::NIL>()) {
+               TokenType::ANY_TYPE, TokenType::VOID_TYPE, TokenType::NIL>()) {
     advance();
     std::string displayName = type->type == TokenType::NIL ? "null" : type->lexeme;
-    return wrapOptionalType(std::make_unique<TypeExpr>(type->span, std::move(displayName),
-                                                       type->type));
+    return wrapOptionalType(
+        std::make_unique<TypeExpr>(type->span, std::move(displayName), type->type));
   }
   if (check(TokenType::FUNC)) {
     std::vector<std::unique_ptr<TypeExpr>> params;
@@ -784,9 +785,9 @@ auto Parser::parseTypePrimary() -> std::unique_ptr<TypeExpr> {
     // Function types are nominal (like classes): values are function pointers in LLVM, but the
     // type is written `func(...)` without a leading `*`. `*func(...)` is still accepted and lowers
     // to the same type.
-    return wrapOptionalType(std::make_unique<TypeExpr>(llvm::SMRange{type->getStart(), ret->getEnd()},
-                                                       lexeme, TokenType::FUNC_TYPE,
-                                                       std::move(params), std::move(ret)));
+    return wrapOptionalType(
+        std::make_unique<TypeExpr>(llvm::SMRange{type->getStart(), ret->getEnd()}, lexeme,
+                                   TokenType::FUNC_TYPE, std::move(params), std::move(ret)));
   }
 
   if (check(TokenType::IDENTIFIER)) {
@@ -802,9 +803,9 @@ auto Parser::parseTypePrimary() -> std::unique_ptr<TypeExpr> {
         }
       }
       lexeme += ">";
-      return wrapOptionalType(std::make_unique<TypeExpr>(
-          llvm::SMRange{type->getStart(), greater->getEnd()}, lexeme, TokenType::CUSTOM_TYPE,
-          std::move(typeArgs)));
+      return wrapOptionalType(
+          std::make_unique<TypeExpr>(llvm::SMRange{type->getStart(), greater->getEnd()}, lexeme,
+                                     TokenType::CUSTOM_TYPE, std::move(typeArgs)));
     }
     return wrapOptionalType(
         std::make_unique<TypeExpr>(type->span, type->lexeme, TokenType::CUSTOM_TYPE));
@@ -1278,8 +1279,8 @@ auto Parser::parseDot() -> std::unique_ptr<Expression> { return parsePostfix(); 
 
 auto Parser::parseUnary() -> std::unique_ptr<Expression> {
   // Handle unary operators recursively to allow chaining: - - x, * * ptr, etc.
-  if (advanceIfMatchAny<TokenType::MINUS, TokenType::STAR, TokenType::AMPERSAND,
-                        TokenType::BANG, TokenType::TILDE>()) {
+  if (advanceIfMatchAny<TokenType::MINUS, TokenType::STAR, TokenType::AMPERSAND, TokenType::BANG,
+                        TokenType::TILDE>()) {
     auto* op = previous();
     consumeOperandContinuationNewlines();
     auto expr = parseUnary(); // Recursive call for chained unary operators
@@ -1671,8 +1672,8 @@ auto Parser::parseAssignment() -> std::unique_ptr<Statement> {
 
   if (advanceIfMatchAny<TokenType::EQUAL, TokenType::PLUS_EQUAL, TokenType::MINUS_EQUAL,
                         TokenType::STAR_EQUAL, TokenType::SLASH_EQUAL, TokenType::MOD_EQUAL,
-                        TokenType::POWER_EQUAL, TokenType::AMPERSAND_EQUAL,
-                        TokenType::PIPE_EQUAL, TokenType::XOR_EQUAL, TokenType::SHIFT_LEFT_EQUAL,
+                        TokenType::POWER_EQUAL, TokenType::AMPERSAND_EQUAL, TokenType::PIPE_EQUAL,
+                        TokenType::XOR_EQUAL, TokenType::SHIFT_LEFT_EQUAL,
                         TokenType::SHIFT_RIGHT_EQUAL, TokenType::NULL_COALESCE_EQUAL>()) {
     auto op = previous()->type;
     consumeOperandContinuationNewlines();
@@ -1793,8 +1794,8 @@ auto Parser::parseStatement(bool isTopLevel) -> std::unique_ptr<Statement> {
   }
   if (checkAnyInLine<TokenType::EQUAL, TokenType::PLUS_EQUAL, TokenType::MINUS_EQUAL,
                      TokenType::STAR_EQUAL, TokenType::SLASH_EQUAL, TokenType::MOD_EQUAL,
-                     TokenType::POWER_EQUAL, TokenType::AMPERSAND_EQUAL,
-                     TokenType::PIPE_EQUAL, TokenType::XOR_EQUAL, TokenType::SHIFT_LEFT_EQUAL,
+                     TokenType::POWER_EQUAL, TokenType::AMPERSAND_EQUAL, TokenType::PIPE_EQUAL,
+                     TokenType::XOR_EQUAL, TokenType::SHIFT_LEFT_EQUAL,
                      TokenType::SHIFT_RIGHT_EQUAL, TokenType::NULL_COALESCE_EQUAL>()) {
     return parseAssignment();
   }

--- a/src/liblesma/Frontend/Parser.cpp
+++ b/src/liblesma/Frontend/Parser.cpp
@@ -888,7 +888,7 @@ auto Parser::parseTypePrimaryAt(unsigned long& off, unsigned short& pendingTypeA
                TokenType::BOOL_TYPE, TokenType::INT8_TYPE, TokenType::INT16_TYPE,
                TokenType::INT32_TYPE, TokenType::UINT_TYPE, TokenType::UINT8_TYPE,
                TokenType::UINT16_TYPE, TokenType::UINT32_TYPE, TokenType::FLOAT32_TYPE,
-               TokenType::VOID_TYPE, TokenType::NIL>(off)) {
+               TokenType::ANY_TYPE, TokenType::VOID_TYPE, TokenType::NIL>(off)) {
     off++;
     while (canPeek(off) && peek(off)->type == TokenType::QUESTION) {
       off++;

--- a/src/liblesma/Symbol/Type.h
+++ b/src/liblesma/Symbol/Type.h
@@ -24,6 +24,7 @@ enum class BaseType : std::uint8_t {
   TY_BOOL,
   TY_PTR,
   TY_ARRAY,
+  TY_ANY,
   TY_VOID,
   TY_NULL,
   TY_FUNCTION,
@@ -81,7 +82,8 @@ class Type {
   Type* returnType;
   /** For TY_CLASS: direct superclass (single inheritance), or nullptr. */
   Type* classSuperclass = nullptr;
-  /** True once another class declares this type as its base (needs vtable dispatch via base ptr). */
+  /** True once another class declares this type as its base (needs vtable dispatch via base ptr).
+   */
   bool classHasDerivedClass = false;
   std::string genericName;
   std::string displayName;
@@ -139,8 +141,7 @@ public:
     return baseType == BaseType::TY_FLOAT || baseType == BaseType::TY_FLOAT32;
   }
   [[nodiscard]] auto isOneOf(const std::vector<BaseType>& baseTypes) const -> bool {
-    return std::ranges::any_of(baseTypes,
-                               [this](BaseType type) { return type == this->baseType; });
+    return std::ranges::any_of(baseTypes, [this](BaseType type) { return type == this->baseType; });
   }
   [[nodiscard]] auto getBaseType() const -> BaseType { return baseType; }
   [[nodiscard]] auto getElementType() const -> Type* { return elementType; }
@@ -415,6 +416,7 @@ private:
     }
     case BaseType::TY_STRING:
     case BaseType::TY_BOOL:
+    case BaseType::TY_ANY:
     case BaseType::TY_VOID:
     case BaseType::TY_NULL:
     case BaseType::TY_INVALID:
@@ -544,6 +546,9 @@ public:
       break;
     case BaseType::TY_ARRAY:
       result = displayName.empty() ? "list" : displayName;
+      break;
+    case BaseType::TY_ANY:
+      result = "any";
       break;
     case BaseType::TY_VOID:
       result = "void";

--- a/src/liblesma/Token/Token.cpp
+++ b/src/liblesma/Token/Token.cpp
@@ -76,6 +76,7 @@ static const std::unordered_map<std::string_view, TokenType> KEYWORDS = {
     {"cstr", TokenType::STRING_TYPE},
     {"bool", TokenType::BOOL_TYPE},
     {"void", TokenType::VOID_TYPE},
+    {"any", TokenType::ANY_TYPE},
 };
 
 auto Token::getIdentifierType(const std::string& identifier, Token* lastTok) -> TokenType {

--- a/src/liblesma/Token/TokenType.h
+++ b/src/liblesma/Token/TokenType.h
@@ -91,6 +91,7 @@ enum class TokenType : std::uint8_t {
   UINT16_TYPE,
   UINT32_TYPE,
   FLOAT32_TYPE,
+  ANY_TYPE,
   /** Structural tuple type `(T1, T2, ...)` in TypeExpr; not a lexer token. */
   TUPLE_TYPE,
   /** Structural union type `T1 | T2 | ...` in TypeExpr; not a lexer token. */

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -2732,7 +2732,7 @@ auto Typechecker::isAssignableTo(Type* from, Type* to) -> bool {
     return true;
   }
   if (to->is(BaseType::TY_ANY)) {
-    return !from->is(BaseType::TY_NULL);
+    return !from->is(BaseType::TY_VOID) && !isNullableType(from);
   }
   if (from->isEqual(to)) {
     return true;

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1532,8 +1532,8 @@ void Typechecker::mergeInferredGenericBindings(
         continue;
       }
       throw TypeCheckError(span, "Conflicting inferred types for generic parameter {}: {} and {}",
-                           kv.first, existingIt->second != nullptr ? existingIt->second->toString()
-                                                                   : "void",
+                           kv.first,
+                           existingIt->second != nullptr ? existingIt->second->toString() : "void",
                            kv.second != nullptr ? kv.second->toString() : "void");
     }
     if (existingIt->second->isEqual(kv.second) ||
@@ -1788,6 +1788,8 @@ auto Typechecker::tryResolveNonCustomTypeExpr(const TypeExpr* node) -> Type* {
     return cacheType(std::make_unique<Type>(BaseType::TY_BOOL));
   case TokenType::STRING_TYPE:
     return cacheType(std::make_unique<Type>(BaseType::TY_STRING));
+  case TokenType::ANY_TYPE:
+    return cacheType(std::make_unique<Type>(BaseType::TY_ANY));
   case TokenType::VOID_TYPE:
     return cacheType(std::make_unique<Type>(BaseType::TY_VOID));
   case TokenType::NIL:
@@ -2579,7 +2581,8 @@ auto Typechecker::getOptionalPayloadType(Type* type) -> Type* {
 }
 
 auto Typechecker::isNullableType(Type* type) -> bool {
-  return (type != nullptr && type->is(BaseType::TY_NULL)) || getOptionalPayloadType(type) != nullptr;
+  return (type != nullptr && type->is(BaseType::TY_NULL)) ||
+         getOptionalPayloadType(type) != nullptr;
 }
 
 auto Typechecker::typecheckBinaryOpResult(TokenType op, Type* leftTy, Type* rightTy,
@@ -2727,6 +2730,12 @@ auto Typechecker::isAssignableTo(Type* from, Type* to) -> bool {
   }
   if (from->is(BaseType::TY_GENERIC) || to->is(BaseType::TY_GENERIC)) {
     return true;
+  }
+  if (to->is(BaseType::TY_ANY)) {
+    return !from->is(BaseType::TY_NULL);
+  }
+  if (from->is(BaseType::TY_ANY)) {
+    return to->is(BaseType::TY_ANY);
   }
   if (from->isEqual(to)) {
     return true;
@@ -3563,7 +3572,8 @@ auto Typechecker::isSupportedUnionMemberType(Type* t) -> bool {
     return false;
   }
   return t->is(BaseType::TY_INT) || t->isFloatingPoint() || t->is(BaseType::TY_BOOL) ||
-         t->is(BaseType::TY_CLASS) || t->is(BaseType::TY_ENUM) || t->is(BaseType::TY_NULL);
+         t->is(BaseType::TY_CLASS) || t->is(BaseType::TY_ENUM) || t->is(BaseType::TY_ANY) ||
+         t->is(BaseType::TY_NULL);
 }
 
 auto Typechecker::lookupUnionNarrowedType(Value* sym) const -> Type* {
@@ -6010,7 +6020,8 @@ auto Typechecker::visit(const CastOp* node) -> void {
   Type* from = result->getType();
   node->getType()->accept(*this);
   Type* to = result->getType();
-  if (!isAssignableTo(from, to)) {
+  if (!isAssignableTo(from, to) && !(from != nullptr && from->is(BaseType::TY_ANY) &&
+                                     to != nullptr && !to->is(BaseType::TY_VOID))) {
     throw TypeCheckError(node->getSpan(), "Cannot cast from {} to {}", from->toString(),
                          to->toString());
   }
@@ -6022,6 +6033,13 @@ auto Typechecker::visit(const IsOp* node) -> void {
   Type* lhsTy = result->getType();
   Type* rhsTy = resolveType(node->getRight());
   node->setResolvedRhsType(rhsTy);
+  if (lhsTy != nullptr && lhsTy->is(BaseType::TY_ANY)) {
+    if (rhsTy != nullptr && rhsTy->is(BaseType::TY_VOID)) {
+      throw TypeCheckError(node->getSpan(), "`is` cannot test `any` against void");
+    }
+    result = std::make_unique<Value>(cacheType(std::make_unique<Type>(BaseType::TY_BOOL)));
+    return;
+  }
   if (lhsTy != nullptr && lhsTy->is(BaseType::TY_UNION)) {
     bool found = false;
     for (Type* m : lhsTy->getUnionMembers()) {

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -2734,9 +2734,6 @@ auto Typechecker::isAssignableTo(Type* from, Type* to) -> bool {
   if (to->is(BaseType::TY_ANY)) {
     return !from->is(BaseType::TY_NULL);
   }
-  if (from->is(BaseType::TY_ANY)) {
-    return to->is(BaseType::TY_ANY);
-  }
   if (from->isEqual(to)) {
     return true;
   }
@@ -2837,6 +2834,9 @@ auto Typechecker::isAssignableTo(Type* from, Type* to) -> bool {
     }
     return std::ranges::any_of(to->getUnionMembers(),
                                [this, from](Type* m) -> bool { return isAssignableTo(from, m); });
+  }
+  if (from->is(BaseType::TY_ANY)) {
+    return to->is(BaseType::TY_ANY);
   }
   return false;
 }

--- a/tests/lesma/failure/any_function_closure_wrong_signature.les
+++ b/tests/lesma/failure/any_function_closure_wrong_signature.les
@@ -1,0 +1,10 @@
+func make_adder() -> func(int) -> int {
+  let base: int = 2
+  return func(x: int) -> int => x + base
+}
+
+let captured = make_adder()
+let erased: any = captured
+let restored = erased as func() -> int
+
+restored()

--- a/tests/lesma/failure/any_implicit_concrete_assignment.les
+++ b/tests/lesma/failure/any_implicit_concrete_assignment.les
@@ -1,0 +1,2 @@
+let value: any = 4
+let number: int = value

--- a/tests/lesma/failure/any_nullable_source_assignment.les
+++ b/tests/lesma/failure/any_nullable_source_assignment.les
@@ -1,0 +1,2 @@
+let maybe: int? = 1
+let erased: any = maybe

--- a/tests/lesma/failure/any_requires_optional_for_null.les
+++ b/tests/lesma/failure/any_requires_optional_for_null.les
@@ -1,0 +1,1 @@
+let value: any = null

--- a/tests/lesma/failure/any_void_source_assignment.les
+++ b/tests/lesma/failure/any_void_source_assignment.les
@@ -1,0 +1,3 @@
+func noop() {}
+
+let erased: any = noop()

--- a/tests/lesma/success/any_explicit_type_arg.les
+++ b/tests/lesma/success/any_explicit_type_arg.les
@@ -1,0 +1,12 @@
+func id<T>(x: T) -> T {
+  return x
+}
+
+let value = id<any>(1)
+if value is not int {
+  exit(1)
+}
+
+if value as int != 1 {
+  exit(2)
+}

--- a/tests/lesma/success/any_function_closure.les
+++ b/tests/lesma/success/any_function_closure.les
@@ -1,0 +1,16 @@
+func make_adder() -> func(int) -> int {
+  let base: int = 2
+  return func(x: int) -> int => x + base
+}
+
+func apply(f: func(int) -> int, x: int) -> int {
+  return f(x)
+}
+
+let captured = make_adder()
+let erased: any = captured
+let restored = erased as func(int) -> int
+
+if apply(restored, 5) != 7 {
+  exit(1)
+}

--- a/tests/lesma/success/any_overload_fallback.les
+++ b/tests/lesma/success/any_overload_fallback.les
@@ -1,0 +1,18 @@
+func pick(x: any) -> int {
+  return 1
+}
+
+func pick(x: int) -> int {
+  return 2
+}
+
+let erased: any = 7
+let anyValue = pick(erased)
+if anyValue != 1 {
+  exit(1)
+}
+
+let intValue = pick(7)
+if intValue != 2 {
+  exit(2)
+}

--- a/tests/lesma/success/any_type.les
+++ b/tests/lesma/success/any_type.les
@@ -69,6 +69,18 @@ var maybe: any? = null
 if maybe is not null {
   exit(107)
 }
+let stillAny: any = 7
+var widenedAny: any? = stillAny
+widenedAny = stillAny
+if widenedAny is null {
+  exit(107)
+} else if widenedAny is not any {
+  exit(107)
+} else {
+  if widenedAny is not int or widenedAny as int != 7 {
+    exit(107)
+  }
+}
 maybe = 9
 if maybe is null {
   exit(108)

--- a/tests/lesma/success/any_type.les
+++ b/tests/lesma/success/any_type.les
@@ -81,6 +81,18 @@ if widenedAny is null {
     exit(107)
   }
 }
+
+let unionAny: any = 11
+let unionValue = unionAny as int | str
+if unionValue is not int {
+  exit(120)
+} else if unionValue != 11 {
+  exit(120)
+}
+if unionAny is not int | str {
+  exit(120)
+}
+
 maybe = 9
 if maybe is null {
   exit(108)

--- a/tests/lesma/success/any_type.les
+++ b/tests/lesma/success/any_type.les
@@ -1,0 +1,189 @@
+enum Kind {
+  START
+  STOP
+}
+
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+var value: any = 1
+if value is not int {
+  exit(101)
+} else if value as int != 1 {
+  exit(101)
+}
+
+value = 2.5
+if value is not float {
+  exit(102)
+}
+let asFloat = value as float
+if asFloat < 2.49 or asFloat > 2.51 {
+  exit(102)
+}
+
+value = true
+if value is not bool {
+  exit(103)
+} else if not (value as bool) {
+  exit(103)
+}
+
+value = str("hello")
+if value is not str {
+  exit(104)
+} else {
+  let helloStr = value as str
+  if helloStr.len() != 5 {
+    exit(104)
+  }
+}
+
+value = Box(7)
+if value is not Box {
+  exit(105)
+} else {
+  let boxedValue = value as Box
+  if boxedValue.get() != 7 {
+    exit(105)
+  }
+}
+
+value = Kind.STOP
+if value is not Kind {
+  exit(106)
+} else if value as Kind != Kind.STOP {
+  exit(106)
+}
+
+var maybe: any? = null
+if maybe is not null {
+  exit(107)
+}
+maybe = 9
+if maybe is null {
+  exit(108)
+} else if maybe is not any {
+  exit(108)
+} else {
+  if maybe is not int or maybe as int != 9 {
+    exit(108)
+  }
+}
+
+let textAny: any = str("two")
+var xs: list<any> = [1, textAny, Box(3)]
+xs.push(Kind.START)
+xs.push(true)
+
+let first = xs[0]
+if first is not int {
+  exit(109)
+} else if first as int != 1 {
+  exit(109)
+}
+
+let second = xs[1]
+if second is not str {
+  exit(110)
+} else {
+  let secondStr = second as str
+  if secondStr.len() != 3 {
+    exit(110)
+  }
+}
+
+let third = xs[2]
+if third is not Box {
+  exit(111)
+} else {
+  let thirdBox = third as Box
+  if thirdBox.get() != 3 {
+    exit(111)
+  }
+}
+
+let fourth = xs[3]
+if fourth is not Kind {
+  exit(112)
+} else if fourth as Kind != Kind.START {
+  exit(112)
+}
+
+let popped = xs.pop()
+if popped is null {
+  exit(113)
+} else if popped is not any {
+  exit(113)
+} else {
+  if popped is not bool or not (popped as bool) {
+    exit(113)
+  }
+}
+
+if xs.len() != 4 {
+  exit(114)
+}
+
+var dictValues: dict<str, any> = {"one": 1, "box": Box(8)}
+let kindAny: any = Kind.STOP
+let doneAny: any = str("done")
+dictValues.set("kind", kindAny)
+dictValues.set("text", doneAny)
+
+let gotOne = dictValues.get("one")
+if gotOne is null {
+  exit(115)
+} else if gotOne is not any {
+  exit(115)
+} else {
+  if gotOne is not int or gotOne as int != 1 {
+    exit(115)
+  }
+}
+
+let gotBox = dictValues["box"]
+if gotBox is not Box {
+  exit(116)
+} else {
+  let gotBoxValue = gotBox as Box
+  if gotBoxValue.get() != 8 {
+    exit(116)
+  }
+}
+
+let gotKind = dictValues["kind"]
+if gotKind is not Kind {
+  exit(117)
+} else if gotKind as Kind != Kind.STOP {
+  exit(117)
+}
+
+let gotText = dictValues.get("text")
+if gotText is null {
+  exit(118)
+} else if gotText is not any {
+  exit(118)
+} else {
+  if gotText is not str {
+    exit(118)
+  } else {
+    let gotTextValue = gotText as str
+    if gotTextValue.len() != 4 {
+      exit(118)
+    }
+  }
+}
+
+if dictValues.get("missing") is not null {
+  exit(119)
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an any type with runtime boxing/unboxing, support for nullable any?, and acceptance in collections (list<any>, dict<str, any>).
  * is/as now work with any and enable runtime type checks and guards.
* **Behavior**
  * Assigning null to any requires optional (any?); any accepts non-null values.
  * Runtime type-mismatch emits an error message and aborts.
* **Tests**
  * New success and failure tests covering any behavior and null handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `any` type to Lesma with runtime boxing/unboxing. Each value boxed into `any` is represented as a `{ptr typeinfo, ptr payload}` struct, where the typeinfo is a `LinkOnceODR` global unique per concrete type and the payload is a heap-allocated copy of the value. `is`/`as` operators on `any` do runtime typeinfo comparisons. `any?` is supported as `TY_UNION[TY_ANY, TY_NULL]`, and `any` is accepted as a list/dict element type. The implementation is well-structured and comes with comprehensive success and failure tests.

Key points:
- **New codegen helpers** (`emitBoxToAny`, `emitUnboxFromAny`, `emitAnyIsCheck`) and a type-info global cache (`anyTypeInfoGlobals`) in `CodegenVisit.cpp`.
- **Typechecker rules**: non-void/non-nullable types can be implicitly widened to `any`; reading back from `any` requires an explicit `as` cast; `null` and nullable types require `any?`.
- **Unresolved from prior review**: every `emitBoxToAny` call `malloc`s a payload buffer that is never `free`d — this will produce LeakSanitizer failures on the `Debug_Asan` CI preset for every test that boxes a value into `any`.
- **New finding**: In `MangleUtils.cpp`, the `TY_ANY` mangled-name case is placed after the `llvmTy == nullptr` null-check guard. Because the typechecker creates `TY_ANY` types without an LLVM type, any future caller of `getTypeMangledName` on such an uninitialized type will get a misleading error. Moving the `TY_ANY` branch before the null check (alongside `TY_GENERIC` and `TY_TRAIT_EXISTENTIAL`) is the correct fix.

<h3>Confidence Score: 3/5</h3>

Not safe to merge yet — the memory leak from emitBoxToAny (flagged in a prior review thread) will cause LeakSanitizer CI failures on every test that boxes a value, and the MangleUtils.cpp ordering issue is a new correctness concern.

The feature is well-designed and the test coverage is strong, but the outstanding payload-malloc leak has not been addressed since the last review. AGENTS.md explicitly states CI runs LeakSanitizer (Debug_Asan preset) on both macOS and Linux, so every any-boxing test will fail there. That unresolved critical issue, combined with the newly found TY_ANY ordering bug in MangleUtils.cpp, keeps confidence at 3.

src/liblesma/Backend/CodegenVisit.cpp (payload malloc never freed in emitBoxToAny) and src/liblesma/Backend/MangleUtils.cpp (TY_ANY case after null LLVM-type guard)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/liblesma/Backend/Codegen.h | Adds anyTypeInfoGlobals cache member and declarations for all new any-type codegen helpers |
| src/liblesma/Backend/CodegenBufferHelpers.cpp | No new changes; emitMalloc/emitFree defined here are consumed by the any boxing logic |
| src/liblesma/Backend/CodegenTypesTraits.cpp | Adds TY_ANY LLVM type (lesma.any = {ptr typeinfo, ptr payload}) and TypeExpr visitor case |
| src/liblesma/Backend/CodegenVisit.cpp | Core any implementation; emitBoxToAny mallocs a payload per boxing without ever freeing it (memory leak), emitUnboxFromAny validates typeinfo at runtime, emitAnyIsCheck emits is/is-not checks |
| src/liblesma/Backend/MangleUtils.cpp | Adds TY_ANY mangled name 'any', but case is placed after the llvmTy==nullptr guard, so an uninitialized any type gives a misleading error instead of returning 'any' |
| src/liblesma/Frontend/Parser.cpp | Adds ANY_TYPE to type-token sets so 'any' is accepted in type positions and lookahead |
| src/liblesma/Symbol/Type.h | Adds TY_ANY to BaseType enum and toString() handling |
| src/liblesma/Token/Token.cpp | Maps 'any' keyword to ANY_TYPE token |
| src/liblesma/Token/TokenType.h | Adds ANY_TYPE enum value to the type-keywords block |
| src/liblesma/Typecheck/Typechecker.cpp | Adds TY_ANY in isAssignableTo, isSupportedUnionMemberType (enables any?), CastOp and IsOp visitors |
| tests/lesma/failure/any_function_closure_wrong_signature.les | Failure test: unboxing any to wrong function signature should abort at runtime |
| tests/lesma/failure/any_implicit_concrete_assignment.les | Failure test: implicit any→int assignment rejected by typechecker |
| tests/lesma/failure/any_nullable_source_assignment.les | Failure test: assigning nullable int? to bare any is rejected |
| tests/lesma/failure/any_requires_optional_for_null.les | Failure test: null cannot be assigned to bare any |
| tests/lesma/failure/any_void_source_assignment.les | Failure test: void return value cannot be assigned to any |
| tests/lesma/success/any_explicit_type_arg.les | Success test: any as explicit generic type argument with is/as round-trip |
| tests/lesma/success/any_function_closure.les | Success test: closure boxing/unboxing round-trip through any |
| tests/lesma/success/any_overload_fallback.les | Success test: overload resolution prefers concrete type over any parameter |
| tests/lesma/success/any_type.les | Comprehensive integration test: all primitives, class, enum, any?, list/dict<any>, is/as, union unbox |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/liblesma/Backend/MangleUtils.cpp
Line: 43-72

Comment:
**`TY_ANY` placed after the null LLVM-type guard**

The `TY_ANY` case returns the mangled string `"any"` without consulting the LLVM type at all — just like `TY_GENERIC` and `TY_TRAIT_EXISTENTIAL` do. However, unlike those two, the `TY_ANY` branch is positioned *after* the `llvmTy == nullptr` throw:

```cpp
auto* llvmTy = type->getLlvmType();
if (llvmTy == nullptr) {
    throw CodegenError(span, "Type has no LLVM type for mangling: {}", type->toString());
}
// … lots of cases …
if (type->is(BaseType::TY_ANY)) {   // ← only reached when llvmTy != nullptr
    return "any";
}
```

The typechecker creates `TY_ANY` types without an LLVM type (`cacheType(std::make_unique<Type>(BaseType::TY_ANY))`). If `getTypeMangledName` is ever called on such a type (e.g., during function signature mangling before `getOrCreateLlvmType` has run), it will throw a confusing `"Type has no LLVM type for mangling: any"` error instead of simply returning `"any"`.

Moving the `TY_ANY` early-return to the same block as `TY_GENERIC` and `TY_TRAIT_EXISTENTIAL` (before the null-check) makes the intent explicit and eliminates the fragile dependency on caller ordering:

```suggestion
  if (type->is(BaseType::TY_GENERIC)) {
    return "(gen_" + type->getGenericName() + ")";
  }
  if (type->is(BaseType::TY_TRAIT_EXISTENTIAL)) {
    return "(exist_" + type->getDisplayName() + ")";
  }
  if (type->is(BaseType::TY_ANY)) {
    return "any";
  }
  auto* llvmTy = type->getLlvmType();
  if (llvmTy == nullptr) {
    throw CodegenError(span, "Type has no LLVM type for mangling: {}", type->toString());
  }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix"](https://github.com/alinalihassan/lesma/commit/3cc7d8b61cc03391aaa494d2e21c4c1e055e9fb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27560191)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=1a29ce80-0253-41d2-97f6-1b260f93ee3c))

<!-- /greptile_comment -->