### PR TITLE
Automatic Reference Counting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,43 @@ jobs:
           name: lesma-macos
           path: ${{github.workspace}}/build/Release/Lesma*.tar.gz
 
+  memory:
+    name: Memory
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Unshallow vcpkg submodule
+        run: git -C vcpkg fetch --unshallow
+
+      - name: Install dependencies with Homebrew
+        env:
+          HOMEBREW_NO_ENV_HINTS: 1
+          HOMEBREW_NO_ANALYTICS: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        run: |
+          brew update
+          brew install llvm@21 lld@21 cmake ninja
+          echo "CMAKE_PREFIX_PATH=$(brew --prefix llvm@21);$(brew --prefix lld@21)" >> $GITHUB_ENV
+
+      - name: Bootstrap vcpkg
+        run: ./vcpkg/bootstrap-vcpkg.sh
+
+      - name: Configure Debug_Asan
+        run: cmake --preset Debug_Asan -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH"
+
+      - name: Build Debug_Asan
+        run: cmake --build --preset Debug_Asan
+
+      - name: Run ARC memory suite
+        env:
+          ASAN_OPTIONS: detect_container_overflow=0
+        run: ./scripts/run_tests.sh build/Debug_Asan/lesma
+
   release:
     name: Release
     needs: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,7 @@ jobs:
       - name: Run ARC memory suite
         env:
           ASAN_OPTIONS: detect_container_overflow=0
+          LESMA_TEST_TIMEOUT: 5
         run: ./scripts/run_tests.sh build/Debug_Asan/lesma
 
   release:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -52,7 +52,7 @@ jobs:
         working-directory: ${{github.workspace}}/build/Release
         run: ninja package
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: lesma-macos
           path: ${{github.workspace}}/build/Release/Lesma*.tar.gz
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,11 @@ jobs:
       - name: Build Debug_Asan
         run: cmake --build --preset Debug_Asan
 
+      - name: Run ARC zero-at-exit checks
+        env:
+          ASAN_OPTIONS: detect_container_overflow=0
+        run: ./build/Debug_Asan/tests --gtest_filter=ArcDebugRuntimeTests.*
+
       - name: Run ARC memory suite
         env:
           ASAN_OPTIONS: detect_container_overflow=0

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/tools-vscode.yaml
+++ b/.github/workflows/tools-vscode.yaml
@@ -14,7 +14,7 @@ jobs:
         working-directory: ./tools/vscode
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -2,9 +2,9 @@
 #include <memory>
 #include <utility>
 
-#include <benchmark/benchmark.h>
-
 #include <llvm/Passes/OptimizationLevel.h>
+
+#include <benchmark/benchmark.h>
 
 #include "liblesma/Backend/Codegen.h"
 #include "liblesma/Frontend/Lexer.h"
@@ -39,44 +39,37 @@ auto InitializeSrcMgr(const std::string& src) -> std::shared_ptr<SourceMgr> {
   return sourceMgr;
 }
 
-auto InitializeLexer(const std::shared_ptr<SourceMgr>& sourceMgr)
-    -> std::shared_ptr<Lexer> {
+auto InitializeLexer(const std::shared_ptr<SourceMgr>& sourceMgr) -> std::shared_ptr<Lexer> {
   auto curLexer = std::make_shared<Lexer>(sourceMgr);
   curLexer->scanAll();
 
   return curLexer;
 }
 
-auto InitializeParser(const std::shared_ptr<Lexer>& lexer)
-    -> std::shared_ptr<Parser> {
+auto InitializeParser(const std::shared_ptr<Lexer>& lexer) -> std::shared_ptr<Parser> {
   auto curParser = std::make_shared<Parser>(lexer->getTokens());
   curParser->parse();
 
   return curParser;
 }
 
-auto InitializeCodegen(std::shared_ptr<Parser> parser,
-                       const std::shared_ptr<SourceMgr>& srcMgr)
+auto InitializeCodegen(std::shared_ptr<Parser> parser, const std::shared_ptr<SourceMgr>& srcMgr)
     -> std::unique_ptr<Codegen> {
   Typechecker typechecker;
   typechecker.run(parser->getAst());
   auto takenTypeCache = typechecker.takeTypeCache();
   auto takenRootScope = typechecker.takeRootScope();
-  auto codegen = std::make_unique<Codegen>(std::move(parser), srcMgr, __FILE__,
-                                           std::vector<std::string>{}, true, true, "", nullptr,
-                                           nullptr, nullptr, nullptr,
-                                           std::move(takenRootScope),
-                                           std::move(takenTypeCache),
-                                           typechecker.takeSpecializedTypeEnv(),
-                                           typechecker.takeSpecializedTypeToTemplate(),
-                                           typechecker.takeSpecializedClassTypes());
+  auto codegen = std::make_unique<Codegen>(
+      std::move(parser), srcMgr, __FILE__, std::vector<std::string>{}, true, true, "", nullptr,
+      nullptr, nullptr, nullptr, std::move(takenRootScope), std::move(takenTypeCache),
+      typechecker.takeSpecializedTypeEnv(), typechecker.takeSpecializedTypeToTemplate(),
+      typechecker.takeSpecializedClassTypes(), false, false, false);
   codegen->run();
 
   return codegen;
 }
 
-[[maybe_unused]] auto GetRange(const std::string& source, int x, int y)
-    -> llvm::SMRange {
+[[maybe_unused]] auto GetRange(const std::string& source, int x, int y) -> llvm::SMRange {
   return {llvm::SMLoc::getFromPointer(std::next(source.c_str(), x)),
           llvm::SMLoc::getFromPointer(std::next(source.c_str(), y))};
 }
@@ -122,9 +115,7 @@ protected:
     parser = InitializeParser(ParserBenchmark::lexer);
   }
 
-  void TearDown(const ::benchmark::State& state) override {
-    ParserBenchmark::TearDown(state);
-  }
+  void TearDown(const ::benchmark::State& state) override { ParserBenchmark::TearDown(state); }
 };
 
 BENCHMARK_F(LexerBenchmark, Lexer)

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -58,6 +58,8 @@ auto parseCli(int argc, char** argv) -> std::unique_ptr<CLIOptions> {
   int optimizationLevel = 3;
   bool emitDebugInfo = false;
   bool suppressWarnings = false;
+  bool arcDebug = false;
+  bool arcTrace = false;
 
   CLI::App app{"Lesma programming language", "lesma"};
   app.set_version_flag("-v,--version", LESMA_VERSION, "Print the Lesma version");
@@ -77,8 +79,7 @@ auto parseCli(int argc, char** argv) -> std::unique_ptr<CLIOptions> {
   compile->add_option("file", file, "Lesma source filename")->required();
   fmt->add_option("paths", fmtPaths, "Files or directories to format")->expected(0, -1);
   compile->add_option("-o,--output", output, "Output filename");
-  fmt->add_option("-w,--width", formatWidth, "Doc layout ribbon width")
-      ->check(CLI::PositiveNumber);
+  fmt->add_option("-w,--width", formatWidth, "Doc layout ribbon width")->check(CLI::PositiveNumber);
   run->add_option("-O,--opt", optimizationLevel, "Optimization level (0–3)")
       ->check(CLI::Range(0, 3));
   compile->add_option("-O,--opt", optimizationLevel, "Optimization level (0–3)")
@@ -96,8 +97,24 @@ auto parseCli(int argc, char** argv) -> std::unique_ptr<CLIOptions> {
         "--no-warnings", [&suppressWarnings]() -> void { suppressWarnings = true; },
         "Do not print compiler warnings to stderr");
   };
+  auto addArcDebugFlags = [&](CLI::App* sub) -> void {
+    sub->add_flag_callback(
+        "--arc-debug", [&arcDebug]() -> void { arcDebug = true; },
+        "Emit debug-only ARC live-object diagnostics in generated code");
+    sub->add_flag_callback(
+        "--arc-trace",
+        [&arcTrace, &arcDebug]() -> void {
+          arcTrace = true;
+          arcDebug = true;
+        },
+        "Emit verbose ARC retain/release/alloc/free trace lines in generated code");
+  };
   addNoWarningsFlag(run);
   addNoWarningsFlag(compile);
+#ifndef NDEBUG
+  addArcDebugFlags(run);
+  addArcDebugFlags(compile);
+#endif
   CLI::Option* const runDebugOpt = addDebugOption(run);
   // add_flag(bool&) uses lexical_cast on flag values; it fails with "--timer = true" on CLI11 2.6.
   run->add_flag_callback(
@@ -132,8 +149,8 @@ auto parseCli(int argc, char** argv) -> std::unique_ptr<CLIOptions> {
 
   bool const timer = runTimer || compileTimer;
   return std::make_unique<CLIOptions>(CLIOptions{
-      .command = fmt->parsed() ? CliCommand::Fmt
-                               : (run->parsed() ? CliCommand::Run : CliCommand::Compile),
+      .command =
+          fmt->parsed() ? CliCommand::Fmt : (run->parsed() ? CliCommand::Run : CliCommand::Compile),
       .file = file.empty() ? std::string{} : std::filesystem::absolute(file).string(),
       .output = output,
       .fmtPaths = std::move(fmtPaths),
@@ -144,6 +161,8 @@ auto parseCli(int argc, char** argv) -> std::unique_ptr<CLIOptions> {
       .optimizationLevel = optimizationLevel,
       .emitDebugInfo = emitDebugInfo,
       .suppressWarnings = suppressWarnings,
+      .arcDebug = arcDebug,
+      .arcTrace = arcTrace,
   });
 }
 
@@ -170,6 +189,8 @@ auto main(int argc, char** argv) -> int {
       .optimizationLevel = optimizationLevelFromCli(options->optimizationLevel),
       .emitDebugInfo = options->emitDebugInfo,
       .suppressWarnings = options->suppressWarnings,
+      .arcDebug = options->arcDebug,
+      .arcTrace = options->arcTrace,
   });
   int const exitCode = options->jit ? Driver::run(std::move(driverOptions))
                                     : Driver::compile(std::move(driverOptions));

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -82,6 +82,13 @@ struct ArcTrackedSlot {
   bool storesFuncValuePair = false;
 };
 
+struct ModuleArcTrackedRoot {
+  llvm::GlobalVariable* slot = nullptr;
+  lesma::Type* type = nullptr;
+  bool storesFuncValuePair = false;
+  std::string debugName;
+};
+
 class Codegen final : public ASTVisitor {
   std::shared_ptr<ThreadSafeContext> theContext;
   std::unique_ptr<Module> theModule;
@@ -90,6 +97,8 @@ class Codegen final : public ASTVisitor {
   std::unique_ptr<LLJIT> theJit;
   /// JIT: mangled per-import init symbols; run from \c prepareJit (shared across nested imports).
   std::shared_ptr<std::vector<std::string>> pendingJitModuleInits;
+  /// JIT: mangled per-import fini symbols; called by the main module in reverse init order.
+  std::shared_ptr<std::vector<std::string>> pendingJitModuleFinis;
   std::unique_ptr<llvm::TargetMachine> targetMachine;
   std::shared_ptr<Parser> parser;
   std::shared_ptr<SourceMgr> sourceManager;
@@ -167,13 +176,21 @@ class Codegen final : public ASTVisitor {
   MainFnTy* mainFuncAddress = nullptr;
   Value* selfSymbol = nullptr;
   llvm::StructType* arcHeaderLlvmType = nullptr;
+  llvm::Function* arcDebugDeltaFn = nullptr;
+  llvm::Function* arcDebugReportFn = nullptr;
+  llvm::Function* arcDebugCleanupBeginFn = nullptr;
+  llvm::Function* arcDebugCleanupStepFn = nullptr;
+  llvm::Function* moduleCleanupFn = nullptr;
   std::vector<std::vector<ArcTrackedSlot>> arcOwnedSlotFrames;
+  std::vector<ModuleArcTrackedRoot> moduleArcTrackedRoots;
   bool isBreak = false;
   bool isReturn = false;
   bool isAssignment = false;
   bool isJit = false;
   bool isMain = true;
   bool emitDebugInfo = false;
+  bool emitArcDebug = false;
+  bool emitArcTrace = false;
   std::size_t lambdaCounter = 0U;
   llvm::OptimizationLevel optimizationLevelForDebug = llvm::OptimizationLevel::O3;
   /** `if x is T` / else: maps parameter/local symbol → union variant index for narrowed loads. */
@@ -229,9 +246,10 @@ public:
               preSpecializedClassTypeEnvs = {},
           std::unordered_map<lesma::Type*, lesma::Type*> preSpecializedClassTemplateOf = {},
           std::unordered_map<std::string, lesma::Type*> preSpecializedClassTypesByKey = {},
-          bool emitDebug = false,
+          bool emitDebug = false, bool emitArcDebug = false, bool emitArcTrace = false,
           llvm::OptimizationLevel optimizationLevelForDebugArg = llvm::OptimizationLevel::O3,
-          std::shared_ptr<std::vector<std::string>> sharedPendingJitModuleInits = nullptr);
+          std::shared_ptr<std::vector<std::string>> sharedPendingJitModuleInits = nullptr,
+          std::shared_ptr<std::vector<std::string>> sharedPendingJitModuleFinis = nullptr);
   ~Codegen() override;
 
   Codegen(const Codegen&) = delete;
@@ -240,6 +258,7 @@ public:
   auto operator=(Codegen&&) -> Codegen& = delete;
 
   auto dump() -> void;
+  [[nodiscard]] auto moduleToString() const -> std::string;
   auto run() -> void;
   auto prepareJit() -> void;
   auto executeJit() -> int;
@@ -516,6 +535,10 @@ protected:
   auto registerArcOwnedSlot(llvm::Value* slot, lesma::Type* type, bool storesFuncValuePair = false)
       -> void;
   auto emitReleaseCurrentArcOwnedSlots() -> void;
+  auto registerModuleArcRoot(llvm::GlobalVariable* slot, lesma::Type* type,
+                             const std::string& debugName, bool storesFuncValuePair = false)
+      -> void;
+  auto emitReleaseRegisteredModuleArcRoots() -> void;
   auto getOrCreateArcStorageRetainFunction(lesma::Type* type) -> llvm::Function*;
   auto getOrCreateArcStorageReleaseFunction(lesma::Type* type) -> llvm::Function*;
   auto getOrCreateArcPayloadDestroyFunction(lesma::Type* type) -> llvm::Function*;
@@ -542,6 +565,18 @@ protected:
   auto emitFree(llvm::Value* ptr) -> void;
   auto emitRuntimeStderrMessage(std::string_view message) -> void;
   auto emitExit(int code) -> void;
+  auto getOrCreateArcDebugDeltaFunction() -> llvm::Function*;
+  auto getOrCreateArcDebugReportFunction() -> llvm::Function*;
+  auto getOrCreateArcDebugCleanupBeginFunction() -> llvm::Function*;
+  auto getOrCreateArcDebugCleanupStepFunction() -> llvm::Function*;
+  auto emitArcDebugDelta(std::int64_t delta, llvm::Value* payloadPtr,
+                         std::string_view traceMessagePrefix) -> void;
+  auto emitArcDebugTraceCounts(std::string_view traceMessagePrefix, llvm::Value* payloadPtr,
+                               llvm::Value* before, llvm::Value* after) -> void;
+  auto emitArcDebugValidateRefcount(llvm::Value* refCount, std::string_view message) -> void;
+  auto emitArcDebugTraceModuleRoot(const ModuleArcTrackedRoot& tracked) -> void;
+  auto getOrCreateModuleCleanupFunction() -> llvm::Function*;
+  auto emitCallPendingJitModuleFinis() -> void;
   auto emitListLength(lesma::Type* listType, llvm::Value* listHandle) -> llvm::Value*;
   auto emitListCapacity(lesma::Type* listType, llvm::Value* listHandle) -> llvm::Value*;
   auto emitListDataPtr(lesma::Type* listType, llvm::Value* listHandle) -> llvm::Value*;

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -76,6 +76,12 @@ struct ImportedSpecializationState {
   std::unordered_map<std::string, const TraitDecl*> traitDeclByName;
 };
 
+struct ArcTrackedSlot {
+  llvm::Value* slot = nullptr;
+  lesma::Type* type = nullptr;
+  bool storesFuncValuePair = false;
+};
+
 class Codegen final : public ASTVisitor {
   std::shared_ptr<ThreadSafeContext> theContext;
   std::unique_ptr<Module> theModule;
@@ -143,7 +149,14 @@ class Codegen final : public ASTVisitor {
   std::unordered_map<std::string, const TraitDecl*> traitDeclByName;
   std::unordered_map<std::string, llvm::GlobalVariable*> witnessGlobalCache;
   std::unordered_map<std::string, llvm::GlobalVariable*> anyTypeInfoGlobals;
+  std::unordered_map<std::string, llvm::Function*> anyTypeInfoRetainFns;
+  std::unordered_map<std::string, llvm::Function*> anyTypeInfoReleaseFns;
   std::unordered_map<lesma::Type*, llvm::GlobalVariable*> classVtableGlobals;
+  std::unordered_map<lesma::Type*, llvm::Function*> arcDestroyFns;
+  std::unordered_map<lesma::Type*, llvm::Function*> arcPayloadDestroyFns;
+  std::unordered_map<lesma::Type*, llvm::Function*> arcStorageRetainFns;
+  std::unordered_map<lesma::Type*, llvm::Function*> arcStorageReleaseFns;
+  std::unordered_map<std::string, llvm::Function*> arcClosureDestroyFns;
   std::unordered_map<lesma::Type*, const Class*> codegenClassAstByType;
   std::unordered_map<std::string, const Class*> codegenClassAstByDisplayName;
   std::unordered_map<std::string, llvm::Function*> traitThunkCache;
@@ -153,6 +166,8 @@ class Codegen final : public ASTVisitor {
   llvm::Function* topLevelFunc;
   MainFnTy* mainFuncAddress = nullptr;
   Value* selfSymbol = nullptr;
+  llvm::StructType* arcHeaderLlvmType = nullptr;
+  std::vector<std::vector<ArcTrackedSlot>> arcOwnedSlotFrames;
   bool isBreak = false;
   bool isReturn = false;
   bool isAssignment = false;
@@ -260,6 +275,7 @@ protected:
   /** Alloca in \p fn's entry block (after PHIs) so LLVM mem2reg can promote loop/stack slots. */
   auto createAllocaInEntry(llvm::Function* fn, llvm::Type* elemTy, const std::string& name)
       -> llvm::AllocaInst*;
+  auto emitEntryNullInit(llvm::AllocaInst* slot, llvm::Type* storageTy) -> void;
 
   [[nodiscard]] auto lookupUnionNarrowVariant(lesma::Value* sym) const -> std::optional<unsigned>;
   auto fillCodegenUnionNarrowVariantMap(
@@ -483,6 +499,30 @@ protected:
   auto emitCalloc(llvm::Value* count, llvm::Value* size, const llvm::Twine& name = "calloc.tmp")
       -> llvm::Value*;
   auto emitMalloc(llvm::Value* size, const llvm::Twine& name = "malloc.tmp") -> llvm::Value*;
+  auto getOrCreateArcHeaderType() -> llvm::StructType*;
+  auto emitArcAlloc(llvm::Value* payloadSize, llvm::Function* destroyFn, const llvm::Twine& name)
+      -> llvm::Value*;
+  auto emitArcRetain(llvm::Value* payloadPtr) -> void;
+  auto emitArcRelease(llvm::Value* payloadPtr) -> void;
+  auto emitArcReleaseNullable(llvm::Value* payloadPtr) -> void;
+  auto emitArcFreePayload(llvm::Value* payloadPtr) -> void;
+  auto emitRetainLoadedValue(lesma::Type* type, llvm::Value* value,
+                             bool storesFuncValuePair = false) -> void;
+  auto emitReleaseLoadedValue(lesma::Type* type, llvm::Value* value,
+                              bool storesFuncValuePair = false) -> void;
+  auto emitReleaseTrackedSlot(const ArcTrackedSlot& tracked) -> void;
+  auto pushArcOwnedSlotFrame() -> void;
+  auto popArcOwnedSlotFrame(bool emitCleanup) -> void;
+  auto registerArcOwnedSlot(llvm::Value* slot, lesma::Type* type, bool storesFuncValuePair = false)
+      -> void;
+  auto emitReleaseCurrentArcOwnedSlots() -> void;
+  auto getOrCreateArcStorageRetainFunction(lesma::Type* type) -> llvm::Function*;
+  auto getOrCreateArcStorageReleaseFunction(lesma::Type* type) -> llvm::Function*;
+  auto getOrCreateArcPayloadDestroyFunction(lesma::Type* type) -> llvm::Function*;
+  auto getOrCreateArcDestroyFunction(lesma::Type* type) -> llvm::Function*;
+  auto getOrCreateArcClosureDestroyFunction(const std::string& key, llvm::StructType* envStructTy,
+                                            const std::vector<lesma::Type*>& captureTypes)
+      -> llvm::Function*;
   auto emitCstrConcatValues(llvm::SMRange span, llvm::Value* a, llvm::Value* b) -> llvm::Value*;
   auto emitFormatIntegerToCstr(llvm::SMRange span, llvm::Value* intVal, lesma::Type* intTy)
       -> llvm::Value*;
@@ -609,11 +649,13 @@ private:
   /** Ptr-to-class direct store vs cast-then-store (shared by globals and simple locals). */
   auto emitSimpleClassPtrOrCastStore(llvm::SMRange span, llvm::Value* destPtr,
                                      std::unique_ptr<lesma::Value>& valueResult,
-                                     lesma::Type* storedType) -> llvm::Instruction*;
+                                     lesma::Type* storedType, bool releasePrevious = false,
+                                     bool destStoresFuncValuePair = false) -> llvm::Instruction*;
   /** Initial store when reusing a typecheck symbol (generic func pair, ptr-to-class, etc.). */
   auto emitExistingVarSlotInitializerStore(const VarDecl* node, llvm::Value* destPtr,
                                            std::unique_ptr<lesma::Value>& valueResult,
-                                           lesma::Type* storedType, const std::string& dbgName)
+                                           lesma::Type* storedType, const std::string& dbgName,
+                                           bool destStoresFuncValuePair = false)
       -> llvm::Instruction*;
   [[nodiscard]] auto makeBoolCompareResult(llvm::Value* cmpVal) -> std::unique_ptr<lesma::Value>;
   [[nodiscard]] auto

--- a/src/liblesma/Backend/Codegen.h
+++ b/src/liblesma/Backend/Codegen.h
@@ -692,6 +692,9 @@ private:
                                            lesma::Type* storedType, const std::string& dbgName,
                                            bool destStoresFuncValuePair = false)
       -> llvm::Instruction*;
+  auto emitForEachUnionMemberWithTagDispatch(
+      lesma::Type* unionTy, llvm::Value* unionSlot, llvm::Value* tagVal, std::string_view blockStem,
+      const std::function<void(lesma::Type*, llvm::Value*)>& callback) -> void;
   [[nodiscard]] auto makeBoolCompareResult(llvm::Value* cmpVal) -> std::unique_ptr<lesma::Value>;
   [[nodiscard]] auto
   emitPromotedArithmetic(llvm::SMRange span, TokenType op, std::unique_ptr<lesma::Value>& left,
@@ -716,6 +719,7 @@ private:
   [[nodiscard]] auto materializeClassStaticFieldGlobalInCurrentModule(lesma::Type* templateClassTy,
                                                                       Field* tf)
       -> llvm::GlobalVariable*;
+  [[nodiscard]] auto traitExistentialBaseName(const std::string& displayName) const -> std::string;
 
   /** Minimum tag bits: ceil(log2(memberCount)), at least 1 (memberCount must be > 0). */
   [[nodiscard]] static auto unionDiscriminantMinBits(std::size_t memberCount) -> unsigned;

--- a/src/liblesma/Backend/CodegenBufferHelpers.cpp
+++ b/src/liblesma/Backend/CodegenBufferHelpers.cpp
@@ -100,8 +100,8 @@ auto Codegen::emitArcAlloc(llvm::Value* payloadSize, llvm::Function* destroyFn,
     throw CodegenError({}, "ARC allocation '{}' is missing a destroy function", name.str());
   }
   auto* headerTy = getOrCreateArcHeaderType();
-  auto* headerSize = builder->getInt64(
-      theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
+  auto* headerSize =
+      builder->getInt64(theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
   auto* totalSize = builder->CreateAdd(payloadSize, headerSize, name + ".arc.bytes");
   auto* raw = emitMalloc(totalSize, name + ".arc.raw");
   auto* headerPtr = builder->CreateBitCast(raw, llvm::PointerType::get(headerTy->getContext(), 0U),
@@ -117,8 +117,8 @@ auto Codegen::emitArcAlloc(llvm::Value* payloadSize, llvm::Function* destroyFn,
 
 auto Codegen::emitArcFreePayload(llvm::Value* payloadPtr) -> void {
   auto* headerTy = getOrCreateArcHeaderType();
-  auto* headerSize = builder->getInt64(
-      theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
+  auto* headerSize =
+      builder->getInt64(theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
   auto* payloadRaw = builder->CreateBitCast(payloadPtr, builder->getPtrTy(), "arc.payload.raw");
   auto* raw = builder->CreateInBoundsGEP(builder->getInt8Ty(), payloadRaw,
                                          builder->CreateNeg(headerSize), "arc.raw");
@@ -135,8 +135,8 @@ auto Codegen::emitArcRetain(llvm::Value* payloadPtr) -> void {
 
   builder->SetInsertPoint(retainBlock);
   auto* headerTy = getOrCreateArcHeaderType();
-  auto* headerSize = builder->getInt64(
-      theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
+  auto* headerSize =
+      builder->getInt64(theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
   auto* raw = builder->CreateInBoundsGEP(builder->getInt8Ty(),
                                          builder->CreateBitCast(payloadPtr, builder->getPtrTy()),
                                          builder->CreateNeg(headerSize), "arc.retain.raw");
@@ -150,10 +150,12 @@ auto Codegen::emitArcRetain(llvm::Value* payloadPtr) -> void {
   builder->SetInsertPoint(doneBlock);
 }
 
+// Precondition: `payloadPtr` is non-null. Callers that may have a null payload must route through
+// `emitArcReleaseNullable()`, which performs the null check before delegating here.
 auto Codegen::emitArcRelease(llvm::Value* payloadPtr) -> void {
   auto* headerTy = getOrCreateArcHeaderType();
-  auto* headerSize = builder->getInt64(
-      theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
+  auto* headerSize =
+      builder->getInt64(theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
   auto* raw = builder->CreateInBoundsGEP(builder->getInt8Ty(),
                                          builder->CreateBitCast(payloadPtr, builder->getPtrTy()),
                                          builder->CreateNeg(headerSize), "arc.release.raw");
@@ -166,10 +168,9 @@ auto Codegen::emitArcRelease(llvm::Value* payloadPtr) -> void {
   builder->CreateStore(next, refSlot);
 
   llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
-  auto* destroyBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.release.destroy",
-                                                parentFn);
-  auto* doneBlock =
-      llvm::BasicBlock::Create(theModule->getContext(), "arc.release.done", parentFn);
+  auto* destroyBlock =
+      llvm::BasicBlock::Create(theModule->getContext(), "arc.release.destroy", parentFn);
+  auto* doneBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.release.done", parentFn);
   builder->CreateCondBr(builder->CreateICmpEQ(next, builder->getInt64(0)), destroyBlock, doneBlock);
 
   builder->SetInsertPoint(destroyBlock);
@@ -225,15 +226,13 @@ auto Codegen::emitRetainLoadedValue(lesma::Type* type, llvm::Value* value, bool 
         continue;
       }
       emitRetainLoadedValue(fields[i]->type, builder->CreateExtractValue(value, {i}, "arc.tuple.v"),
-                           false);
+                            false);
     }
     return;
   }
   case BaseType::TY_UNION: {
-    bool hasArcMember = false;
-    for (Type* member : type->getUnionMembers()) {
-      hasArcMember = hasArcMember || TypeUtils::containsArcManagedValue(member);
-    }
+    bool const hasArcMember =
+        std::ranges::any_of(type->getUnionMembers(), TypeUtils::containsArcManagedValue);
     if (!hasArcMember) {
       return;
     }
@@ -277,8 +276,8 @@ auto Codegen::emitRetainLoadedValue(lesma::Type* type, llvm::Value* value, bool 
   }
 }
 
-auto Codegen::emitReleaseLoadedValue(lesma::Type* type, llvm::Value* value, bool storesFuncValuePair)
-    -> void {
+auto Codegen::emitReleaseLoadedValue(lesma::Type* type, llvm::Value* value,
+                                     bool storesFuncValuePair) -> void {
   if (type == nullptr || value == nullptr) {
     return;
   }
@@ -307,16 +306,14 @@ auto Codegen::emitReleaseLoadedValue(lesma::Type* type, llvm::Value* value, bool
       if (!TypeUtils::containsArcManagedValue(fields[i]->type)) {
         continue;
       }
-      emitReleaseLoadedValue(fields[i]->type, builder->CreateExtractValue(value, {i}, "arc.tuple.v"),
-                             false);
+      emitReleaseLoadedValue(fields[i]->type,
+                             builder->CreateExtractValue(value, {i}, "arc.tuple.v"), false);
     }
     return;
   }
   case BaseType::TY_UNION: {
-    bool hasArcMember = false;
-    for (Type* member : type->getUnionMembers()) {
-      hasArcMember = hasArcMember || TypeUtils::containsArcManagedValue(member);
-    }
+    bool const hasArcMember =
+        std::ranges::any_of(type->getUnionMembers(), TypeUtils::containsArcManagedValue);
     if (!hasArcMember) {
       return;
     }
@@ -371,7 +368,8 @@ auto Codegen::emitReleaseTrackedSlot(const ArcTrackedSlot& tracked) -> void {
   if (slotTy == nullptr) {
     return;
   }
-  emitReleaseLoadedValue(tracked.type, builder->CreateLoad(slotTy, tracked.slot, "arc.slot.release"),
+  emitReleaseLoadedValue(tracked.type,
+                         builder->CreateLoad(slotTy, tracked.slot, "arc.slot.release"),
                          tracked.storesFuncValuePair);
 }
 
@@ -382,7 +380,8 @@ auto Codegen::popArcOwnedSlotFrame(bool emitCleanup) -> void {
     return;
   }
   if (emitCleanup) {
-    for (auto it = arcOwnedSlotFrames.back().rbegin(); it != arcOwnedSlotFrames.back().rend(); ++it) {
+    for (auto it = arcOwnedSlotFrames.back().rbegin(); it != arcOwnedSlotFrames.back().rend();
+         ++it) {
       emitReleaseTrackedSlot(*it);
     }
   }
@@ -508,8 +507,8 @@ auto Codegen::getOrCreateArcDestroyFunction(lesma::Type* type) -> llvm::Function
   llvm::Value* payload = fn->getArg(0U);
 
   if (type->is(BaseType::TY_ARRAY)) {
-    auto* listHandle = builder->CreateBitCast(payload, llvm::PointerType::get(builder->getContext(), 0U),
-                                              "arc.list.handle");
+    auto* listHandle = builder->CreateBitCast(
+        payload, llvm::PointerType::get(builder->getContext(), 0U), "arc.list.handle");
     if (type->getElementType() != nullptr &&
         TypeUtils::containsArcManagedValue(type->getElementType())) {
       llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
@@ -577,16 +576,15 @@ auto Codegen::getOrCreateArcDestroyFunction(lesma::Type* type) -> llvm::Function
                              false);
       continue;
     }
-    if (type->getDisplayName() == "str" && fieldTy != nullptr && fieldTy->is(BaseType::TY_STRING)) {
+    if (type->isBuiltinStringClass() && fieldTy != nullptr && fieldTy->is(BaseType::TY_STRING)) {
       llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
-      auto* freeBlock =
-          llvm::BasicBlock::Create(theModule->getContext(), "arc.str.free", parentFn);
+      auto* freeBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.str.free", parentFn);
       auto* doneBlock =
           llvm::BasicBlock::Create(theModule->getContext(), "arc.str.free.done", parentFn);
       auto* raw = builder->CreateLoad(builder->getPtrTy(), slot, "arc.str.raw");
       builder->CreateCondBr(
-          builder->CreateICmpEQ(raw, llvm::ConstantPointerNull::get(builder->getPtrTy())), doneBlock,
-          freeBlock);
+          builder->CreateICmpEQ(raw, llvm::ConstantPointerNull::get(builder->getPtrTy())),
+          doneBlock, freeBlock);
       builder->SetInsertPoint(freeBlock);
       emitFree(raw);
       builder->CreateBr(doneBlock);
@@ -613,8 +611,8 @@ auto Codegen::getOrCreateArcClosureDestroyFunction(const std::string& key,
   auto savedIp = builder->saveIP();
   auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
   builder->SetInsertPoint(entry);
-  auto* env = builder->CreateBitCast(fn->getArg(0U), llvm::PointerType::get(envStructTy->getContext(), 0U),
-                                     "arc.env");
+  auto* env = builder->CreateBitCast(
+      fn->getArg(0U), llvm::PointerType::get(envStructTy->getContext(), 0U), "arc.env");
   for (unsigned i = 0; i < captureTypes.size(); ++i) {
     if (!TypeUtils::containsArcManagedValue(captureTypes[i])) {
       continue;
@@ -768,8 +766,8 @@ auto Codegen::emitListDeepCopy(lesma::Type* listType, llvm::Value* listHandle) -
   auto* structType = getOrCreateListStructType(listType);
   auto* headerSize =
       builder->getInt64(theModule->getDataLayout().getTypeAllocSize(structType).getFixedValue());
-  auto* newHandle = emitArcAlloc(headerSize, getOrCreateArcDestroyFunction(listType),
-                                 "list.copy.header");
+  auto* newHandle =
+      emitArcAlloc(headerSize, getOrCreateArcDestroyFunction(listType), "list.copy.header");
   auto* length = emitListLength(listType, listHandle);
   auto* capacity = emitListCapacity(listType, listHandle);
   emitStoreListLength(listType, newHandle, length);

--- a/src/liblesma/Backend/CodegenBufferHelpers.cpp
+++ b/src/liblesma/Backend/CodegenBufferHelpers.cpp
@@ -9,6 +9,7 @@
 
 #include "Codegen.h"
 
+#include "liblesma/Backend/CodegenError.h"
 #include "liblesma/Backend/CodegenRuntimeNames.h"
 #include "liblesma/Backend/MangleUtils.h"
 #include "liblesma/Symbol/Type.h"
@@ -95,6 +96,9 @@ auto Codegen::getOrCreateArcHeaderType() -> llvm::StructType* {
 
 auto Codegen::emitArcAlloc(llvm::Value* payloadSize, llvm::Function* destroyFn,
                            const llvm::Twine& name) -> llvm::Value* {
+  if (destroyFn == nullptr) {
+    throw CodegenError({}, "ARC allocation '{}' is missing a destroy function", name.str());
+  }
   auto* headerTy = getOrCreateArcHeaderType();
   auto* headerSize = builder->getInt64(
       theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
@@ -103,9 +107,7 @@ auto Codegen::emitArcAlloc(llvm::Value* payloadSize, llvm::Function* destroyFn,
   auto* headerPtr = builder->CreateBitCast(raw, llvm::PointerType::get(headerTy->getContext(), 0U),
                                            name + ".arc.header");
   builder->CreateStore(builder->getInt64(1), builder->CreateStructGEP(headerTy, headerPtr, 0U));
-  llvm::Value* destroyValue =
-      destroyFn != nullptr ? builder->CreateBitCast(destroyFn, builder->getPtrTy())
-                           : llvm::ConstantPointerNull::get(builder->getPtrTy());
+  llvm::Value* destroyValue = builder->CreateBitCast(destroyFn, builder->getPtrTy());
   builder->CreateStore(destroyValue, builder->CreateStructGEP(headerTy, headerPtr, 1U));
   auto* payload =
       builder->CreateInBoundsGEP(builder->getInt8Ty(), raw, headerSize, name + ".arc.payload");

--- a/src/liblesma/Backend/CodegenBufferHelpers.cpp
+++ b/src/liblesma/Backend/CodegenBufferHelpers.cpp
@@ -112,7 +112,11 @@ auto Codegen::emitArcAlloc(llvm::Value* payloadSize, llvm::Function* destroyFn,
   auto* payload =
       builder->CreateInBoundsGEP(builder->getInt8Ty(), raw, headerSize, name + ".arc.payload");
   builder->CreateMemSet(payload, builder->getInt8(0), payloadSize, llvm::MaybeAlign(1U));
-  return builder->CreateBitCast(payload, builder->getPtrTy(), name);
+  auto* payloadPtr = builder->CreateBitCast(payload, builder->getPtrTy(), name);
+  if (emitArcDebug) {
+    emitArcDebugDelta(1, payloadPtr, "[arc] alloc");
+  }
+  return payloadPtr;
 }
 
 auto Codegen::emitArcFreePayload(llvm::Value* payloadPtr) -> void {
@@ -122,6 +126,9 @@ auto Codegen::emitArcFreePayload(llvm::Value* payloadPtr) -> void {
   auto* payloadRaw = builder->CreateBitCast(payloadPtr, builder->getPtrTy(), "arc.payload.raw");
   auto* raw = builder->CreateInBoundsGEP(builder->getInt8Ty(), payloadRaw,
                                          builder->CreateNeg(headerSize), "arc.raw");
+  if (emitArcDebug) {
+    emitArcDebugDelta(-1, payloadPtr, "[arc] free");
+  }
   emitFree(raw);
 }
 
@@ -144,7 +151,12 @@ auto Codegen::emitArcRetain(llvm::Value* payloadPtr) -> void {
                                            "arc.retain.header");
   auto* refSlot = builder->CreateStructGEP(headerTy, headerPtr, 0U);
   auto* refCount = builder->CreateLoad(builder->getInt64Ty(), refSlot, "arc.retain.count");
-  builder->CreateStore(builder->CreateAdd(refCount, builder->getInt64(1)), refSlot);
+  if (emitArcDebug) {
+    emitArcDebugValidateRefcount(refCount, "[arc] retain on zero-count object\n");
+  }
+  auto* next = builder->CreateAdd(refCount, builder->getInt64(1), "arc.retain.next");
+  builder->CreateStore(next, refSlot);
+  emitArcDebugTraceCounts("[arc] retain", payloadPtr, refCount, next);
   builder->CreateBr(doneBlock);
 
   builder->SetInsertPoint(doneBlock);
@@ -164,8 +176,12 @@ auto Codegen::emitArcRelease(llvm::Value* payloadPtr) -> void {
   auto* refSlot = builder->CreateStructGEP(headerTy, headerPtr, 0U);
   auto* destroySlot = builder->CreateStructGEP(headerTy, headerPtr, 1U);
   auto* refCount = builder->CreateLoad(builder->getInt64Ty(), refSlot, "arc.release.count");
+  if (emitArcDebug) {
+    emitArcDebugValidateRefcount(refCount, "[arc] release on zero-count object\n");
+  }
   auto* next = builder->CreateSub(refCount, builder->getInt64(1), "arc.release.next");
   builder->CreateStore(next, refSlot);
+  emitArcDebugTraceCounts("[arc] release", payloadPtr, refCount, next);
 
   llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
   auto* destroyBlock =
@@ -412,6 +428,34 @@ auto Codegen::emitReleaseCurrentArcOwnedSlots() -> void {
   }
 }
 
+auto Codegen::registerModuleArcRoot(llvm::GlobalVariable* slot, lesma::Type* type,
+                                    const std::string& debugName, bool storesFuncValuePair) -> void {
+  if (slot == nullptr || type == nullptr || !TypeUtils::containsArcManagedValue(type)) {
+    return;
+  }
+  for (const ModuleArcTrackedRoot& tracked : moduleArcTrackedRoots) {
+    if (tracked.slot == slot) {
+      return;
+    }
+  }
+  moduleArcTrackedRoots.push_back(ModuleArcTrackedRoot{slot, type, storesFuncValuePair, debugName});
+}
+
+auto Codegen::emitReleaseRegisteredModuleArcRoots() -> void {
+  for (auto it = moduleArcTrackedRoots.rbegin(); it != moduleArcTrackedRoots.rend(); ++it) {
+    llvm::Type* storageTy = it->slot->getValueType();
+    if (emitArcTrace) {
+      emitArcDebugTraceModuleRoot(*it);
+    }
+    emitReleaseLoadedValue(it->type, builder->CreateLoad(storageTy, it->slot, "arc.root.load"),
+                           it->storesFuncValuePair);
+    builder->CreateStore(llvm::Constant::getNullValue(it->slot->getValueType()), it->slot);
+    if (emitArcDebug) {
+      builder->CreateCall(getOrCreateArcDebugCleanupStepFunction());
+    }
+  }
+}
+
 auto Codegen::getOrCreateArcStorageRetainFunction(lesma::Type* type) -> llvm::Function* {
   if (type == nullptr) {
     return nullptr;
@@ -644,6 +688,295 @@ auto Codegen::emitExit(int code) -> void {
       std::string{codegen::runtime::EXIT},
       llvm::FunctionType::get(builder->getVoidTy(), {builder->getInt64Ty()}, false));
   builder->CreateCall(exitFn, {builder->getInt64(code)});
+}
+
+auto Codegen::getOrCreateArcDebugDeltaFunction() -> llvm::Function* {
+  if (arcDebugDeltaFn != nullptr) {
+    return arcDebugDeltaFn;
+  }
+  auto* fn = theModule->getFunction(std::string{codegen::runtime::ARC_DEBUG_DELTA});
+  if (fn == nullptr) {
+    auto* fnTy = llvm::FunctionType::get(builder->getInt64Ty(), {builder->getInt64Ty()}, false);
+    fn = llvm::Function::Create(fnTy, llvm::Function::LinkOnceODRLinkage,
+                                std::string{codegen::runtime::ARC_DEBUG_DELTA}, *theModule);
+  }
+  arcDebugDeltaFn = fn;
+  if (!fn->empty()) {
+    return fn;
+  }
+
+  fn->addFnAttr(llvm::Attribute::NoInline);
+  auto* liveCount = theModule->getGlobalVariable("__lesma_arc_debug_live_count", true);
+  if (liveCount == nullptr) {
+    liveCount = new llvm::GlobalVariable(*theModule, builder->getInt64Ty(), false,
+                                         llvm::GlobalValue::CommonLinkage, builder->getInt64(0),
+                                         "__lesma_arc_debug_live_count");
+  }
+
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  auto* current = builder->CreateLoad(builder->getInt64Ty(), liveCount, "arc.debug.live.current");
+  auto* next = builder->CreateAdd(current, fn->getArg(0U), "arc.debug.live.next");
+  builder->CreateStore(next, liveCount);
+  builder->CreateRet(next);
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::getOrCreateArcDebugReportFunction() -> llvm::Function* {
+  if (arcDebugReportFn != nullptr) {
+    return arcDebugReportFn;
+  }
+  auto* fn = theModule->getFunction(std::string{codegen::runtime::ARC_DEBUG_REPORT});
+  if (fn == nullptr) {
+    auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {}, false);
+    fn = llvm::Function::Create(fnTy, llvm::Function::LinkOnceODRLinkage,
+                                std::string{codegen::runtime::ARC_DEBUG_REPORT}, *theModule);
+  }
+  arcDebugReportFn = fn;
+  if (!fn->empty()) {
+    return fn;
+  }
+
+  fn->addFnAttr(llvm::Attribute::NoInline);
+  auto* liveCount = theModule->getGlobalVariable("__lesma_arc_debug_live_count", true);
+  if (liveCount == nullptr) {
+    liveCount = new llvm::GlobalVariable(*theModule, builder->getInt64Ty(), false,
+                                         llvm::GlobalValue::CommonLinkage, builder->getInt64(0),
+                                         "__lesma_arc_debug_live_count");
+  }
+  auto* rootsTotal =
+      theModule->getGlobalVariable(std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_TOTAL}, true);
+  if (rootsTotal == nullptr) {
+    rootsTotal = new llvm::GlobalVariable(
+        *theModule, builder->getInt64Ty(), false, llvm::GlobalValue::CommonLinkage,
+        builder->getInt64(0), std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_TOTAL});
+  }
+  auto* rootsRemaining = theModule->getGlobalVariable(
+      std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_REMAINING}, true);
+  if (rootsRemaining == nullptr) {
+    rootsRemaining = new llvm::GlobalVariable(
+        *theModule, builder->getInt64Ty(), false, llvm::GlobalValue::CommonLinkage,
+        builder->getInt64(0), std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_REMAINING});
+  }
+
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  auto printfFn = theModule->getOrInsertFunction(
+      "printf", llvm::FunctionType::get(builder->getInt32Ty(), {builder->getPtrTy()}, true));
+  auto* format = builder->CreateBitCast(builder->CreateGlobalString(
+                                            "[arc] live objects: %lld (roots tracked: %lld, "
+                                            "roots remaining: %lld)\n",
+                                            "arc.debug.report"),
+                                        builder->getPtrTy());
+  auto* count = builder->CreateLoad(builder->getInt64Ty(), liveCount, "arc.debug.live.report");
+  auto* total = builder->CreateLoad(builder->getInt64Ty(), rootsTotal, "arc.debug.roots.total");
+  auto* remaining =
+      builder->CreateLoad(builder->getInt64Ty(), rootsRemaining, "arc.debug.roots.remaining");
+  builder->CreateCall(printfFn, {format, count, total, remaining});
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::getOrCreateArcDebugCleanupBeginFunction() -> llvm::Function* {
+  if (arcDebugCleanupBeginFn != nullptr) {
+    return arcDebugCleanupBeginFn;
+  }
+  auto* fn = theModule->getFunction(std::string{codegen::runtime::ARC_DEBUG_CLEANUP_BEGIN});
+  if (fn == nullptr) {
+    auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getInt64Ty()}, false);
+    fn = llvm::Function::Create(fnTy, llvm::Function::LinkOnceODRLinkage,
+                                std::string{codegen::runtime::ARC_DEBUG_CLEANUP_BEGIN}, *theModule);
+  }
+  arcDebugCleanupBeginFn = fn;
+  if (!fn->empty()) {
+    return fn;
+  }
+
+  auto* rootsTotal =
+      theModule->getGlobalVariable(std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_TOTAL}, true);
+  if (rootsTotal == nullptr) {
+    rootsTotal = new llvm::GlobalVariable(
+        *theModule, builder->getInt64Ty(), false, llvm::GlobalValue::CommonLinkage,
+        builder->getInt64(0), std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_TOTAL});
+  }
+  auto* rootsRemaining = theModule->getGlobalVariable(
+      std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_REMAINING}, true);
+  if (rootsRemaining == nullptr) {
+    rootsRemaining = new llvm::GlobalVariable(
+        *theModule, builder->getInt64Ty(), false, llvm::GlobalValue::CommonLinkage,
+        builder->getInt64(0), std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_REMAINING});
+  }
+
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  auto* currentTotal =
+      builder->CreateLoad(builder->getInt64Ty(), rootsTotal, "arc.debug.cleanup.total.current");
+  auto* currentRemaining = builder->CreateLoad(builder->getInt64Ty(), rootsRemaining,
+                                               "arc.debug.cleanup.remaining.current");
+  auto* delta = fn->getArg(0U);
+  builder->CreateStore(builder->CreateAdd(currentTotal, delta), rootsTotal);
+  builder->CreateStore(builder->CreateAdd(currentRemaining, delta), rootsRemaining);
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::getOrCreateArcDebugCleanupStepFunction() -> llvm::Function* {
+  if (arcDebugCleanupStepFn != nullptr) {
+    return arcDebugCleanupStepFn;
+  }
+  auto* fn = theModule->getFunction(std::string{codegen::runtime::ARC_DEBUG_CLEANUP_STEP});
+  if (fn == nullptr) {
+    auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {}, false);
+    fn = llvm::Function::Create(fnTy, llvm::Function::LinkOnceODRLinkage,
+                                std::string{codegen::runtime::ARC_DEBUG_CLEANUP_STEP}, *theModule);
+  }
+  arcDebugCleanupStepFn = fn;
+  if (!fn->empty()) {
+    return fn;
+  }
+
+  auto* rootsRemaining = theModule->getGlobalVariable(
+      std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_REMAINING}, true);
+  if (rootsRemaining == nullptr) {
+    rootsRemaining = new llvm::GlobalVariable(
+        *theModule, builder->getInt64Ty(), false, llvm::GlobalValue::CommonLinkage,
+        builder->getInt64(0), std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_REMAINING});
+  }
+
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  auto* current =
+      builder->CreateLoad(builder->getInt64Ty(), rootsRemaining, "arc.debug.cleanup.step.current");
+  auto* next = builder->CreateSub(current, builder->getInt64(1), "arc.debug.cleanup.step.next");
+  builder->CreateStore(next, rootsRemaining);
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::emitArcDebugDelta(std::int64_t delta, llvm::Value* payloadPtr,
+                                std::string_view traceMessagePrefix) -> void {
+  if (!emitArcDebug) {
+    return;
+  }
+  auto* next = builder->CreateCall(getOrCreateArcDebugDeltaFunction(), {builder->getInt64(delta)});
+  if (!emitArcTrace) {
+    return;
+  }
+  auto printfFn = theModule->getOrInsertFunction(
+      "printf", llvm::FunctionType::get(builder->getInt32Ty(), {builder->getPtrTy()}, true));
+  auto* format = builder->CreateBitCast(
+      builder->CreateGlobalString(std::string(traceMessagePrefix) + " ptr=%p live=%lld\n",
+                                  "arc.debug.live.trace"),
+      builder->getPtrTy());
+  builder->CreateCall(printfFn, {format, payloadPtr, next});
+}
+
+auto Codegen::emitArcDebugTraceCounts(std::string_view traceMessagePrefix, llvm::Value* payloadPtr,
+                                      llvm::Value* before, llvm::Value* after) -> void {
+  if (!emitArcTrace) {
+    return;
+  }
+  auto printfFn = theModule->getOrInsertFunction(
+      "printf", llvm::FunctionType::get(builder->getInt32Ty(), {builder->getPtrTy()}, true));
+  auto* format =
+      builder->CreateBitCast(builder->CreateGlobalString(std::string(traceMessagePrefix) +
+                                                             " ptr=%p before=%lld after=%lld\n",
+                                                         "arc.debug.count.trace"),
+                             builder->getPtrTy());
+  builder->CreateCall(printfFn, {format, payloadPtr, before, after});
+}
+
+auto Codegen::emitArcDebugValidateRefcount(llvm::Value* refCount, std::string_view message)
+    -> void {
+  if (!emitArcDebug) {
+    return;
+  }
+  llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+  auto* failBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.debug.fail", parentFn);
+  auto* okBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.debug.ok", parentFn);
+  builder->CreateCondBr(builder->CreateICmpSGE(refCount, builder->getInt64(1)), okBlock, failBlock);
+  builder->SetInsertPoint(failBlock);
+  emitRuntimeStderrMessage(message);
+  emitExit(1);
+  builder->CreateUnreachable();
+  builder->SetInsertPoint(okBlock);
+}
+
+auto Codegen::emitArcDebugTraceModuleRoot(const ModuleArcTrackedRoot& tracked) -> void {
+  if (!emitArcTrace) {
+    return;
+  }
+  auto printfFn = theModule->getOrInsertFunction(
+      "printf", llvm::FunctionType::get(builder->getInt32Ty(), {builder->getPtrTy()}, true));
+  auto* format = builder->CreateBitCast(
+      builder->CreateGlobalString("[arc] cleanup root %s\n", "arc.debug.root.trace"),
+      builder->getPtrTy());
+  auto* name = builder->CreateBitCast(
+      builder->CreateGlobalString(tracked.debugName, "arc.debug.root.name"), builder->getPtrTy());
+  builder->CreateCall(printfFn, {format, name});
+}
+
+auto Codegen::getOrCreateModuleCleanupFunction() -> llvm::Function* {
+  if (moduleCleanupFn != nullptr) {
+    return moduleCleanupFn;
+  }
+  if (moduleArcTrackedRoots.empty()) {
+    return nullptr;
+  }
+  auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {}, false);
+  auto* fn = llvm::Function::Create(
+      fnTy, llvm::GlobalValue::PrivateLinkage,
+      MangleUtils::getImportedModuleFiniSymbolName(filename.empty() ? std::string() : filename),
+      *theModule);
+  moduleCleanupFn = fn;
+
+  auto* doneGlobal = new llvm::GlobalVariable(*theModule, builder->getInt1Ty(), false,
+                                              llvm::GlobalValue::PrivateLinkage,
+                                              builder->getFalse(),
+                                              fn->getName().str() + ".done");
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  auto* cleanupBlock = llvm::BasicBlock::Create(theModule->getContext(), "cleanup", fn);
+  auto* doneBlock = llvm::BasicBlock::Create(theModule->getContext(), "done", fn);
+  builder->SetInsertPoint(entry);
+  auto* alreadyDone = builder->CreateLoad(builder->getInt1Ty(), doneGlobal, "arc.cleanup.done");
+  builder->CreateCondBr(alreadyDone, doneBlock, cleanupBlock);
+
+  builder->SetInsertPoint(cleanupBlock);
+  builder->CreateStore(builder->getTrue(), doneGlobal);
+  if (emitArcDebug) {
+    builder->CreateCall(getOrCreateArcDebugCleanupBeginFunction(),
+                        {builder->getInt64(static_cast<std::int64_t>(moduleArcTrackedRoots.size()))});
+  }
+  emitReleaseRegisteredModuleArcRoots();
+  builder->CreateBr(doneBlock);
+
+  builder->SetInsertPoint(doneBlock);
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::emitCallPendingJitModuleFinis() -> void {
+  if (pendingJitModuleFinis == nullptr) {
+    return;
+  }
+  auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {}, false);
+  for (auto it = pendingJitModuleFinis->rbegin(); it != pendingJitModuleFinis->rend(); ++it) {
+    if (it->empty()) {
+      continue;
+    }
+    auto finiFn = theModule->getOrInsertFunction(*it, fnTy);
+    builder->CreateCall(finiFn);
+  }
 }
 
 auto Codegen::emitListLength(lesma::Type* listType, llvm::Value* listHandle) -> llvm::Value* {

--- a/src/liblesma/Backend/CodegenBufferHelpers.cpp
+++ b/src/liblesma/Backend/CodegenBufferHelpers.cpp
@@ -256,30 +256,9 @@ auto Codegen::emitRetainLoadedValue(lesma::Type* type, llvm::Value* value, bool 
     auto* slot = createAllocaInEntry(parentFn, type->getLlvmType(), "arc.union.retain.slot");
     builder->CreateStore(value, slot);
     llvm::Value* tagVal = builder->CreateExtractValue(value, {0U}, "arc.union.tag");
-    llvm::BasicBlock* mergeBlock =
-        llvm::BasicBlock::Create(theModule->getContext(), "arc.union.retain.done", parentFn);
-    llvm::BasicBlock* currentBlock = builder->GetInsertBlock();
-    for (unsigned idx = 0; idx < type->getUnionMembers().size(); ++idx) {
-      Type* member = type->getUnionMembers()[idx];
-      if (!TypeUtils::containsArcManagedValue(member)) {
-        continue;
-      }
-      auto* matchBlock =
-          llvm::BasicBlock::Create(theModule->getContext(), "arc.union.retain.match", parentFn);
-      auto* nextBlock =
-          llvm::BasicBlock::Create(theModule->getContext(), "arc.union.retain.next", parentFn);
-      builder->SetInsertPoint(currentBlock);
-      builder->CreateCondBr(
-          builder->CreateICmpEQ(tagVal, llvm::ConstantInt::get(tagVal->getType(), idx)), matchBlock,
-          nextBlock);
-      builder->SetInsertPoint(matchBlock);
-      emitRetainLoadedValue(member, emitUnionPayloadLoadFromSlot(slot, type, member), false);
-      builder->CreateBr(mergeBlock);
-      currentBlock = nextBlock;
-    }
-    builder->SetInsertPoint(currentBlock);
-    builder->CreateBr(mergeBlock);
-    builder->SetInsertPoint(mergeBlock);
+    emitForEachUnionMemberWithTagDispatch(
+        type, slot, tagVal, "arc.union.retain",
+        [this](Type* member, llvm::Value* payload) { emitRetainLoadedValue(member, payload, false); });
     return;
   }
   case BaseType::TY_ANY: {
@@ -337,30 +316,10 @@ auto Codegen::emitReleaseLoadedValue(lesma::Type* type, llvm::Value* value,
     auto* slot = createAllocaInEntry(parentFn, type->getLlvmType(), "arc.union.release.slot");
     builder->CreateStore(value, slot);
     llvm::Value* tagVal = builder->CreateExtractValue(value, {0U}, "arc.union.tag");
-    llvm::BasicBlock* mergeBlock =
-        llvm::BasicBlock::Create(theModule->getContext(), "arc.union.release.done", parentFn);
-    llvm::BasicBlock* currentBlock = builder->GetInsertBlock();
-    for (unsigned idx = 0; idx < type->getUnionMembers().size(); ++idx) {
-      Type* member = type->getUnionMembers()[idx];
-      if (!TypeUtils::containsArcManagedValue(member)) {
-        continue;
-      }
-      auto* matchBlock =
-          llvm::BasicBlock::Create(theModule->getContext(), "arc.union.release.match", parentFn);
-      auto* nextBlock =
-          llvm::BasicBlock::Create(theModule->getContext(), "arc.union.release.next", parentFn);
-      builder->SetInsertPoint(currentBlock);
-      builder->CreateCondBr(
-          builder->CreateICmpEQ(tagVal, llvm::ConstantInt::get(tagVal->getType(), idx)), matchBlock,
-          nextBlock);
-      builder->SetInsertPoint(matchBlock);
-      emitReleaseLoadedValue(member, emitUnionPayloadLoadFromSlot(slot, type, member), false);
-      builder->CreateBr(mergeBlock);
-      currentBlock = nextBlock;
-    }
-    builder->SetInsertPoint(currentBlock);
-    builder->CreateBr(mergeBlock);
-    builder->SetInsertPoint(mergeBlock);
+    emitForEachUnionMemberWithTagDispatch(type, slot, tagVal, "arc.union.release",
+                                          [this](Type* member, llvm::Value* payload) {
+                                            emitReleaseLoadedValue(member, payload, false);
+                                          });
     return;
   }
   case BaseType::TY_ANY: {
@@ -371,6 +330,38 @@ auto Codegen::emitReleaseLoadedValue(lesma::Type* type, llvm::Value* value,
   default:
     return;
   }
+}
+
+auto Codegen::emitForEachUnionMemberWithTagDispatch(
+    lesma::Type* unionTy, llvm::Value* unionSlot, llvm::Value* tagVal, std::string_view blockStem,
+    const std::function<void(lesma::Type*, llvm::Value*)>& callback) -> void {
+  if (unionTy == nullptr || unionSlot == nullptr || tagVal == nullptr) {
+    return;
+  }
+  llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+  llvm::BasicBlock* mergeBlock = llvm::BasicBlock::Create(theModule->getContext(),
+                                                          std::string(blockStem) + ".done", parentFn);
+  llvm::BasicBlock* currentBlock = builder->GetInsertBlock();
+  for (unsigned idx = 0; idx < unionTy->getUnionMembers().size(); ++idx) {
+    Type* member = unionTy->getUnionMembers()[idx];
+    if (!TypeUtils::containsArcManagedValue(member)) {
+      continue;
+    }
+    auto* matchBlock = llvm::BasicBlock::Create(theModule->getContext(),
+                                                std::string(blockStem) + ".match", parentFn);
+    auto* nextBlock = llvm::BasicBlock::Create(theModule->getContext(), std::string(blockStem) + ".next",
+                                               parentFn);
+    builder->SetInsertPoint(currentBlock);
+    builder->CreateCondBr(builder->CreateICmpEQ(tagVal, llvm::ConstantInt::get(tagVal->getType(), idx)),
+                          matchBlock, nextBlock);
+    builder->SetInsertPoint(matchBlock);
+    callback(member, emitUnionPayloadLoadFromSlot(unionSlot, unionTy, member));
+    builder->CreateBr(mergeBlock);
+    currentBlock = nextBlock;
+  }
+  builder->SetInsertPoint(currentBlock);
+  builder->CreateBr(mergeBlock);
+  builder->SetInsertPoint(mergeBlock);
 }
 
 auto Codegen::emitReleaseTrackedSlot(const ArcTrackedSlot& tracked) -> void {
@@ -706,11 +697,12 @@ auto Codegen::getOrCreateArcDebugDeltaFunction() -> llvm::Function* {
   }
 
   fn->addFnAttr(llvm::Attribute::NoInline);
-  auto* liveCount = theModule->getGlobalVariable("__lesma_arc_debug_live_count", true);
+  auto* liveCount =
+      theModule->getGlobalVariable(std::string{codegen::runtime::ARC_DEBUG_LIVE_COUNT}, true);
   if (liveCount == nullptr) {
     liveCount = new llvm::GlobalVariable(*theModule, builder->getInt64Ty(), false,
                                          llvm::GlobalValue::CommonLinkage, builder->getInt64(0),
-                                         "__lesma_arc_debug_live_count");
+                                         std::string{codegen::runtime::ARC_DEBUG_LIVE_COUNT});
   }
 
   auto savedIp = builder->saveIP();
@@ -740,11 +732,12 @@ auto Codegen::getOrCreateArcDebugReportFunction() -> llvm::Function* {
   }
 
   fn->addFnAttr(llvm::Attribute::NoInline);
-  auto* liveCount = theModule->getGlobalVariable("__lesma_arc_debug_live_count", true);
+  auto* liveCount =
+      theModule->getGlobalVariable(std::string{codegen::runtime::ARC_DEBUG_LIVE_COUNT}, true);
   if (liveCount == nullptr) {
     liveCount = new llvm::GlobalVariable(*theModule, builder->getInt64Ty(), false,
                                          llvm::GlobalValue::CommonLinkage, builder->getInt64(0),
-                                         "__lesma_arc_debug_live_count");
+                                         std::string{codegen::runtime::ARC_DEBUG_LIVE_COUNT});
   }
   auto* rootsTotal =
       theModule->getGlobalVariable(std::string{codegen::runtime::ARC_DEBUG_MODULE_ROOTS_TOTAL}, true);

--- a/src/liblesma/Backend/CodegenBufferHelpers.cpp
+++ b/src/liblesma/Backend/CodegenBufferHelpers.cpp
@@ -12,6 +12,7 @@
 #include "liblesma/Backend/CodegenRuntimeNames.h"
 #include "liblesma/Backend/MangleUtils.h"
 #include "liblesma/Symbol/Type.h"
+#include "liblesma/Symbol/TypeUtils.h"
 #include "liblesma/Symbol/Value.h"
 
 using namespace lesma;
@@ -81,6 +82,550 @@ auto Codegen::emitFree(llvm::Value* ptr) -> void {
       std::string{codegen::runtime::FREE},
       llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false));
   builder->CreateCall(freeFn, {ptr});
+}
+
+auto Codegen::getOrCreateArcHeaderType() -> llvm::StructType* {
+  if (arcHeaderLlvmType == nullptr) {
+    arcHeaderLlvmType = llvm::StructType::create(theModule->getContext(),
+                                                 {builder->getInt64Ty(), builder->getPtrTy()},
+                                                 "lesma.arc.header", false);
+  }
+  return arcHeaderLlvmType;
+}
+
+auto Codegen::emitArcAlloc(llvm::Value* payloadSize, llvm::Function* destroyFn,
+                           const llvm::Twine& name) -> llvm::Value* {
+  auto* headerTy = getOrCreateArcHeaderType();
+  auto* headerSize = builder->getInt64(
+      theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
+  auto* totalSize = builder->CreateAdd(payloadSize, headerSize, name + ".arc.bytes");
+  auto* raw = emitMalloc(totalSize, name + ".arc.raw");
+  auto* headerPtr = builder->CreateBitCast(raw, llvm::PointerType::get(headerTy->getContext(), 0U),
+                                           name + ".arc.header");
+  builder->CreateStore(builder->getInt64(1), builder->CreateStructGEP(headerTy, headerPtr, 0U));
+  llvm::Value* destroyValue =
+      destroyFn != nullptr ? builder->CreateBitCast(destroyFn, builder->getPtrTy())
+                           : llvm::ConstantPointerNull::get(builder->getPtrTy());
+  builder->CreateStore(destroyValue, builder->CreateStructGEP(headerTy, headerPtr, 1U));
+  auto* payload =
+      builder->CreateInBoundsGEP(builder->getInt8Ty(), raw, headerSize, name + ".arc.payload");
+  builder->CreateMemSet(payload, builder->getInt8(0), payloadSize, llvm::MaybeAlign(1U));
+  return builder->CreateBitCast(payload, builder->getPtrTy(), name);
+}
+
+auto Codegen::emitArcFreePayload(llvm::Value* payloadPtr) -> void {
+  auto* headerTy = getOrCreateArcHeaderType();
+  auto* headerSize = builder->getInt64(
+      theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
+  auto* payloadRaw = builder->CreateBitCast(payloadPtr, builder->getPtrTy(), "arc.payload.raw");
+  auto* raw = builder->CreateInBoundsGEP(builder->getInt8Ty(), payloadRaw,
+                                         builder->CreateNeg(headerSize), "arc.raw");
+  emitFree(raw);
+}
+
+auto Codegen::emitArcRetain(llvm::Value* payloadPtr) -> void {
+  llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+  auto* retainBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.retain", parentFn);
+  auto* doneBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.retain.done", parentFn);
+  builder->CreateCondBr(
+      builder->CreateICmpEQ(payloadPtr, llvm::ConstantPointerNull::get(builder->getPtrTy())),
+      doneBlock, retainBlock);
+
+  builder->SetInsertPoint(retainBlock);
+  auto* headerTy = getOrCreateArcHeaderType();
+  auto* headerSize = builder->getInt64(
+      theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
+  auto* raw = builder->CreateInBoundsGEP(builder->getInt8Ty(),
+                                         builder->CreateBitCast(payloadPtr, builder->getPtrTy()),
+                                         builder->CreateNeg(headerSize), "arc.retain.raw");
+  auto* headerPtr = builder->CreateBitCast(raw, llvm::PointerType::get(headerTy->getContext(), 0U),
+                                           "arc.retain.header");
+  auto* refSlot = builder->CreateStructGEP(headerTy, headerPtr, 0U);
+  auto* refCount = builder->CreateLoad(builder->getInt64Ty(), refSlot, "arc.retain.count");
+  builder->CreateStore(builder->CreateAdd(refCount, builder->getInt64(1)), refSlot);
+  builder->CreateBr(doneBlock);
+
+  builder->SetInsertPoint(doneBlock);
+}
+
+auto Codegen::emitArcRelease(llvm::Value* payloadPtr) -> void {
+  auto* headerTy = getOrCreateArcHeaderType();
+  auto* headerSize = builder->getInt64(
+      theModule->getDataLayout().getTypeAllocSize(headerTy).getFixedValue());
+  auto* raw = builder->CreateInBoundsGEP(builder->getInt8Ty(),
+                                         builder->CreateBitCast(payloadPtr, builder->getPtrTy()),
+                                         builder->CreateNeg(headerSize), "arc.release.raw");
+  auto* headerPtr = builder->CreateBitCast(raw, llvm::PointerType::get(headerTy->getContext(), 0U),
+                                           "arc.release.header");
+  auto* refSlot = builder->CreateStructGEP(headerTy, headerPtr, 0U);
+  auto* destroySlot = builder->CreateStructGEP(headerTy, headerPtr, 1U);
+  auto* refCount = builder->CreateLoad(builder->getInt64Ty(), refSlot, "arc.release.count");
+  auto* next = builder->CreateSub(refCount, builder->getInt64(1), "arc.release.next");
+  builder->CreateStore(next, refSlot);
+
+  llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+  auto* destroyBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.release.destroy",
+                                                parentFn);
+  auto* doneBlock =
+      llvm::BasicBlock::Create(theModule->getContext(), "arc.release.done", parentFn);
+  builder->CreateCondBr(builder->CreateICmpEQ(next, builder->getInt64(0)), destroyBlock, doneBlock);
+
+  builder->SetInsertPoint(destroyBlock);
+  auto* destroyPtr = builder->CreateLoad(builder->getPtrTy(), destroySlot, "arc.release.destroyfn");
+  auto* destroyTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
+  builder->CreateCall(destroyTy, destroyPtr, {payloadPtr});
+  builder->CreateBr(doneBlock);
+
+  builder->SetInsertPoint(doneBlock);
+}
+
+auto Codegen::emitArcReleaseNullable(llvm::Value* payloadPtr) -> void {
+  llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+  auto* releaseBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.release", parentFn);
+  auto* doneBlock = llvm::BasicBlock::Create(theModule->getContext(), "arc.release.done", parentFn);
+  builder->CreateCondBr(
+      builder->CreateICmpEQ(payloadPtr, llvm::ConstantPointerNull::get(builder->getPtrTy())),
+      doneBlock, releaseBlock);
+  builder->SetInsertPoint(releaseBlock);
+  emitArcRelease(payloadPtr);
+  builder->CreateBr(doneBlock);
+  builder->SetInsertPoint(doneBlock);
+}
+
+auto Codegen::emitRetainLoadedValue(lesma::Type* type, llvm::Value* value, bool storesFuncValuePair)
+    -> void {
+  if (type == nullptr || value == nullptr) {
+    return;
+  }
+  if (TypeUtils::isArcReferenceType(type)) {
+    emitArcRetain(value);
+    return;
+  }
+  switch (type->getBaseType()) {
+  case BaseType::TY_PTR:
+    if (type->getElementType() != nullptr && type->getElementType()->is(BaseType::TY_CLASS)) {
+      emitArcRetain(value);
+    }
+    return;
+  case BaseType::TY_FUNCTION:
+    if (!storesFuncValuePair || !value->getType()->isStructTy()) {
+      return;
+    }
+    emitArcRetain(builder->CreateExtractValue(value, {1U}, "arc.fn.env"));
+    return;
+  case BaseType::TY_TRAIT_EXISTENTIAL:
+    emitArcRetain(builder->CreateExtractValue(value, {0U}, "arc.existential.payload"));
+    return;
+  case BaseType::TY_TUPLE: {
+    auto fields = type->getFields();
+    for (unsigned i = 0; i < fields.size(); ++i) {
+      if (!TypeUtils::containsArcManagedValue(fields[i]->type)) {
+        continue;
+      }
+      emitRetainLoadedValue(fields[i]->type, builder->CreateExtractValue(value, {i}, "arc.tuple.v"),
+                           false);
+    }
+    return;
+  }
+  case BaseType::TY_UNION: {
+    bool hasArcMember = false;
+    for (Type* member : type->getUnionMembers()) {
+      hasArcMember = hasArcMember || TypeUtils::containsArcManagedValue(member);
+    }
+    if (!hasArcMember) {
+      return;
+    }
+    llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+    auto* slot = createAllocaInEntry(parentFn, type->getLlvmType(), "arc.union.retain.slot");
+    builder->CreateStore(value, slot);
+    llvm::Value* tagVal = builder->CreateExtractValue(value, {0U}, "arc.union.tag");
+    llvm::BasicBlock* mergeBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), "arc.union.retain.done", parentFn);
+    llvm::BasicBlock* currentBlock = builder->GetInsertBlock();
+    for (unsigned idx = 0; idx < type->getUnionMembers().size(); ++idx) {
+      Type* member = type->getUnionMembers()[idx];
+      if (!TypeUtils::containsArcManagedValue(member)) {
+        continue;
+      }
+      auto* matchBlock =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.union.retain.match", parentFn);
+      auto* nextBlock =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.union.retain.next", parentFn);
+      builder->SetInsertPoint(currentBlock);
+      builder->CreateCondBr(
+          builder->CreateICmpEQ(tagVal, llvm::ConstantInt::get(tagVal->getType(), idx)), matchBlock,
+          nextBlock);
+      builder->SetInsertPoint(matchBlock);
+      emitRetainLoadedValue(member, emitUnionPayloadLoadFromSlot(slot, type, member), false);
+      builder->CreateBr(mergeBlock);
+      currentBlock = nextBlock;
+    }
+    builder->SetInsertPoint(currentBlock);
+    builder->CreateBr(mergeBlock);
+    builder->SetInsertPoint(mergeBlock);
+    return;
+  }
+  case BaseType::TY_ANY: {
+    llvm::Value* payloadPtr = builder->CreateExtractValue(value, {1U}, "arc.any.payload");
+    emitArcRetain(payloadPtr);
+    return;
+  }
+  default:
+    return;
+  }
+}
+
+auto Codegen::emitReleaseLoadedValue(lesma::Type* type, llvm::Value* value, bool storesFuncValuePair)
+    -> void {
+  if (type == nullptr || value == nullptr) {
+    return;
+  }
+  if (TypeUtils::isArcReferenceType(type)) {
+    emitArcReleaseNullable(value);
+    return;
+  }
+  switch (type->getBaseType()) {
+  case BaseType::TY_PTR:
+    if (type->getElementType() != nullptr && type->getElementType()->is(BaseType::TY_CLASS)) {
+      emitArcReleaseNullable(value);
+    }
+    return;
+  case BaseType::TY_FUNCTION:
+    if (!storesFuncValuePair || !value->getType()->isStructTy()) {
+      return;
+    }
+    emitArcReleaseNullable(builder->CreateExtractValue(value, {1U}, "arc.fn.env"));
+    return;
+  case BaseType::TY_TRAIT_EXISTENTIAL:
+    emitArcReleaseNullable(builder->CreateExtractValue(value, {0U}, "arc.existential.payload"));
+    return;
+  case BaseType::TY_TUPLE: {
+    auto fields = type->getFields();
+    for (unsigned i = 0; i < fields.size(); ++i) {
+      if (!TypeUtils::containsArcManagedValue(fields[i]->type)) {
+        continue;
+      }
+      emitReleaseLoadedValue(fields[i]->type, builder->CreateExtractValue(value, {i}, "arc.tuple.v"),
+                             false);
+    }
+    return;
+  }
+  case BaseType::TY_UNION: {
+    bool hasArcMember = false;
+    for (Type* member : type->getUnionMembers()) {
+      hasArcMember = hasArcMember || TypeUtils::containsArcManagedValue(member);
+    }
+    if (!hasArcMember) {
+      return;
+    }
+    llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+    auto* slot = createAllocaInEntry(parentFn, type->getLlvmType(), "arc.union.release.slot");
+    builder->CreateStore(value, slot);
+    llvm::Value* tagVal = builder->CreateExtractValue(value, {0U}, "arc.union.tag");
+    llvm::BasicBlock* mergeBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), "arc.union.release.done", parentFn);
+    llvm::BasicBlock* currentBlock = builder->GetInsertBlock();
+    for (unsigned idx = 0; idx < type->getUnionMembers().size(); ++idx) {
+      Type* member = type->getUnionMembers()[idx];
+      if (!TypeUtils::containsArcManagedValue(member)) {
+        continue;
+      }
+      auto* matchBlock =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.union.release.match", parentFn);
+      auto* nextBlock =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.union.release.next", parentFn);
+      builder->SetInsertPoint(currentBlock);
+      builder->CreateCondBr(
+          builder->CreateICmpEQ(tagVal, llvm::ConstantInt::get(tagVal->getType(), idx)), matchBlock,
+          nextBlock);
+      builder->SetInsertPoint(matchBlock);
+      emitReleaseLoadedValue(member, emitUnionPayloadLoadFromSlot(slot, type, member), false);
+      builder->CreateBr(mergeBlock);
+      currentBlock = nextBlock;
+    }
+    builder->SetInsertPoint(currentBlock);
+    builder->CreateBr(mergeBlock);
+    builder->SetInsertPoint(mergeBlock);
+    return;
+  }
+  case BaseType::TY_ANY: {
+    llvm::Value* payloadPtr = builder->CreateExtractValue(value, {1U}, "arc.any.payload");
+    emitArcReleaseNullable(payloadPtr);
+    return;
+  }
+  default:
+    return;
+  }
+}
+
+auto Codegen::emitReleaseTrackedSlot(const ArcTrackedSlot& tracked) -> void {
+  if (tracked.slot == nullptr || tracked.type == nullptr ||
+      !TypeUtils::containsArcManagedValue(tracked.type)) {
+    return;
+  }
+  llvm::Type* slotTy = tracked.type->is(BaseType::TY_FUNCTION) && tracked.storesFuncValuePair
+                           ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                           : getStoredAggregateFieldLlvmType(tracked.type);
+  if (slotTy == nullptr) {
+    return;
+  }
+  emitReleaseLoadedValue(tracked.type, builder->CreateLoad(slotTy, tracked.slot, "arc.slot.release"),
+                         tracked.storesFuncValuePair);
+}
+
+auto Codegen::pushArcOwnedSlotFrame() -> void { arcOwnedSlotFrames.emplace_back(); }
+
+auto Codegen::popArcOwnedSlotFrame(bool emitCleanup) -> void {
+  if (arcOwnedSlotFrames.empty()) {
+    return;
+  }
+  if (emitCleanup) {
+    for (auto it = arcOwnedSlotFrames.back().rbegin(); it != arcOwnedSlotFrames.back().rend(); ++it) {
+      emitReleaseTrackedSlot(*it);
+    }
+  }
+  arcOwnedSlotFrames.pop_back();
+}
+
+auto Codegen::registerArcOwnedSlot(llvm::Value* slot, lesma::Type* type, bool storesFuncValuePair)
+    -> void {
+  if (slot == nullptr || type == nullptr || arcOwnedSlotFrames.empty() ||
+      !TypeUtils::containsArcManagedValue(type)) {
+    return;
+  }
+  auto& frame = arcOwnedSlotFrames.back();
+  for (const ArcTrackedSlot& tracked : frame) {
+    if (tracked.slot == slot) {
+      return;
+    }
+  }
+  frame.push_back(ArcTrackedSlot{slot, type, storesFuncValuePair});
+}
+
+auto Codegen::emitReleaseCurrentArcOwnedSlots() -> void {
+  if (arcOwnedSlotFrames.empty()) {
+    return;
+  }
+  for (auto it = arcOwnedSlotFrames.back().rbegin(); it != arcOwnedSlotFrames.back().rend(); ++it) {
+    emitReleaseTrackedSlot(*it);
+  }
+}
+
+auto Codegen::getOrCreateArcStorageRetainFunction(lesma::Type* type) -> llvm::Function* {
+  if (type == nullptr) {
+    return nullptr;
+  }
+  if (auto it = arcStorageRetainFns.find(type); it != arcStorageRetainFns.end()) {
+    return it->second;
+  }
+  std::string fnName = "__lesma_arc_retain_storage_" + MangleUtils::getTypeMangledName({}, type);
+  auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
+  auto* fn = llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage, fnName, *theModule);
+  arcStorageRetainFns[type] = fn;
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  llvm::Value* storage = fn->getArg(0U);
+  llvm::Type* storageTy = type->is(BaseType::TY_FUNCTION)
+                              ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                              : getStoredAggregateFieldLlvmType(type);
+  llvm::Value* typedStorage =
+      builder->CreateBitCast(storage, llvm::PointerType::get(storageTy->getContext(), 0U));
+  emitRetainLoadedValue(type, builder->CreateLoad(storageTy, typedStorage, "arc.storage.load"),
+                        type->is(BaseType::TY_FUNCTION));
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::getOrCreateArcStorageReleaseFunction(lesma::Type* type) -> llvm::Function* {
+  if (type == nullptr) {
+    return nullptr;
+  }
+  if (auto it = arcStorageReleaseFns.find(type); it != arcStorageReleaseFns.end()) {
+    return it->second;
+  }
+  std::string fnName = "__lesma_arc_release_storage_" + MangleUtils::getTypeMangledName({}, type);
+  auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
+  auto* fn = llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage, fnName, *theModule);
+  arcStorageReleaseFns[type] = fn;
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  llvm::Value* storage = fn->getArg(0U);
+  llvm::Type* storageTy = type->is(BaseType::TY_FUNCTION)
+                              ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                              : getStoredAggregateFieldLlvmType(type);
+  llvm::Value* typedStorage =
+      builder->CreateBitCast(storage, llvm::PointerType::get(storageTy->getContext(), 0U));
+  emitReleaseLoadedValue(type, builder->CreateLoad(storageTy, typedStorage, "arc.storage.load"),
+                         type->is(BaseType::TY_FUNCTION));
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::getOrCreateArcPayloadDestroyFunction(lesma::Type* type) -> llvm::Function* {
+  if (type == nullptr) {
+    return nullptr;
+  }
+  if (auto it = arcPayloadDestroyFns.find(type); it != arcPayloadDestroyFns.end()) {
+    return it->second;
+  }
+  std::string fnName = "__lesma_arc_destroy_payload_" + MangleUtils::getTypeMangledName({}, type);
+  auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
+  auto* fn = llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage, fnName, *theModule);
+  arcPayloadDestroyFns[type] = fn;
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  auto* releaseFn = getOrCreateArcStorageReleaseFunction(type);
+  auto* releaseTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
+  builder->CreateCall(releaseTy, releaseFn, {fn->getArg(0U)});
+  emitArcFreePayload(fn->getArg(0U));
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::getOrCreateArcDestroyFunction(lesma::Type* type) -> llvm::Function* {
+  if (type == nullptr) {
+    return nullptr;
+  }
+  if (auto it = arcDestroyFns.find(type); it != arcDestroyFns.end()) {
+    return it->second;
+  }
+  std::string fnName = "__lesma_arc_destroy_" + MangleUtils::getTypeMangledName({}, type);
+  auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
+  auto* fn = llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage, fnName, *theModule);
+  arcDestroyFns[type] = fn;
+
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  llvm::Value* payload = fn->getArg(0U);
+
+  if (type->is(BaseType::TY_ARRAY)) {
+    auto* listHandle = builder->CreateBitCast(payload, llvm::PointerType::get(builder->getContext(), 0U),
+                                              "arc.list.handle");
+    if (type->getElementType() != nullptr &&
+        TypeUtils::containsArcManagedValue(type->getElementType())) {
+      llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+      auto* loopCond =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.list.release.cond", parentFn);
+      auto* loopBody =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.list.release.body", parentFn);
+      auto* loopInc =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.list.release.inc", parentFn);
+      auto* loopDone =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.list.release.done", parentFn);
+      auto* indexPtr = createAllocaInEntry(parentFn, builder->getInt64Ty(), "arc.list.release.idx");
+      builder->CreateStore(builder->getInt64(0), indexPtr);
+      builder->CreateBr(loopCond);
+
+      builder->SetInsertPoint(loopCond);
+      auto* index = builder->CreateLoad(builder->getInt64Ty(), indexPtr);
+      auto* length = emitListLength(type, listHandle);
+      builder->CreateCondBr(builder->CreateICmpSLT(index, length), loopBody, loopDone);
+
+      builder->SetInsertPoint(loopBody);
+      auto* elemPtr = emitListElementPointer({}, type, listHandle, index);
+      auto* elemVal = builder->CreateLoad(getListStoredElementType(type), elemPtr, "arc.list.elem");
+      emitReleaseLoadedValue(type->getElementType(), elemVal, false);
+      builder->CreateBr(loopInc);
+
+      builder->SetInsertPoint(loopInc);
+      builder->CreateStore(builder->CreateAdd(builder->CreateLoad(builder->getInt64Ty(), indexPtr),
+                                              builder->getInt64(1)),
+                           indexPtr);
+      builder->CreateBr(loopCond);
+      builder->SetInsertPoint(loopDone);
+    }
+
+    llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+    auto* freeBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), "arc.list.data.free", parentFn);
+    auto* doneBlock =
+        llvm::BasicBlock::Create(theModule->getContext(), "arc.list.data.done", parentFn);
+    auto* data = emitListDataPtr(type, listHandle);
+    builder->CreateCondBr(
+        builder->CreateICmpEQ(data, llvm::ConstantPointerNull::get(builder->getPtrTy())), doneBlock,
+        freeBlock);
+    builder->SetInsertPoint(freeBlock);
+    emitFree(data);
+    builder->CreateBr(doneBlock);
+    builder->SetInsertPoint(doneBlock);
+    emitArcFreePayload(listHandle);
+    builder->CreateRetVoid();
+    builder->restoreIP(savedIp);
+    return fn;
+  }
+
+  auto* classTy = llvm::cast<llvm::StructType>(getOrCreateLlvmType(type));
+  auto* object = builder->CreateBitCast(payload, llvm::PointerType::get(classTy->getContext(), 0U),
+                                        "arc.class.obj");
+  auto fields = type->getFields();
+  for (unsigned i = 0; i < fields.size(); ++i) {
+    Type* fieldTy = fields[i]->type;
+    unsigned const structIdx = TypeUtils::classDataFieldStructIndex(type, i);
+    auto* slot = builder->CreateStructGEP(classTy, object, structIdx, "arc.field.ptr");
+    if (TypeUtils::containsArcManagedValue(fieldTy)) {
+      llvm::Type* storageTy = getStoredAggregateFieldLlvmType(fieldTy);
+      emitReleaseLoadedValue(fieldTy, builder->CreateLoad(storageTy, slot, "arc.field.load"),
+                             false);
+      continue;
+    }
+    if (type->getDisplayName() == "str" && fieldTy != nullptr && fieldTy->is(BaseType::TY_STRING)) {
+      llvm::Function* parentFn = builder->GetInsertBlock()->getParent();
+      auto* freeBlock =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.str.free", parentFn);
+      auto* doneBlock =
+          llvm::BasicBlock::Create(theModule->getContext(), "arc.str.free.done", parentFn);
+      auto* raw = builder->CreateLoad(builder->getPtrTy(), slot, "arc.str.raw");
+      builder->CreateCondBr(
+          builder->CreateICmpEQ(raw, llvm::ConstantPointerNull::get(builder->getPtrTy())), doneBlock,
+          freeBlock);
+      builder->SetInsertPoint(freeBlock);
+      emitFree(raw);
+      builder->CreateBr(doneBlock);
+      builder->SetInsertPoint(doneBlock);
+    }
+  }
+  emitArcFreePayload(object);
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
+}
+
+auto Codegen::getOrCreateArcClosureDestroyFunction(const std::string& key,
+                                                   llvm::StructType* envStructTy,
+                                                   const std::vector<lesma::Type*>& captureTypes)
+    -> llvm::Function* {
+  if (auto it = arcClosureDestroyFns.find(key); it != arcClosureDestroyFns.end()) {
+    return it->second;
+  }
+  auto* fnTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
+  auto* fn = llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage,
+                                    "__lesma_arc_destroy_env_" + key, *theModule);
+  arcClosureDestroyFns[key] = fn;
+  auto savedIp = builder->saveIP();
+  auto* entry = llvm::BasicBlock::Create(theModule->getContext(), "entry", fn);
+  builder->SetInsertPoint(entry);
+  auto* env = builder->CreateBitCast(fn->getArg(0U), llvm::PointerType::get(envStructTy->getContext(), 0U),
+                                     "arc.env");
+  for (unsigned i = 0; i < captureTypes.size(); ++i) {
+    if (!TypeUtils::containsArcManagedValue(captureTypes[i])) {
+      continue;
+    }
+    auto* slot = builder->CreateStructGEP(envStructTy, env, i, "arc.env.slot");
+    llvm::Type* storageTy = getStoredAggregateFieldLlvmType(captureTypes[i]);
+    emitReleaseLoadedValue(captureTypes[i], builder->CreateLoad(storageTy, slot, "arc.env.load"),
+                           false);
+  }
+  emitArcFreePayload(env);
+  builder->CreateRetVoid();
+  builder->restoreIP(savedIp);
+  return fn;
 }
 
 auto Codegen::emitRuntimeStderrMessage(std::string_view message) -> void {
@@ -221,7 +766,8 @@ auto Codegen::emitListDeepCopy(lesma::Type* listType, llvm::Value* listHandle) -
   auto* structType = getOrCreateListStructType(listType);
   auto* headerSize =
       builder->getInt64(theModule->getDataLayout().getTypeAllocSize(structType).getFixedValue());
-  auto* newHandle = emitMalloc(headerSize, "list.copy.header");
+  auto* newHandle = emitArcAlloc(headerSize, getOrCreateArcDestroyFunction(listType),
+                                 "list.copy.header");
   auto* length = emitListLength(listType, listHandle);
   auto* capacity = emitListCapacity(listType, listHandle);
   emitStoreListLength(listType, newHandle, length);
@@ -254,7 +800,8 @@ auto Codegen::emitListDeepCopy(lesma::Type* listType, llvm::Value* listHandle) -
     return !fields.empty() && fields.front()->type != nullptr &&
            fields.front()->type->is(BaseType::TY_ARRAY);
   };
-  if (elementType->is(BaseType::TY_ARRAY) || isNestedListLike()) {
+  if (elementType->is(BaseType::TY_ARRAY) || isNestedListLike() ||
+      TypeUtils::containsArcManagedValue(elementType)) {
     auto* indexPtr = builder->CreateAlloca(builder->getInt64Ty(), nullptr, "list.copy.index");
     builder->CreateStore(builder->getInt64(0), indexPtr);
     auto* loopCond =
@@ -275,10 +822,13 @@ auto Codegen::emitListDeepCopy(lesma::Type* listType, llvm::Value* listHandle) -
     llvm::Value* copiedElement = nullptr;
     if (elementType->is(BaseType::TY_ARRAY)) {
       copiedElement = emitListDeepCopy(elementType, oldElement);
-    } else {
+    } else if (isNestedListLike()) {
       lesma::Value oldValue("", elementType, oldElement);
       auto copiedValue = callMethodByName({}, &oldValue, "copy");
       copiedElement = copiedValue->getLlvmValue();
+    } else {
+      copiedElement = oldElement;
+      emitRetainLoadedValue(elementType, copiedElement, false);
     }
     auto* newElementPtr = builder->CreateGEP(elementLlvmType, newData, index, "list.copy.elem.ptr");
     builder->CreateStore(copiedElement, newElementPtr);

--- a/src/liblesma/Backend/CodegenBuiltinIntrinsics.cpp
+++ b/src/liblesma/Backend/CodegenBuiltinIntrinsics.cpp
@@ -269,12 +269,11 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     lenTy->setIntWidth(64);
     return std::make_unique<Value>("", lenTy, emitListLength(listType, listHandle));
   }
-  case BuiltinIntrinsicKind::BufferCopy:
-    {
-      auto out = std::make_unique<Value>("", listType, emitListDeepCopy(listType, listHandle));
-      out->setArcOwnedValue(true);
-      return out;
-    }
+  case BuiltinIntrinsicKind::BufferCopy: {
+    auto out = std::make_unique<Value>("", listType, emitListDeepCopy(listType, listHandle));
+    out->setArcOwnedValue(true);
+    return out;
+  }
   case BuiltinIntrinsicKind::BufferClear: {
     if (listType->getElementType() != nullptr &&
         TypeUtils::containsArcManagedValue(listType->getElementType())) {
@@ -285,8 +284,8 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
           llvm::BasicBlock::Create(theModule->getContext(), "list.clear.body", parentFunction);
       auto* loopInc =
           llvm::BasicBlock::Create(theModule->getContext(), "list.clear.inc", parentFunction);
-      auto* releaseDone =
-          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.release.done", parentFunction);
+      auto* releaseDone = llvm::BasicBlock::Create(theModule->getContext(),
+                                                   "list.clear.release.done", parentFunction);
       auto* indexPtr = createAllocaInEntry(parentFunction, builder->getInt64Ty(), "list.clear.idx");
       builder->CreateStore(builder->getInt64(0), indexPtr);
       builder->CreateBr(loopCond);
@@ -339,7 +338,8 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     auto* storedElement =
         getListStoredElementValue(node->getSpan(), &pushedArg, listType->getElementType());
     if (TypeUtils::containsArcManagedValue(listType->getElementType())) {
-      emitRetainLoadedValue(listType->getElementType(), storedElement, pushedArg.getStoresFuncValuePair());
+      emitRetainLoadedValue(listType->getElementType(), storedElement,
+                            pushedArg.getStoresFuncValuePair());
     }
     builder->CreateStore(storedElement, elementPtr);
     emitStoreListLength(listType, listHandle, nextLength);
@@ -361,14 +361,13 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     }
     auto* elementPtr = emitListElementPointer(node->getSpan(), listType, listHandle, paramsLLVM[1]);
     Value setArg("", paramTypes[2], paramsLLVM[2]);
-    if (TypeUtils::containsArcManagedValue(listType->getElementType())) {
-      auto* oldElement = builder->CreateLoad(getListStoredElementType(listType), elementPtr);
-      emitReleaseLoadedValue(listType->getElementType(), oldElement, false);
-    }
     auto* storedElement =
         getListStoredElementValue(node->getSpan(), &setArg, listType->getElementType());
     if (TypeUtils::containsArcManagedValue(listType->getElementType())) {
-      emitRetainLoadedValue(listType->getElementType(), storedElement, setArg.getStoresFuncValuePair());
+      emitRetainLoadedValue(listType->getElementType(), storedElement,
+                            setArg.getStoresFuncValuePair());
+      auto* oldElement = builder->CreateLoad(getListStoredElementType(listType), elementPtr);
+      emitReleaseLoadedValue(listType->getElementType(), oldElement, false);
     }
     builder->CreateStore(storedElement, elementPtr);
     return std::make_unique<Value>(
@@ -408,8 +407,7 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     if (nullIndex == std::nullopt) {
       throw CodegenError(node->getSpan(), "pop() could not resolve null union arm");
     }
-    auto nullWrapped =
-        emitUnionWrapValue(node->getSpan(), &nullValue, popType, *nullIndex);
+    auto nullWrapped = emitUnionWrapValue(node->getSpan(), &nullValue, popType, *nullIndex);
     builder->CreateBr(mergeBlock);
 
     builder->SetInsertPoint(valueBlock);
@@ -421,7 +419,8 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     emitStoreListLength(listType, listHandle, newLength);
     Value popped("", listType->getElementType(), poppedValue);
     auto poppedWrapped = cast(node->getSpan(), &popped, popType);
-    if (TypeUtils::containsArcManagedValue(listType->getElementType()) && poppedWrapped != nullptr) {
+    if (TypeUtils::containsArcManagedValue(listType->getElementType()) &&
+        poppedWrapped != nullptr) {
       poppedWrapped->setArcOwnedValue(true);
     }
     llvm::BasicBlock* valueIncoming = builder->GetInsertBlock();

--- a/src/liblesma/Backend/CodegenBuiltinIntrinsics.cpp
+++ b/src/liblesma/Backend/CodegenBuiltinIntrinsics.cpp
@@ -232,11 +232,14 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     auto* listStructTy = getOrCreateListStructType(listType);
     auto* headerSize = builder->getInt64(
         theModule->getDataLayout().getTypeAllocSize(listStructTy).getFixedValue());
-    auto* listHandle = emitMalloc(headerSize, "buffer.header");
+    auto* listHandle =
+        emitArcAlloc(headerSize, getOrCreateArcDestroyFunction(listType), "buffer.header");
     emitStoreListDataPtr(listType, listHandle, llvm::ConstantPointerNull::get(builder->getPtrTy()));
     emitStoreListLength(listType, listHandle, builder->getInt64(0));
     emitStoreListCapacity(listType, listHandle, builder->getInt64(0));
-    return std::make_unique<Value>("", listType, listHandle);
+    auto out = std::make_unique<Value>("", listType, listHandle);
+    out->setArcOwnedValue(true);
+    return out;
   }
   case BuiltinIntrinsicKind::BufferLen:
   case BuiltinIntrinsicKind::BufferCopy:
@@ -267,8 +270,42 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     return std::make_unique<Value>("", lenTy, emitListLength(listType, listHandle));
   }
   case BuiltinIntrinsicKind::BufferCopy:
-    return std::make_unique<Value>("", listType, emitListDeepCopy(listType, listHandle));
+    {
+      auto out = std::make_unique<Value>("", listType, emitListDeepCopy(listType, listHandle));
+      out->setArcOwnedValue(true);
+      return out;
+    }
   case BuiltinIntrinsicKind::BufferClear: {
+    if (listType->getElementType() != nullptr &&
+        TypeUtils::containsArcManagedValue(listType->getElementType())) {
+      llvm::Function* parentFunction = builder->GetInsertBlock()->getParent();
+      auto* loopCond =
+          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.cond", parentFunction);
+      auto* loopBody =
+          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.body", parentFunction);
+      auto* loopInc =
+          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.inc", parentFunction);
+      auto* releaseDone =
+          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.release.done", parentFunction);
+      auto* indexPtr = createAllocaInEntry(parentFunction, builder->getInt64Ty(), "list.clear.idx");
+      builder->CreateStore(builder->getInt64(0), indexPtr);
+      builder->CreateBr(loopCond);
+      builder->SetInsertPoint(loopCond);
+      auto* index = builder->CreateLoad(builder->getInt64Ty(), indexPtr);
+      auto* curLen = emitListLength(listType, listHandle);
+      builder->CreateCondBr(builder->CreateICmpSLT(index, curLen), loopBody, releaseDone);
+      builder->SetInsertPoint(loopBody);
+      auto* elementPtr = emitListElementPointer(node->getSpan(), listType, listHandle, index);
+      auto* elementVal = builder->CreateLoad(getListStoredElementType(listType), elementPtr);
+      emitReleaseLoadedValue(listType->getElementType(), elementVal, false);
+      builder->CreateBr(loopInc);
+      builder->SetInsertPoint(loopInc);
+      builder->CreateStore(builder->CreateAdd(builder->CreateLoad(builder->getInt64Ty(), indexPtr),
+                                              builder->getInt64(1)),
+                           indexPtr);
+      builder->CreateBr(loopCond);
+      builder->SetInsertPoint(releaseDone);
+    }
     auto* currentData = emitListDataPtr(listType, listHandle);
     llvm::Function* parentFunction = builder->GetInsertBlock()->getParent();
     auto* freeBlock =
@@ -299,9 +336,12 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
         builder->CreateGEP(getListStoredElementType(listType),
                            emitListDataPtr(listType, listHandle), length, "list.push.ptr");
     Value pushedArg("", paramTypes[1], paramsLLVM[1]);
-    builder->CreateStore(
-        getListStoredElementValue(node->getSpan(), &pushedArg, listType->getElementType()),
-        elementPtr);
+    auto* storedElement =
+        getListStoredElementValue(node->getSpan(), &pushedArg, listType->getElementType());
+    if (TypeUtils::containsArcManagedValue(listType->getElementType())) {
+      emitRetainLoadedValue(listType->getElementType(), storedElement, pushedArg.getStoresFuncValuePair());
+    }
+    builder->CreateStore(storedElement, elementPtr);
     emitStoreListLength(listType, listHandle, nextLength);
     return std::make_unique<Value>(
         "", cacheType(std::make_unique<Type>(BaseType::TY_VOID, builder->getVoidTy())), nullptr);
@@ -321,9 +361,16 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     }
     auto* elementPtr = emitListElementPointer(node->getSpan(), listType, listHandle, paramsLLVM[1]);
     Value setArg("", paramTypes[2], paramsLLVM[2]);
-    builder->CreateStore(
-        getListStoredElementValue(node->getSpan(), &setArg, listType->getElementType()),
-        elementPtr);
+    if (TypeUtils::containsArcManagedValue(listType->getElementType())) {
+      auto* oldElement = builder->CreateLoad(getListStoredElementType(listType), elementPtr);
+      emitReleaseLoadedValue(listType->getElementType(), oldElement, false);
+    }
+    auto* storedElement =
+        getListStoredElementValue(node->getSpan(), &setArg, listType->getElementType());
+    if (TypeUtils::containsArcManagedValue(listType->getElementType())) {
+      emitRetainLoadedValue(listType->getElementType(), storedElement, setArg.getStoresFuncValuePair());
+    }
+    builder->CreateStore(storedElement, elementPtr);
     return std::make_unique<Value>(
         "", cacheType(std::make_unique<Type>(BaseType::TY_VOID, builder->getVoidTy())), nullptr);
   }
@@ -374,6 +421,9 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     emitStoreListLength(listType, listHandle, newLength);
     Value popped("", listType->getElementType(), poppedValue);
     auto poppedWrapped = cast(node->getSpan(), &popped, popType);
+    if (TypeUtils::containsArcManagedValue(listType->getElementType()) && poppedWrapped != nullptr) {
+      poppedWrapped->setArcOwnedValue(true);
+    }
     llvm::BasicBlock* valueIncoming = builder->GetInsertBlock();
     builder->CreateBr(mergeBlock);
 
@@ -381,7 +431,9 @@ auto Codegen::genListIntrinsicCall(const FuncCall* node,
     auto* phi = builder->CreatePHI(popType->getLlvmType(), 2, "list.pop.result");
     phi->addIncoming(nullWrapped->getLlvmValue(), emptyBlock);
     phi->addIncoming(poppedWrapped->getLlvmValue(), valueIncoming);
-    return std::make_unique<Value>("", popType, phi);
+    auto out = std::make_unique<Value>("", popType, phi);
+    out->setArcOwnedValue(TypeUtils::containsArcManagedValue(listType->getElementType()));
+    return out;
   }
   default:
     break;

--- a/src/liblesma/Backend/CodegenImport.cpp
+++ b/src/liblesma/Backend/CodegenImport.cpp
@@ -303,10 +303,10 @@ auto Codegen::compileModule(llvm::SMRange span, const std::string& filepath, boo
     auto codegen = std::make_unique<Codegen>(
         std::move(parser), sourceManager, canonicalPath, std::vector<std::string>{}, isJit, false,
         !importToScope ? moduleAlias : "", theContext, importedModules, importedScopes,
-        importedSpecializationStates,
-        std::move(preScope), std::move(preTypeCache), std::move(preSpecEnv),
-        std::move(preTemplateOf), std::move(preSpecializedClassTypes), emitDebugInfo,
-        OptimizationLevel::O0, pendingJitModuleInits);
+        importedSpecializationStates, std::move(preScope), std::move(preTypeCache),
+        std::move(preSpecEnv), std::move(preTemplateOf), std::move(preSpecializedClassTypes),
+        emitDebugInfo, emitArcDebug, emitArcTrace, OptimizationLevel::O0, pendingJitModuleInits,
+        pendingJitModuleFinis);
     codegen->run();
     ImportedSpecializationState importedState = codegen->captureImportedSpecializationState();
     importedSpecializationStates->at(importIdx) = importedState;
@@ -332,6 +332,7 @@ auto Codegen::compileModule(llvm::SMRange span, const std::string& filepath, boo
     mergeImportedSpecializationState(importedState);
 
     std::string jitModuleInitSymbol;
+    std::string jitModuleFiniSymbol;
     if (isJit) {
       codegen->verifyIrModuleOrThrow(fmt::format("import {}", filepath));
       if (llvm::Function* importMain = codegen->theModule->getFunction("main");
@@ -340,6 +341,14 @@ auto Codegen::compileModule(llvm::SMRange span, const std::string& filepath, boo
         importMain->setName(jitModuleInitSymbol);
         importMain->setLinkage(llvm::GlobalValue::ExternalLinkage);
         importMain->setVisibility(llvm::GlobalValue::HiddenVisibility);
+      }
+      jitModuleFiniSymbol = MangleUtils::getImportedModuleFiniSymbolName(canonicalPath);
+      if (llvm::Function* importFini = codegen->theModule->getFunction(jitModuleFiniSymbol);
+          importFini != nullptr) {
+        importFini->setLinkage(llvm::GlobalValue::ExternalLinkage);
+        importFini->setVisibility(llvm::GlobalValue::HiddenVisibility);
+      } else {
+        jitModuleFiniSymbol.clear();
       }
       for (llvm::Function& fn : *codegen->theModule) {
         if (fn.hasPrivateLinkage()) {
@@ -357,6 +366,9 @@ auto Codegen::compileModule(llvm::SMRange span, const std::string& filepath, boo
       }
       if (!jitModuleInitSymbol.empty() && pendingJitModuleInits != nullptr) {
         pendingJitModuleInits->push_back(jitModuleInitSymbol);
+      }
+      if (!jitModuleFiniSymbol.empty() && pendingJitModuleFinis != nullptr) {
+        pendingJitModuleFinis->push_back(jitModuleFiniSymbol);
       }
       codegen->theModule = codegen->initializeModule();
     } else {

--- a/src/liblesma/Backend/CodegenPipeline.cpp
+++ b/src/liblesma/Backend/CodegenPipeline.cpp
@@ -57,8 +57,9 @@
 #include <llvm/Transforms/Vectorize/LoopVectorize.h>
 
 #include "Codegen.h"
-#include "liblesma/AST/AST.h"
 #include <lld/Common/Driver.h>
+
+#include "liblesma/AST/AST.h"
 
 #ifdef __APPLE__
 LLD_HAS_DRIVER(macho)
@@ -620,6 +621,7 @@ auto Codegen::run() -> void {
 
   deferStack.emplace();
   pushDeferBaseline();
+  pushArcOwnedSlotFrame();
   if (parser->getAst() != nullptr) {
     setDebugLoc(parser->getAst()->getSpan());
   }
@@ -662,8 +664,8 @@ auto Codegen::run() -> void {
     // params (e.g. `T` on `Cell<T>`) from the formal receiver (`self` or `cls`) for method bodies.
     Type* mergeClassTy = nullptr;
     if (auto* clsSym = std::get<2>(prototypes[pi]);
-        clsSym != nullptr && clsSym->getType() != nullptr && clsSym->getType()->is(BaseType::TY_PTR) &&
-        clsSym->getType()->getElementType() != nullptr) {
+        clsSym != nullptr && clsSym->getType() != nullptr &&
+        clsSym->getType()->is(BaseType::TY_PTR) && clsSym->getType()->getElementType() != nullptr) {
       mergeClassTy = clsSym->getType()->getElementType();
     }
     if (mergeClassTy == nullptr) {
@@ -730,9 +732,53 @@ auto Codegen::run() -> void {
   if (parser->getAst() != nullptr) {
     setDebugLoc(parser->getAst()->getSpan());
   }
+  auto savedIp = builder->saveIP();
+  auto* finalBlock =
+      llvm::BasicBlock::Create(theModule->getContext(), "top.level.return", topLevelFunc);
+  bool wiredFinalBlock = false;
+  for (llvm::BasicBlock& block : *topLevelFunc) {
+    if (&block == finalBlock || block.getTerminator() != nullptr) {
+      continue;
+    }
+    builder->SetInsertPoint(&block);
+    builder->CreateBr(finalBlock);
+    wiredFinalBlock = true;
+  }
+  if (!wiredFinalBlock) {
+    llvm::BasicBlock* currentBlock = builder->GetInsertBlock();
+    if (currentBlock != nullptr && currentBlock->getParent() == topLevelFunc &&
+        currentBlock->getTerminator() == nullptr) {
+      builder->CreateBr(finalBlock);
+      wiredFinalBlock = true;
+    }
+  }
+  builder->restoreIP(savedIp);
+  builder->SetInsertPoint(finalBlock);
+  emitReleaseCurrentArcOwnedSlots();
+  llvm::Function* cleanupFn = getOrCreateModuleCleanupFunction();
+  if (isMain) {
+    if (isJit) {
+      emitCallPendingJitModuleFinis();
+    }
+    if (cleanupFn != nullptr) {
+      builder->CreateCall(cleanupFn);
+    }
+    if (emitArcDebug) {
+      builder->CreateCall(getOrCreateArcDebugReportFunction());
+    }
+  }
   builder->CreateRet(ConstantInt::getSigned(builder->getInt64Ty(), 0));
+  popArcOwnedSlotFrame(false);
 
   finalizeDebugMetadata();
 }
 
 auto Codegen::dump() -> void { theModule->print(outs(), nullptr); }
+
+auto Codegen::moduleToString() const -> std::string {
+  std::string moduleText;
+  llvm::raw_string_ostream os(moduleText);
+  theModule->print(os, nullptr);
+  os.flush();
+  return moduleText;
+}

--- a/src/liblesma/Backend/CodegenPipeline.cpp
+++ b/src/liblesma/Backend/CodegenPipeline.cpp
@@ -285,6 +285,17 @@ auto Codegen::createAllocaInEntry(llvm::Function* fn, llvm::Type* elemTy, const 
   return atEntry.CreateAlloca(elemTy, nullptr, name);
 }
 
+auto Codegen::emitEntryNullInit(llvm::AllocaInst* slot, llvm::Type* storageTy) -> void {
+  llvm::Instruction* next = slot->getNextNode();
+  llvm::IRBuilder<> atEntry(slot->getContext());
+  if (next != nullptr) {
+    atEntry.SetInsertPoint(next);
+  } else {
+    atEntry.SetInsertPoint(slot->getParent());
+  }
+  atEntry.CreateStore(llvm::Constant::getNullValue(storageTy), slot);
+}
+
 auto Codegen::initializeModule() -> std::unique_ptr<Module> {
   std::unique_ptr<Module> mod;
 #if LLVM_VERSION_MAJOR >= 21

--- a/src/liblesma/Backend/CodegenRuntimeNames.h
+++ b/src/liblesma/Backend/CodegenRuntimeNames.h
@@ -17,6 +17,7 @@ inline constexpr std::string_view STRSTR = "strstr";
 inline constexpr std::string_view EXIT = "exit";
 inline constexpr std::string_view ARC_DEBUG_DELTA = "__lesma_arc_debug_delta";
 inline constexpr std::string_view ARC_DEBUG_REPORT = "__lesma_arc_debug_report";
+inline constexpr std::string_view ARC_DEBUG_LIVE_COUNT = "__lesma_arc_debug_live_count";
 inline constexpr std::string_view ARC_DEBUG_CLEANUP_BEGIN = "__lesma_arc_debug_cleanup_begin";
 inline constexpr std::string_view ARC_DEBUG_CLEANUP_STEP = "__lesma_arc_debug_cleanup_step";
 inline constexpr std::string_view ARC_DEBUG_MODULE_ROOTS_TOTAL =

--- a/src/liblesma/Backend/CodegenRuntimeNames.h
+++ b/src/liblesma/Backend/CodegenRuntimeNames.h
@@ -15,5 +15,13 @@ inline constexpr std::string_view MEMCPY = "memcpy";
 inline constexpr std::string_view STRLEN = "strlen";
 inline constexpr std::string_view STRSTR = "strstr";
 inline constexpr std::string_view EXIT = "exit";
+inline constexpr std::string_view ARC_DEBUG_DELTA = "__lesma_arc_debug_delta";
+inline constexpr std::string_view ARC_DEBUG_REPORT = "__lesma_arc_debug_report";
+inline constexpr std::string_view ARC_DEBUG_CLEANUP_BEGIN = "__lesma_arc_debug_cleanup_begin";
+inline constexpr std::string_view ARC_DEBUG_CLEANUP_STEP = "__lesma_arc_debug_cleanup_step";
+inline constexpr std::string_view ARC_DEBUG_MODULE_ROOTS_TOTAL =
+    "__lesma_arc_debug_module_roots_total";
+inline constexpr std::string_view ARC_DEBUG_MODULE_ROOTS_REMAINING =
+    "__lesma_arc_debug_module_roots_remaining";
 
 } // namespace lesma::codegen::runtime

--- a/src/liblesma/Backend/CodegenTypeUtils.cpp
+++ b/src/liblesma/Backend/CodegenTypeUtils.cpp
@@ -90,7 +90,9 @@ auto cast(llvm::SMRange span, Value* val, Type* type, llvm::IRBuilder<>* builder
     if (fromElem != nullptr && fromElem->is(BaseType::TY_CLASS)) {
       for (Type* t = fromElem; t != nullptr; t = t->getClassSuperclass()) {
         if (t->isEqual(type)) {
-          return std::make_unique<Value>("", type, val->getLlvmValue());
+          auto out = std::make_unique<Value>("", type, val->getLlvmValue());
+          out->setArcOwnedValue(val->getArcOwnedValue());
+          return out;
         }
       }
     }
@@ -128,8 +130,10 @@ auto cast(llvm::SMRange span, Value* val, Type* type, llvm::IRBuilder<>* builder
           elem != nullptr && elem->is(BaseType::TY_INT) && elem->getLlvmType() != nullptr &&
           elem->getLlvmType()->isIntegerTy() && elem->getLlvmType()->getIntegerBitWidth() == 8U;
       if (isPtrToVoid || isPtrToByte) {
-        return std::make_unique<Value>(
+        auto out = std::make_unique<Value>(
             "", type, builder->CreateBitCast(val->getLlvmValue(), type->getLlvmType()));
+        out->setArcOwnedValue(val->getArcOwnedValue());
+        return out;
       }
     }
   }
@@ -141,8 +145,10 @@ auto cast(llvm::SMRange span, Value* val, Type* type, llvm::IRBuilder<>* builder
         toElem->is(BaseType::TY_CLASS)) {
       for (Type* t = fromElem; t != nullptr; t = t->getClassSuperclass()) {
         if (t->isEqual(toElem)) {
-          return std::make_unique<Value>(
+          auto out = std::make_unique<Value>(
               "", type, builder->CreateBitCast(val->getLlvmValue(), type->getLlvmType()));
+          out->setArcOwnedValue(val->getArcOwnedValue());
+          return out;
         }
       }
     }
@@ -176,7 +182,9 @@ auto cast(llvm::SMRange span, Value* val, Type* type, llvm::IRBuilder<>* builder
       agg = builder->CreateInsertValue(agg, casted->getLlvmValue(), static_cast<unsigned>(i),
                                        "tup.cast");
     }
-    return std::make_unique<Value>("", type, agg);
+    auto out = std::make_unique<Value>("", type, agg);
+    out->setArcOwnedValue(val->getArcOwnedValue());
+    return out;
   }
 
   throw CodegenError(span, "Unsupported Cast between {} and {}",

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -19,20 +19,15 @@
 #include "liblesma/Symbol/Value.h"
 #include "liblesma/Token/TokenType.h"
 
-namespace {
+using namespace lesma;
+using namespace llvm;
 
-// `Iterator<int>` -> `Iterator` for trait registry / witness metadata keyed by trait identifier.
-auto traitExistentialBaseName(const std::string& displayName) -> std::string {
+auto Codegen::traitExistentialBaseName(const std::string& displayName) const -> std::string {
   if (const auto pos = displayName.find('<'); pos != std::string::npos) {
     return displayName.substr(0U, pos);
   }
   return displayName;
 }
-
-} // namespace
-
-using namespace lesma;
-using namespace llvm;
 
 auto Codegen::unionDiscriminantMinBits(std::size_t memberCount) -> unsigned {
   unsigned bits = 0;
@@ -659,7 +654,7 @@ auto Codegen::getOrEmitWitnessTable(lesma::Type* classType, const std::string& t
   if (auto it = witnessGlobalCache.find(cacheKey); it != witnessGlobalCache.end()) {
     return it->second;
   }
-  const std::string baseTraitName = traitExistentialBaseName(traitName);
+  const std::string baseTraitName = this->traitExistentialBaseName(traitName);
   const TraitDecl* tr = traitDeclByName[baseTraitName];
   if (tr == nullptr) {
     throw CodegenError({}, "Codegen: unknown trait {}", traitName);
@@ -728,7 +723,7 @@ auto Codegen::callExistentialMethod(llvm::SMRange span, lesma::Value* receiver,
     throw CodegenError(span, "Expected trait existential receiver for dynamic dispatch");
   }
   const std::string receiverDisplay = receiverType->getDisplayName();
-  const std::string baseTraitName = traitExistentialBaseName(receiverDisplay);
+  const std::string baseTraitName = this->traitExistentialBaseName(receiverDisplay);
   auto ordIt = traitRequirementMethodOrder.find(baseTraitName);
   if (ordIt == traitRequirementMethodOrder.end()) {
     throw CodegenError(span, "Trait {} has no codegen metadata", receiverDisplay);

--- a/src/liblesma/Backend/CodegenTypesTraits.cpp
+++ b/src/liblesma/Backend/CodegenTypesTraits.cpp
@@ -478,6 +478,9 @@ auto Codegen::getStoredAggregateFieldLlvmType(lesma::Type* fieldType) -> llvm::T
     return nullptr;
   }
   getOrCreateLlvmType(fieldType);
+  if (fieldType->is(BaseType::TY_TRAIT_EXISTENTIAL)) {
+    return fieldType->getLlvmType();
+  }
   if (TypeUtils::passesByPointerInAbi(fieldType)) {
     return builder->getPtrTy();
   }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -313,6 +313,7 @@ auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* c
   currentFunction = value;
   deferStack.emplace();
   pushDeferBaseline();
+  pushArcOwnedSlotFrame();
 
   if (value->getLlvmValue() == nullptr) {
     throw CodegenError(node->getSpan(), "Function {} is declared but has no LLVM body",
@@ -391,6 +392,7 @@ auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* c
       cur != nullptr && cur->getTerminator() == nullptr && cur->empty()) {
     lesma::Type* rt = value->getType()->getReturnType();
     if (rt != nullptr && rt->is(BaseType::TY_VOID)) {
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRetVoid();
     } else {
       builder->CreateUnreachable();
@@ -416,6 +418,7 @@ auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* c
     if (value->getType()->getReturnType()->is(BaseType::TY_VOID)) {
       // Make implicit return of void Function explicit.
       builder->SetInsertPoint(&bb);
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRetVoid();
     } else {
       throw CodegenError(node->getSpan(), "Function {} does not always return a result",
@@ -434,6 +437,7 @@ auto Codegen::defineFunction(lesma::Value* value, const FuncDecl* node, Value* c
 
   // Insert Function to Symbol Table
   scope = savedScope;
+  popArcOwnedSlotFrame(false);
 
   currentFunction = nullptr;
 
@@ -460,6 +464,7 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
   currentFunction = value;
   deferStack.emplace();
   pushDeferBaseline();
+  pushArcOwnedSlotFrame();
 
   if (value->getLlvmValue() == nullptr) {
     throw CodegenError(node->getSpan(), "Lambda specialization has no LLVM function");
@@ -525,11 +530,16 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
     Type* rt = value->getType()->getReturnType();
     flushDeferredFramesForReturn();
     if (rt != nullptr && rt->is(BaseType::TY_VOID)) {
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRetVoid();
     } else {
       if (rv == nullptr) {
         throw CodegenError(node->getSpan(), "Lambda body did not produce a value");
       }
+      if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(rt)) {
+        emitRetainLoadedValue(rt, rv, result->getStoresFuncValuePair());
+      }
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRet(rv);
     }
   } else if (node->getBlockBody() != nullptr) {
@@ -538,6 +548,7 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
       Type* rt = value->getType()->getReturnType();
       if (rt != nullptr && rt->is(BaseType::TY_VOID)) {
         flushDeferredFramesForReturn();
+        emitReleaseCurrentArcOwnedSlots();
         builder->CreateRetVoid();
       } else {
         throw CodegenError(node->getSpan(), "Non-void lambda may reach end without returning");
@@ -547,6 +558,7 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
 
   deferStack.pop();
   deferBaselineStack.pop();
+  popArcOwnedSlotFrame(false);
 
   for (BasicBlock& bb : *f) {
     if (bb.getTerminator() != nullptr) {
@@ -554,6 +566,7 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
     }
     if (value->getType()->getReturnType()->is(BaseType::TY_VOID)) {
       builder->SetInsertPoint(&bb);
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRetVoid();
     } else {
       throw CodegenError(node->getSpan(), "Lambda does not always return a result");
@@ -687,7 +700,8 @@ auto Codegen::llvmStorageTypeForVarSlot(lesma::Type* storedType, lesma::Value* e
 
 auto Codegen::emitSimpleClassPtrOrCastStore(llvm::SMRange span, llvm::Value* destPtr,
                                             std::unique_ptr<lesma::Value>& valueResult,
-                                            lesma::Type* storedType) -> llvm::Instruction* {
+                                            lesma::Type* storedType, bool releasePrevious,
+                                            bool destStoresFuncValuePair) -> llvm::Instruction* {
   std::unique_ptr<lesma::Value> unwrappedFnPair;
   lesma::Value* valueForStore = valueResult.get();
   if (valueResult->getStoresFuncValuePair()) {
@@ -708,44 +722,58 @@ auto Codegen::emitSimpleClassPtrOrCastStore(llvm::SMRange span, llvm::Value* des
       valueForStore = unwrappedFnPair.get();
     }
   }
+  llvm::Value* storedValue = nullptr;
   const bool ptrToClass = isLesmaPtrToClass(storedType);
   if (ptrToClass && valueForStore->getType() != nullptr &&
       valueForStore->getType()->is(BaseType::TY_PTR)) {
-    return builder->CreateStore(valueForStore->getLlvmValue(), destPtr);
+    storedValue = valueForStore->getLlvmValue();
+  } else {
+    lesma::Type* castTarget = ptrToClass ? storedType->getElementType() : storedType;
+    auto castVal = cast(span, valueForStore, castTarget);
+    storedValue = castVal->getLlvmValue();
   }
-  lesma::Type* castTarget = ptrToClass ? storedType->getElementType() : storedType;
-  auto castVal = cast(span, valueForStore, castTarget);
-  return builder->CreateStore(castVal->getLlvmValue(), destPtr);
+  if (!valueForStore->getArcOwnedValue() && TypeUtils::containsArcManagedValue(storedType)) {
+    emitRetainLoadedValue(storedType, storedValue, destStoresFuncValuePair);
+  }
+  if (releasePrevious && TypeUtils::containsArcManagedValue(storedType)) {
+    llvm::Type* oldStorageTy = destStoresFuncValuePair
+                                   ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                                   : getStoredAggregateFieldLlvmType(storedType);
+    emitReleaseLoadedValue(storedType, builder->CreateLoad(oldStorageTy, destPtr, "arc.store.old"),
+                           destStoresFuncValuePair);
+  }
+  return builder->CreateStore(storedValue, destPtr);
 }
 
 auto Codegen::emitExistingVarSlotInitializerStore(const VarDecl* node, llvm::Value* destPtr,
                                                   std::unique_ptr<lesma::Value>& valueResult,
                                                   lesma::Type* storedType,
-                                                  const std::string& dbgName)
+                                                  const std::string& dbgName,
+                                                  bool destStoresFuncValuePair)
     -> llvm::Instruction* {
   const bool ptrToClass = isLesmaPtrToClass(storedType);
+  llvm::Value* storedValue = nullptr;
   if (valueResult->getLlvmValue() == nullptr && storedType->is(BaseType::TY_FUNCTION) &&
       !storedType->getGenericParams().empty()) {
-    return builder->CreateStore(llvm::ConstantAggregateZero::get(getFuncValuePairLlvmType()),
-                                destPtr);
-  }
-  if (storedType->is(BaseType::TY_FUNCTION) && valueResult->getLlvmValue() != nullptr &&
-      valueResult->getLlvmValue()->getType() == getFuncValuePairLlvmType()) {
-    return builder->CreateStore(valueResult->getLlvmValue(), destPtr);
-  }
-  if (valueResult->getStoresFuncValuePair() && storedType->is(BaseType::TY_FUNCTION)) {
+    storedValue = llvm::ConstantAggregateZero::get(getFuncValuePairLlvmType());
+  } else if (storedType->is(BaseType::TY_FUNCTION) && valueResult->getLlvmValue() != nullptr &&
+             valueResult->getLlvmValue()->getType() == getFuncValuePairLlvmType()) {
+    storedValue = valueResult->getLlvmValue();
+  } else if (valueResult->getStoresFuncValuePair() && storedType->is(BaseType::TY_FUNCTION)) {
     llvm::StructType* pt = getFuncValuePairLlvmType();
-    llvm::Value* loaded =
-        builder->CreateLoad(pt, valueResult->getLlvmValue(), dbgName + ".fnpair.load");
-    return builder->CreateStore(loaded, destPtr);
+    storedValue = builder->CreateLoad(pt, valueResult->getLlvmValue(), dbgName + ".fnpair.load");
+  } else if (ptrToClass && valueResult->getType() != nullptr &&
+             valueResult->getType()->is(BaseType::TY_PTR)) {
+    storedValue = valueResult->getLlvmValue();
+  } else {
+    lesma::Type* castTarget = ptrToClass ? storedType->getElementType() : storedType;
+    auto castVal = cast(node->getSpan(), valueResult.get(), castTarget);
+    storedValue = castVal->getLlvmValue();
   }
-  if (ptrToClass && valueResult->getType() != nullptr &&
-      valueResult->getType()->is(BaseType::TY_PTR)) {
-    return builder->CreateStore(valueResult->getLlvmValue(), destPtr);
+  if (!valueResult->getArcOwnedValue() && TypeUtils::containsArcManagedValue(storedType)) {
+    emitRetainLoadedValue(storedType, storedValue, destStoresFuncValuePair);
   }
-  lesma::Type* castTarget = ptrToClass ? storedType->getElementType() : storedType;
-  auto castVal = cast(node->getSpan(), valueResult.get(), castTarget);
-  return builder->CreateStore(castVal->getLlvmValue(), destPtr);
+  return builder->CreateStore(storedValue, destPtr);
 }
 
 auto Codegen::makeBoolCompareResult(llvm::Value* cmpVal) -> std::unique_ptr<lesma::Value> {
@@ -1005,14 +1033,21 @@ auto Codegen::visit(const VarDecl* node) -> void {
           i < resolvedUnpack.size() ? resolvedUnpack[i] : scope->lookup(elemName);
       llvm::Type* allocaTy = llvmStorageTypeForVarSlot(elemTy, existing);
       llvm::AllocaInst* ptr = createAllocaInEntry(parentFct, allocaTy, elemName);
+      emitEntryNullInit(ptr, allocaTy);
+      lesma::Type* storedType = elemTy;
       if (elemTy->is(BaseType::TY_CLASS)) {
         lesma::Type* ptrType =
             cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), elemTy));
+        storedType = ptrType;
         if (existing != nullptr) {
           existing->setType(ptrType);
         }
       }
-      llvm::Instruction* st = builder->CreateStore(ev, ptr);
+      registerArcOwnedSlot(ptr, storedType, existing != nullptr && existing->getStoresFuncValuePair());
+      auto unpacked = std::make_unique<Value>("", storedType, ev);
+      llvm::Instruction* st = emitSimpleClassPtrOrCastStore(
+          node->getSpan(), ptr, unpacked, storedType, false,
+          existing != nullptr && existing->getStoresFuncValuePair());
       emitAutoVarDebugDeclare(llvm::cast<llvm::AllocaInst>(ptr), elemName, node->getSpan(), st);
       if (existing != nullptr) {
         existing->setLlvmValue(ptr);
@@ -1095,21 +1130,26 @@ auto Codegen::visit(const VarDecl* node) -> void {
       existing->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
       existing->setMutable(node->getMutability());
       if (valueResult != nullptr) {
-        emitSimpleClassPtrOrCastStore(node->getSpan(), gv, valueResult, storedType);
+        emitSimpleClassPtrOrCastStore(node->getSpan(), gv, valueResult, storedType, false,
+                                      existing->getStoresFuncValuePair());
       }
       return;
     }
 
     llvm::Function* parentFct = builder->GetInsertBlock()->getParent();
     llvm::AllocaInst* ptr = createAllocaInEntry(parentFct, storageLlvmTy, name);
+    emitEntryNullInit(ptr, storageLlvmTy);
     existing->setLlvmValue(ptr);
     existing->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
     existing->setMutable(node->getMutability());
+    registerArcOwnedSlot(ptr, storedType, existing->getStoresFuncValuePair());
     if (valueResult != nullptr) {
       llvm::Instruction* const st =
-          emitExistingVarSlotInitializerStore(node, ptr, valueResult, storedType, name);
+          emitExistingVarSlotInitializerStore(node, ptr, valueResult, storedType, name,
+                                              existing->getStoresFuncValuePair());
       emitAutoVarDebugDeclare(llvm::cast<llvm::AllocaInst>(ptr), name, node->getSpan(), st);
     } else {
+      builder->CreateStore(llvm::Constant::getNullValue(storageLlvmTy), ptr);
       emitAutoVarDebugDeclare(llvm::cast<llvm::AllocaInst>(ptr), name, node->getSpan(), nullptr);
     }
     if (node->getValue() != nullptr) {
@@ -1146,6 +1186,7 @@ auto Codegen::visit(const VarDecl* node) -> void {
   getOrCreateLlvmType(type);
   llvm::Function* parentFct = builder->GetInsertBlock()->getParent();
   llvm::AllocaInst* ptr = createAllocaInEntry(parentFct, type->getLlvmType(), name);
+  emitEntryNullInit(ptr, type->getLlvmType());
 
   if (type->is(BaseType::TY_CLASS)) {
     type = cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), type));
@@ -1155,12 +1196,15 @@ auto Codegen::visit(const VarDecl* node) -> void {
   symbol->setLlvmValue(ptr);
   symbol->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
   symbol->setMutable(node->getMutability());
+  registerArcOwnedSlot(ptr, type, symbol->getStoresFuncValuePair());
   scope->insertSymbol(std::move(symbol));
 
   if (node->getValue() != nullptr) {
-    llvm::Instruction* const st = emitSimpleClassPtrOrCastStore(node->getSpan(), ptr, val, type);
+    llvm::Instruction* const st =
+        emitSimpleClassPtrOrCastStore(node->getSpan(), ptr, val, type, false, false);
     emitAutoVarDebugDeclare(llvm::cast<llvm::AllocaInst>(ptr), name, node->getSpan(), st);
   } else {
+    builder->CreateStore(llvm::Constant::getNullValue(type->getLlvmType()), ptr);
     emitAutoVarDebugDeclare(llvm::cast<llvm::AllocaInst>(ptr), name, node->getSpan(), nullptr);
   }
 }
@@ -1447,7 +1491,9 @@ auto Codegen::emitUnionWrapValueToSlot(llvm::SMRange /*span*/, lesma::Value* val
       payPtr, llvm::PointerType::get(theModule->getContext(), 0U), "union.pay.tptr");
   builder->CreateStore(v, typedPayPtr);
   llvm::Value* agg = builder->CreateLoad(st, destSlot, "union.val");
-  return std::make_unique<lesma::Value>("", unionTy, agg);
+  auto out = std::make_unique<lesma::Value>("", unionTy, agg);
+  out->setArcOwnedValue(val != nullptr && val->getArcOwnedValue());
+  return out;
 }
 
 auto Codegen::emitUnionWrapValue(llvm::SMRange span, lesma::Value* val, lesma::Type* unionTy,
@@ -1478,10 +1524,20 @@ auto Codegen::getOrCreateAnyTypeInfoGlobal(lesma::Type* type) -> llvm::GlobalVar
     anyTypeInfoGlobals[typeName] = existing;
     return existing;
   }
-  auto* gv = new llvm::GlobalVariable(*theModule, builder->getInt8Ty(), true,
-                                      llvm::GlobalValue::LinkOnceODRLinkage, builder->getInt8(0),
-                                      globalName);
-  gv->setAlignment(llvm::MaybeAlign(1));
+  auto* typeInfoTy = llvm::StructType::getTypeByName(theModule->getContext(), "lesma.any.typeinfo");
+  if (typeInfoTy == nullptr) {
+    typeInfoTy = llvm::StructType::create(theModule->getContext(),
+                                          {builder->getPtrTy(), builder->getPtrTy()},
+                                          "lesma.any.typeinfo");
+  }
+  llvm::Constant* retainFn = llvm::ConstantExpr::getBitCast(getOrCreateArcStorageRetainFunction(type),
+                                                            builder->getPtrTy());
+  llvm::Constant* releaseFn = llvm::ConstantExpr::getBitCast(
+      getOrCreateArcStorageReleaseFunction(type), builder->getPtrTy());
+  auto* init = llvm::ConstantStruct::get(typeInfoTy, {retainFn, releaseFn});
+  auto* gv = new llvm::GlobalVariable(*theModule, typeInfoTy, true,
+                                      llvm::GlobalValue::LinkOnceODRLinkage, init, globalName);
+  gv->setAlignment(theModule->getDataLayout().getABITypeAlign(typeInfoTy));
   anyTypeInfoGlobals[typeName] = gv;
   return gv;
 }
@@ -1566,16 +1622,24 @@ auto Codegen::emitBoxToAny(llvm::SMRange span, lesma::Value* value, lesma::Type*
 
   auto* allocSize =
       builder->getInt64(theModule->getDataLayout().getTypeAllocSize(storageTy).getFixedValue());
-  llvm::Value* payloadPtr = emitMalloc(allocSize, "any.payload");
+  llvm::Value* payloadPtr =
+      emitArcAlloc(allocSize, getOrCreateArcPayloadDestroyFunction(value->getType()), "any.payload");
   llvm::Value* typedPayloadPtr = builder->CreateBitCast(
       payloadPtr, llvm::PointerType::get(theModule->getContext(), 0U), "any.payload.typed");
   builder->CreateStore(storageValue, typedPayloadPtr);
+  if (!value->getArcOwnedValue() && TypeUtils::containsArcManagedValue(value->getType())) {
+    auto* retainFn = getOrCreateArcStorageRetainFunction(value->getType());
+    auto* retainTy = llvm::FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
+    builder->CreateCall(retainTy, retainFn, {payloadPtr});
+  }
 
   llvm::Value* anyAgg = llvm::UndefValue::get(anyType->getLlvmType());
   anyAgg = builder->CreateInsertValue(anyAgg, emitAnyTypeInfoPtr(value->getType()), {0U},
                                       "any.box.typeinfo");
   anyAgg = builder->CreateInsertValue(anyAgg, payloadPtr, {1U}, "any.box.payload");
-  return std::make_unique<Value>("", anyType, anyAgg);
+  auto out = std::make_unique<Value>("", anyType, anyAgg);
+  out->setArcOwnedValue(true);
+  return out;
 }
 
 auto Codegen::emitUnboxFromAny(llvm::SMRange span, lesma::Value* value, lesma::Type* targetType)
@@ -1862,6 +1926,8 @@ auto Codegen::visit(const ForIn* node) -> void {
     llvm::AllocaInst* elemPtr = createAllocaInEntry(parentFct, allocaTy, loopVar->getName());
     loopVar->setLlvmValue(elemPtr);
     loopVar->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+    builder->CreateStore(llvm::Constant::getNullValue(allocaTy), elemPtr);
+    registerArcOwnedSlot(elemPtr, storedType, loopVar->getStoresFuncValuePair());
   }
   scope = savedScope;
 
@@ -1895,6 +1961,16 @@ auto Codegen::visit(const ForIn* node) -> void {
     emitForInLoopIteration(parentFct, node, savedScope, forBodyScope, bLoop, bInc, [&] {
       auto* elemPtr = emitListElementPointer(node->getSpan(), listType, listHandle, idxVal);
       auto* elemVal = builder->CreateLoad(getListStoredElementType(listType), elemPtr);
+      if (TypeUtils::containsArcManagedValue(loopVar->getType())) {
+        llvm::Type* loopStorageTy = loopVar->getStoresFuncValuePair()
+                                        ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                                        : getStoredAggregateFieldLlvmType(loopVar->getType());
+        emitReleaseLoadedValue(loopVar->getType(),
+                               builder->CreateLoad(loopStorageTy, loopVar->getLlvmValue(),
+                                                   "for.loopvar.old"),
+                               loopVar->getStoresFuncValuePair());
+        emitRetainLoadedValue(loopVar->getType(), elemVal, loopVar->getStoresFuncValuePair());
+      }
       builder->CreateStore(elemVal, loopVar->getLlvmValue());
     });
 
@@ -1946,6 +2022,19 @@ auto Codegen::visit(const ForIn* node) -> void {
       if (unwrapped != nullptr && loopVar != nullptr && loopVar->getType() != nullptr &&
           !unwrapped->getType()->isEqual(loopVar->getType())) {
         unwrapped = cast(node->getSpan(), unwrapped.get(), loopVar->getType());
+      }
+      if (TypeUtils::containsArcManagedValue(loopVar->getType())) {
+        llvm::Type* loopStorageTy = loopVar->getStoresFuncValuePair()
+                                        ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                                        : getStoredAggregateFieldLlvmType(loopVar->getType());
+        emitReleaseLoadedValue(loopVar->getType(),
+                               builder->CreateLoad(loopStorageTy, loopVar->getLlvmValue(),
+                                                   "for.loopvar.old"),
+                               loopVar->getStoresFuncValuePair());
+        if (!unwrapped->getArcOwnedValue()) {
+          emitRetainLoadedValue(loopVar->getType(), unwrapped->getLlvmValue(),
+                               loopVar->getStoresFuncValuePair());
+        }
       }
       builder->CreateStore(unwrapped->getLlvmValue(), loopVar->getLlvmValue());
     });
@@ -2176,6 +2265,7 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
   currentFunction = ctorSym;
   deferStack.emplace();
   pushDeferBaseline();
+  pushArcOwnedSlotFrame();
 
   if (ctorSym->getLlvmValue() == nullptr) {
     throw CodegenError(astNode->getSpan(), "Synthesized constructor has no LLVM function");
@@ -2260,6 +2350,9 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
     if (v->getValue() != nullptr) {
       v->getValue()->accept(*this);
       auto rhs = cast(v->getValue()->getSpan(), result.get(), storageTy);
+      if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(storageTy)) {
+        emitRetainLoadedValue(storageTy, rhs->getLlvmValue(), result->getStoresFuncValuePair());
+      }
       builder->CreateStore(rhs->getLlvmValue(), slotPtr);
     } else {
       Value* ps = scope->lookup(v->getIdentifier()->getValue());
@@ -2271,15 +2364,20 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
       llvm::Value* loaded =
           loadStoredAggregateFieldValue(ps->getLlvmValue(), storageTy,
                                         llvm::Twine(v->getIdentifier()->getValue()).concat(".arg"));
+      if (TypeUtils::containsArcManagedValue(storageTy)) {
+        emitRetainLoadedValue(storageTy, loaded, ps->getStoresFuncValuePair());
+      }
       builder->CreateStore(loaded, slotPtr);
     }
   }
 
   flushDeferredFramesForReturn();
+  emitReleaseCurrentArcOwnedSlots();
   builder->CreateRetVoid();
 
   deferStack.pop();
   deferBaselineStack.pop();
+  popArcOwnedSlotFrame(false);
 
   for (BasicBlock& bb : *f) {
     Instruction* terminator = bb.getTerminator();
@@ -2287,6 +2385,7 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
       continue;
     }
     builder->SetInsertPoint(&bb);
+    emitReleaseCurrentArcOwnedSlots();
     builder->CreateRetVoid();
   }
 
@@ -2888,6 +2987,17 @@ auto Codegen::visit(const Assignment* node) -> void {
     builder->SetInsertPoint(assignBlock);
     node->getRightHandSide()->accept(*this);
     auto storedValue = cast(node->getSpan(), result.get(), targetType);
+    if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(targetType)) {
+      emitRetainLoadedValue(targetType, storedValue->getLlvmValue(), lhs->getStoresFuncValuePair());
+    }
+    if (TypeUtils::containsArcManagedValue(targetType)) {
+      llvm::Type* oldStorageTy = lhs->getStoresFuncValuePair()
+                                     ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                                     : getStoredAggregateFieldLlvmType(targetType);
+      emitReleaseLoadedValue(
+          targetType, builder->CreateLoad(oldStorageTy, lhs->getLlvmValue(), "assign.coalesce.old"),
+          lhs->getStoresFuncValuePair());
+    }
     builder->CreateStore(storedValue->getLlvmValue(), lhs->getLlvmValue());
     builder->CreateBr(mergeBlock);
 
@@ -2904,6 +3014,11 @@ auto Codegen::visit(const Assignment* node) -> void {
     if (rhsAgg->getType()->isPointerTy()) {
       rhsAgg = builder->CreateLoad(pt, rhsAgg, "fnval.assign");
     }
+    if (!result->getArcOwnedValue()) {
+      emitRetainLoadedValue(lhs->getType(), rhsAgg, true);
+    }
+    emitReleaseLoadedValue(lhs->getType(), builder->CreateLoad(pt, lhs->getLlvmValue(), "fnval.old"),
+                           true);
     builder->CreateStore(rhsAgg, lhs->getLlvmValue());
     lhs->setClosureCalleeUsesEnvParameter(result->getClosureCalleeUsesEnvParameter());
     return;
@@ -2914,6 +3029,18 @@ auto Codegen::visit(const Assignment* node) -> void {
   case TokenType::EQUAL: {
     auto value = cast(node->getSpan(), result.get(),
                       isPtr ? lhs->getType()->getElementType() : lhs->getType());
+    lesma::Type* storeType = isPtr ? lhs->getType()->getElementType() : lhs->getType();
+    if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(storeType)) {
+      emitRetainLoadedValue(storeType, value->getLlvmValue(), lhs->getStoresFuncValuePair());
+    }
+    if (TypeUtils::containsArcManagedValue(storeType)) {
+      llvm::Type* oldStorageTy = lhs->getStoresFuncValuePair()
+                                     ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
+                                     : getStoredAggregateFieldLlvmType(storeType);
+      emitReleaseLoadedValue(
+          storeType, builder->CreateLoad(oldStorageTy, lhs->getLlvmValue(), "assign.old"),
+          lhs->getStoresFuncValuePair());
+    }
     builder->CreateStore(value->getLlvmValue(), lhs->getLlvmValue());
     break;
   }
@@ -2979,6 +3106,7 @@ auto Codegen::visit(const Return* node) -> void {
 
   if (node->getValue() == nullptr) {
     if (currentFunction->getType()->getReturnType()->is(BaseType::TY_VOID)) {
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRetVoid();
     } else {
       throw CodegenError(node->getSpan(),
@@ -3003,6 +3131,10 @@ auto Codegen::visit(const Return* node) -> void {
       if (result->getCategory() == ValueCategory::ADDRESSABLE_STORAGE) {
         toRet = builder->CreateLoad(pt, toRet, "ret.fnval");
       }
+      if (!result->getArcOwnedValue()) {
+        emitRetainLoadedValue(actualType, toRet, true);
+      }
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRet(toRet);
       return;
     }
@@ -3025,6 +3157,10 @@ auto Codegen::visit(const Return* node) -> void {
     llvm::Type* expectedReturnType =
         declaredClass != nullptr ? builder->getPtrTy() : builder->getCurrentFunctionReturnType();
     if (actualReturnType == expectedReturnType) {
+      if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(actualType)) {
+        emitRetainLoadedValue(actualType, result->getLlvmValue(), false);
+      }
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRet(result->getLlvmValue());
     } else {
       throw CodegenError(node->getSpan(),
@@ -3244,14 +3380,23 @@ auto Codegen::emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* ast
           builder->CreateStore(llvm::ConstantAggregateZero::get(getFuncValuePairLlvmType()), gv);
         } else if (valueResult->getLlvmValue() != nullptr &&
                    valueResult->getLlvmValue()->getType() == getFuncValuePairLlvmType()) {
+          if (!valueResult->getArcOwnedValue()) {
+            emitRetainLoadedValue(fieldTy, valueResult->getLlvmValue(), true);
+          }
           builder->CreateStore(valueResult->getLlvmValue(), gv);
         } else if (valueResult->getStoresFuncValuePair()) {
           llvm::StructType* pt = getFuncValuePairLlvmType();
           llvm::Value* loaded = builder->CreateLoad(pt, valueResult->getLlvmValue(),
                                                     sym->getName() + ".sfnpair.init");
+          if (!valueResult->getArcOwnedValue()) {
+            emitRetainLoadedValue(fieldTy, loaded, true);
+          }
           builder->CreateStore(loaded, gv);
         } else {
           auto rhs = cast(vd->getValue()->getSpan(), valueResult, fieldTy);
+          if (!valueResult->getArcOwnedValue() && TypeUtils::containsArcManagedValue(fieldTy)) {
+            emitRetainLoadedValue(fieldTy, rhs->getLlvmValue(), false);
+          }
           builder->CreateStore(rhs->getLlvmValue(), gv);
         }
         if (valueResult->getStoresFuncValuePair() &&
@@ -3267,6 +3412,9 @@ auto Codegen::emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* ast
         }
       } else {
         auto rhs = cast(vd->getValue()->getSpan(), valueResult, fieldTy);
+        if (!valueResult->getArcOwnedValue() && TypeUtils::containsArcManagedValue(fieldTy)) {
+          emitRetainLoadedValue(fieldTy, rhs->getLlvmValue(), false);
+        }
         builder->CreateStore(rhs->getLlvmValue(), gv);
       }
     }
@@ -3368,6 +3516,7 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
   currentFunction = resolved;
   deferStack.emplace();
   pushDeferBaseline();
+  pushArcOwnedSlotFrame();
   BasicBlock* entry = BasicBlock::Create(theModule->getContext(), "entry", f);
   builder->SetInsertPoint(entry);
   setDebugLoc(node->getSpan());
@@ -3421,11 +3570,16 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
     llvm::Value* rv = result != nullptr ? result->getLlvmValue() : nullptr;
     flushDeferredFramesForReturn();
     if (retType->is(BaseType::TY_VOID)) {
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRetVoid();
     } else {
       if (rv == nullptr) {
         throw CodegenError(node->getSpan(), "Lambda expression body did not produce a value");
       }
+      if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(retType)) {
+        emitRetainLoadedValue(retType, rv, result->getStoresFuncValuePair());
+      }
+      emitReleaseCurrentArcOwnedSlots();
       builder->CreateRet(rv);
     }
   } else if (node->getBlockBody() != nullptr) {
@@ -3433,6 +3587,7 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
     if (builder->GetInsertBlock()->getTerminator() == nullptr) {
       flushDeferredFramesForReturn();
       if (retType->is(BaseType::TY_VOID)) {
+        emitReleaseCurrentArcOwnedSlots();
         builder->CreateRetVoid();
       } else {
         throw CodegenError(node->getSpan(), "Non-void lambda may reach end without returning");
@@ -3449,6 +3604,7 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
   currentFunction = savedCurrentFunction;
   deferStack.pop();
   deferBaselineStack.pop();
+  popArcOwnedSlotFrame(false);
   builder->SetInsertPoint(resumeBlock);
   builder->SetCurrentDebugLocation(llvm::DebugLoc());
 
@@ -3459,9 +3615,16 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
   llvm::Value* envStoreVal = llvm::ConstantPointerNull::get(builder->getPtrTy());
   if (!caps.empty()) {
     llvm::Type* i64Ty = builder->getInt64Ty();
+    std::vector<lesma::Type*> captureTypes;
+    captureTypes.reserve(caps.size());
+    for (Value* outer : caps) {
+      captureTypes.push_back(outer != nullptr ? outer->getType() : nullptr);
+    }
     llvm::Value* envSize = llvm::ConstantInt::get(
         i64Ty, theModule->getDataLayout().getTypeAllocSize(envStructTy).getFixedValue());
-    envStoreVal = emitMalloc(envSize, lambdaName + ".env");
+    envStoreVal = emitArcAlloc(
+        envSize, getOrCreateArcClosureDestroyFunction(lambdaName, envStructTy, captureTypes),
+        lambdaName + ".env");
     llvm::Value* typedEnv =
         builder->CreateBitCast(envStoreVal, llvm::PointerType::get(envStructTy->getContext(), 0U));
     for (size_t i = 0; i < caps.size(); ++i) {
@@ -3474,6 +3637,9 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
       getOrCreateLlvmType(outerTy);
       llvm::Value* v = builder->CreateLoad(outerTy->getLlvmType(), outer->getLlvmValue(),
                                            outer->getName() + ".v");
+      if (TypeUtils::containsArcManagedValue(outerTy)) {
+        emitRetainLoadedValue(outerTy, v, outer->getStoresFuncValuePair());
+      }
       llvm::Value* slot =
           builder->CreateStructGEP(envStructTy, typedEnv, static_cast<unsigned>(i), "cap.slot");
       builder->CreateStore(v, slot);
@@ -3488,6 +3654,7 @@ auto Codegen::visit(const LambdaExpr* node) -> void {
   out->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
   out->setStoresFuncValuePair(true);
   out->setClosureCalleeUsesEnvParameter(!caps.empty());
+  out->setArcOwnedValue(!caps.empty());
   result = std::move(out);
 }
 
@@ -4860,7 +5027,8 @@ auto Codegen::visit(const ListLiteral* node) -> void {
     auto* structType = cast<llvm::StructType>(getOrCreateLlvmType(listType));
     auto* classSize =
         builder->getInt64(theModule->getDataLayout().getTypeAllocSize(structType).getFixedValue());
-    auto* classHandle = emitMalloc(classSize, "list.obj");
+    auto* classHandle =
+        emitArcAlloc(classSize, getOrCreateArcDestroyFunction(listType), "list.obj");
     emitInitClassVtablePointer(listType, classHandle);
     unsigned const bufIdx = TypeUtils::classDataFieldStructIndex(listType, 0U);
     auto* storagePtr =
@@ -4869,7 +5037,8 @@ auto Codegen::visit(const ListLiteral* node) -> void {
     auto* listStructTy = getOrCreateListStructType(bufferType);
     auto* headerSize = builder->getInt64(
         theModule->getDataLayout().getTypeAllocSize(listStructTy).getFixedValue());
-    auto* bufferHandle = emitMalloc(headerSize, "list.header");
+    auto* bufferHandle =
+        emitArcAlloc(headerSize, getOrCreateArcDestroyFunction(bufferType), "list.header");
     llvm::Value* dataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
     auto elements = node->getElements();
     if (!elements.empty()) {
@@ -4883,9 +5052,14 @@ auto Codegen::visit(const ListLiteral* node) -> void {
         setDebugLoc(node->getSpan());
         auto* elementPtr =
             builder->CreateGEP(elementLlvmType, dataPtr, builder->getInt64(i), "list.elem.ptr");
-        builder->CreateStore(
-            getListStoredElementValue(node->getSpan(), result.get(), bufferType->getElementType()),
-            elementPtr);
+        auto* storedElement =
+            getListStoredElementValue(node->getSpan(), result.get(), bufferType->getElementType());
+        if (!result->getArcOwnedValue() &&
+            TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
+          emitRetainLoadedValue(bufferType->getElementType(), storedElement,
+                               result->getStoresFuncValuePair());
+        }
+        builder->CreateStore(storedElement, elementPtr);
       }
     }
     auto* count = builder->getInt64(elements.size());
@@ -4894,6 +5068,7 @@ auto Codegen::visit(const ListLiteral* node) -> void {
     emitStoreListCapacity(bufferType, bufferHandle, count);
     builder->CreateStore(bufferHandle, storagePtr);
     result = std::make_unique<Value>("", listType, classHandle);
+    result->setArcOwnedValue(true);
     return;
   }
   if (listType == nullptr || !listType->is(BaseType::TY_ARRAY) ||
@@ -4908,7 +5083,7 @@ auto Codegen::visit(const ListLiteral* node) -> void {
   std::vector<Expression*> elements = node->getElements();
   auto* headerSize =
       builder->getInt64(theModule->getDataLayout().getTypeAllocSize(listStructTy).getFixedValue());
-  auto* listHandle = emitMalloc(headerSize, "list.header");
+  auto* listHandle = emitArcAlloc(headerSize, getOrCreateArcDestroyFunction(listType), "list.header");
 
   llvm::Value* dataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
   if (!elements.empty()) {
@@ -4922,8 +5097,12 @@ auto Codegen::visit(const ListLiteral* node) -> void {
       setDebugLoc(node->getSpan());
       auto* elementPtr =
           builder->CreateGEP(elementLlvmType, dataPtr, builder->getInt64(i), "list.elem.ptr");
-      builder->CreateStore(
-          getListStoredElementValue(elements[i]->getSpan(), result.get(), elementType), elementPtr);
+      auto* storedElement =
+          getListStoredElementValue(elements[i]->getSpan(), result.get(), elementType);
+      if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(elementType)) {
+        emitRetainLoadedValue(elementType, storedElement, result->getStoresFuncValuePair());
+      }
+      builder->CreateStore(storedElement, elementPtr);
     }
   }
 
@@ -4932,6 +5111,7 @@ auto Codegen::visit(const ListLiteral* node) -> void {
   emitStoreListLength(listType, listHandle, count);
   emitStoreListCapacity(listType, listHandle, count);
   result = std::make_unique<Value>("", listType, listHandle);
+  result->setArcOwnedValue(true);
 }
 
 auto Codegen::visit(const DictLiteral* node) -> void {
@@ -4956,7 +5136,7 @@ auto Codegen::visit(const DictLiteral* node) -> void {
   auto* structType = cast<llvm::StructType>(getOrCreateLlvmType(dictType));
   auto* classSize =
       builder->getInt64(theModule->getDataLayout().getTypeAllocSize(structType).getFixedValue());
-  auto* classHandle = emitMalloc(classSize, "dict.obj");
+  auto* classHandle = emitArcAlloc(classSize, getOrCreateArcDestroyFunction(dictType), "dict.obj");
   emitInitClassVtablePointer(dictType, classHandle);
   unsigned const keysIdx = TypeUtils::classDataFieldStructIndex(dictType, 0U);
   unsigned const valsIdx = TypeUtils::classDataFieldStructIndex(dictType, 1U);
@@ -4973,13 +5153,13 @@ auto Codegen::visit(const DictLiteral* node) -> void {
   auto* keysListStructTy = getOrCreateListStructType(keysBufferType);
   auto* valsListStructTy = getOrCreateListStructType(valsBufferType);
   auto* keysHeader =
-      emitMalloc(builder->getInt64(
-                     theModule->getDataLayout().getTypeAllocSize(keysListStructTy).getFixedValue()),
-                 "dict.keys.header");
+      emitArcAlloc(builder->getInt64(
+                       theModule->getDataLayout().getTypeAllocSize(keysListStructTy).getFixedValue()),
+                   getOrCreateArcDestroyFunction(keysBufferType), "dict.keys.header");
   auto* valsHeader =
-      emitMalloc(builder->getInt64(
-                     theModule->getDataLayout().getTypeAllocSize(valsListStructTy).getFixedValue()),
-                 "dict.vals.header");
+      emitArcAlloc(builder->getInt64(
+                       theModule->getDataLayout().getTypeAllocSize(valsListStructTy).getFixedValue()),
+                   getOrCreateArcDestroyFunction(valsBufferType), "dict.vals.header");
 
   llvm::Value* keysDataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
   llvm::Value* valsDataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
@@ -5002,15 +5182,21 @@ auto Codegen::visit(const DictLiteral* node) -> void {
       setDebugLoc(node->getSpan());
       auto* keyPtr = builder->CreateGEP(keysElementLlvmType, keysDataPtr, builder->getInt64(i),
                                         "dict.key.elem.ptr");
-      builder->CreateStore(getListStoredElementValue(keys[i]->getSpan(), result.get(), keyElemType),
-                           keyPtr);
+      auto* storedKey = getListStoredElementValue(keys[i]->getSpan(), result.get(), keyElemType);
+      if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(keyElemType)) {
+        emitRetainLoadedValue(keyElemType, storedKey, result->getStoresFuncValuePair());
+      }
+      builder->CreateStore(storedKey, keyPtr);
 
       values[i]->accept(*this);
       setDebugLoc(node->getSpan());
       auto* valPtr = builder->CreateGEP(valsElementLlvmType, valsDataPtr, builder->getInt64(i),
                                         "dict.val.elem.ptr");
-      builder->CreateStore(
-          getListStoredElementValue(values[i]->getSpan(), result.get(), valElemType), valPtr);
+      auto* storedVal = getListStoredElementValue(values[i]->getSpan(), result.get(), valElemType);
+      if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(valElemType)) {
+        emitRetainLoadedValue(valElemType, storedVal, result->getStoresFuncValuePair());
+      }
+      builder->CreateStore(storedVal, valPtr);
     }
   }
 
@@ -5024,6 +5210,7 @@ auto Codegen::visit(const DictLiteral* node) -> void {
   builder->CreateStore(keysHeader, keysFieldPtr);
   builder->CreateStore(valsHeader, valsFieldPtr);
   result = std::make_unique<Value>("", dictType, classHandle);
+  result->setArcOwnedValue(true);
 }
 
 auto Codegen::visit(const TupleLiteral* node) -> void {
@@ -5038,6 +5225,7 @@ auto Codegen::visit(const TupleLiteral* node) -> void {
   llvm::Value* agg = llvm::UndefValue::get(st);
   std::vector<Expression*> const elements = node->getElements();
   std::vector<Field*> const fields = tupleType->getFields();
+  bool tupleOwnsArcValue = false;
   if (elements.size() != fields.size()) {
     throw CodegenError(node->getSpan(), "Tuple literal element count mismatch");
   }
@@ -5046,8 +5234,10 @@ auto Codegen::visit(const TupleLiteral* node) -> void {
     setDebugLoc(node->getSpan());
     llvm::Value* ev = result->getLlvmValue();
     agg = builder->CreateInsertValue(agg, ev, static_cast<unsigned>(i), "tuple");
+    tupleOwnsArcValue = tupleOwnsArcValue || (result != nullptr && result->getArcOwnedValue());
   }
   result = std::make_unique<Value>("", tupleType, agg);
+  result->setArcOwnedValue(tupleOwnsArcValue);
 }
 
 auto Codegen::visit(const Literal* node) -> void {
@@ -5069,22 +5259,8 @@ auto Codegen::visit(const Literal* node) -> void {
   } else if (node->getType() == TokenType::STRING) {
     lesma::Type* strClass = node->getResolvedStrClassType();
     if (strClass != nullptr && strClass->is(BaseType::TY_CLASS)) {
-      auto fields = strClass->getFields();
-      if (fields.empty() || fields.front()->type == nullptr ||
-          !fields.front()->type->is(BaseType::TY_STRING)) {
-        throw CodegenError(node->getSpan(), "String literal resolved to invalid stdlib str class");
-      }
-      auto* structType = cast<llvm::StructType>(getOrCreateLlvmType(strClass));
-      auto* classSize = builder->getInt64(
-          theModule->getDataLayout().getTypeAllocSize(structType).getFixedValue());
-      auto* classHandle = emitMalloc(classSize, "str.obj");
-      emitInitClassVtablePointer(strClass, classHandle);
-      unsigned const strFieldIdx = TypeUtils::classDataFieldStructIndex(strClass, 0U);
-      auto* storagePtr =
-          builder->CreateStructGEP(structType, classHandle, strFieldIdx, "str.storage.ptr");
-      llvm::Value* globalStr = builder->CreateGlobalString(node->getValue());
-      builder->CreateStore(globalStr, storagePtr);
-      result = std::make_unique<Value>("", strClass, classHandle);
+      result = emitBoxedStrWithCstrField(node->getSpan(), builder->CreateGlobalString(node->getValue()),
+                                         strClass);
     } else {
       auto* type = cacheType(std::make_unique<Type>(BaseType::TY_STRING, builder->getPtrTy()));
       result = std::make_unique<Value>("", type, builder->CreateGlobalString(node->getValue()));
@@ -5280,25 +5456,7 @@ auto Codegen::emitFormatFloatToCstr(llvm::SMRange span, llvm::Value* floatVal, l
 
 auto Codegen::emitBoxedStrLiteralText(llvm::SMRange span, const std::string& text,
                                       lesma::Type* strClass) -> std::unique_ptr<lesma::Value> {
-  if (strClass == nullptr || !strClass->is(BaseType::TY_CLASS)) {
-    throw CodegenError(span, "Invalid str class for string interpolation chunk");
-  }
-  auto fields = strClass->getFields();
-  if (fields.empty() || fields.front()->type == nullptr ||
-      !fields.front()->type->is(BaseType::TY_STRING)) {
-    throw CodegenError(span, "String interpolation chunk: invalid stdlib str class");
-  }
-  auto* structType = llvm::cast<llvm::StructType>(getOrCreateLlvmType(strClass));
-  auto* classSize =
-      builder->getInt64(theModule->getDataLayout().getTypeAllocSize(structType).getFixedValue());
-  auto* classHandle = emitMalloc(classSize, "ip.str.obj");
-  emitInitClassVtablePointer(strClass, classHandle);
-  unsigned const strFieldIdx = TypeUtils::classDataFieldStructIndex(strClass, 0U);
-  auto* storagePtr =
-      builder->CreateStructGEP(structType, classHandle, strFieldIdx, "ip.str.storage.ptr");
-  llvm::Value* globalStr = builder->CreateGlobalString(text);
-  builder->CreateStore(globalStr, storagePtr);
-  return std::make_unique<Value>("", strClass, classHandle);
+  return emitBoxedStrWithCstrField(span, builder->CreateGlobalString(text), strClass);
 }
 
 auto Codegen::emitBoxedStrWithCstrField(llvm::SMRange span, llvm::Value* nulTerminatedPtr,
@@ -5314,13 +5472,22 @@ auto Codegen::emitBoxedStrWithCstrField(llvm::SMRange span, llvm::Value* nulTerm
   auto* structType = llvm::cast<llvm::StructType>(getOrCreateLlvmType(strClass));
   auto* classSize =
       builder->getInt64(theModule->getDataLayout().getTypeAllocSize(structType).getFixedValue());
-  auto* classHandle = emitMalloc(classSize, "ip.str.dyn");
+  auto* classHandle =
+      emitArcAlloc(classSize, getOrCreateArcDestroyFunction(strClass), "ip.str.dyn");
   emitInitClassVtablePointer(strClass, classHandle);
   unsigned const strFieldIdx2 = TypeUtils::classDataFieldStructIndex(strClass, 0U);
   auto* storagePtr =
       builder->CreateStructGEP(structType, classHandle, strFieldIdx2, "ip.str.dyn.ptr");
-  builder->CreateStore(nulTerminatedPtr, storagePtr);
-  return std::make_unique<Value>("", strClass, classHandle);
+  llvm::Value* ownedCstr = nulTerminatedPtr;
+  if (!isOwnedMallocCstrBuffer(nulTerminatedPtr)) {
+    auto* strdupTy = llvm::FunctionType::get(builder->getPtrTy(), {builder->getPtrTy()}, false);
+    llvm::FunctionCallee strdupFn = theModule->getOrInsertFunction("strdup", strdupTy);
+    ownedCstr = builder->CreateCall(strdupFn, {nulTerminatedPtr}, "ip.strdup");
+  }
+  builder->CreateStore(ownedCstr, storagePtr);
+  auto out = std::make_unique<Value>("", strClass, classHandle);
+  out->setArcOwnedValue(true);
+  return out;
 }
 
 auto Codegen::emitInterpolationExprToCstr(llvm::SMRange span, const Expression* expr,
@@ -6082,7 +6249,8 @@ auto Codegen::callNamedFunction(
     auto* classLlvmType = getOrCreateLlvmType(classSym->getType());
     auto* classSize = builder->getInt64(
         theModule->getDataLayout().getTypeAllocSize(classLlvmType).getFixedValue());
-    classPtr = emitMalloc(classSize, functionName + ".obj");
+    classPtr = emitArcAlloc(classSize, getOrCreateArcDestroyFunction(classSym->getType()),
+                            functionName + ".obj");
     emitInitClassVtablePointer(classSym->getType(), classPtr);
     localParamsLLVM.insert(localParamsLLVM.begin(), classPtr);
     lesma::Type* selfArgTy = cacheType(
@@ -6481,7 +6649,9 @@ auto Codegen::callNamedFunction(
 
   if (classSym != nullptr && classSym->getType()->is(BaseType::TY_CLASS)) {
     selfSymbol = selfSymbolTmp;
-    return std::make_unique<Value>("", classSym->getType(), classPtr);
+    auto out = std::make_unique<Value>("", classSym->getType(), classPtr);
+    out->setArcOwnedValue(true);
+    return out;
   }
 
   selfSymbol = selfSymbolTmp;
@@ -6490,6 +6660,9 @@ auto Codegen::callNamedFunction(
   if (retLesma != nullptr && retLesma->is(BaseType::TY_FUNCTION)) {
     callResult->setStoresFuncValuePair(true);
     callResult->setCategory(ValueCategory::DIRECT_VALUE);
+  }
+  if (retLesma != nullptr && TypeUtils::containsArcManagedValue(retLesma)) {
+    callResult->setArcOwnedValue(true);
   }
   return callResult;
 }
@@ -6554,6 +6727,36 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     return std::make_unique<Value>("", type, emitListLength(bufferType, bufferHandle));
   }
   if (methodName == "clear") {
+    if (bufferType->getElementType() != nullptr &&
+        TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
+      llvm::Function* parentFunction = builder->GetInsertBlock()->getParent();
+      auto* loopCond =
+          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.cond", parentFunction);
+      auto* loopBody =
+          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.body", parentFunction);
+      auto* loopInc =
+          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.inc", parentFunction);
+      auto* releaseDone =
+          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.release.done", parentFunction);
+      auto* indexPtr = createAllocaInEntry(parentFunction, builder->getInt64Ty(), "list.clear.idx");
+      builder->CreateStore(builder->getInt64(0), indexPtr);
+      builder->CreateBr(loopCond);
+      builder->SetInsertPoint(loopCond);
+      auto* index = builder->CreateLoad(builder->getInt64Ty(), indexPtr);
+      auto* length = emitListLength(bufferType, bufferHandle);
+      builder->CreateCondBr(builder->CreateICmpSLT(index, length), loopBody, releaseDone);
+      builder->SetInsertPoint(loopBody);
+      auto* elementPtr = emitListElementPointer(span, bufferType, bufferHandle, index);
+      auto* elementVal = builder->CreateLoad(getListStoredElementType(bufferType), elementPtr);
+      emitReleaseLoadedValue(bufferType->getElementType(), elementVal, false);
+      builder->CreateBr(loopInc);
+      builder->SetInsertPoint(loopInc);
+      builder->CreateStore(builder->CreateAdd(builder->CreateLoad(builder->getInt64Ty(), indexPtr),
+                                              builder->getInt64(1)),
+                           indexPtr);
+      builder->CreateBr(loopCond);
+      builder->SetInsertPoint(releaseDone);
+    }
     auto* currentData = emitListDataPtr(bufferType, bufferHandle);
     llvm::Function* parentFunction = builder->GetInsertBlock()->getParent();
     auto* freeBlock =
@@ -6584,8 +6787,13 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     auto* elementPtr =
         builder->CreateGEP(getListStoredElementType(bufferType),
                            emitListDataPtr(bufferType, bufferHandle), length, "list.push.ptr");
-    builder->CreateStore(getListStoredElementValue(span, args[0], bufferType->getElementType()),
-                         elementPtr);
+    auto* storedElement = getListStoredElementValue(span, args[0], bufferType->getElementType());
+    if (!args[0]->getArcOwnedValue() &&
+        TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
+      emitRetainLoadedValue(bufferType->getElementType(), storedElement,
+                           args[0]->getStoresFuncValuePair());
+    }
+    builder->CreateStore(storedElement, elementPtr);
     emitStoreListLength(bufferType, bufferHandle, nextLength);
     return std::make_unique<Value>(
         "", cacheType(std::make_unique<Type>(BaseType::TY_VOID, builder->getVoidTy())), nullptr);
@@ -6636,6 +6844,9 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     emitStoreListLength(bufferType, bufferHandle, newLength);
     Value popped("", bufferType->getElementType(), poppedValue);
     auto poppedWrapped = cast(span, &popped, popType);
+    if (TypeUtils::containsArcManagedValue(bufferType->getElementType()) && poppedWrapped != nullptr) {
+      poppedWrapped->setArcOwnedValue(true);
+    }
     llvm::BasicBlock* valueIncoming = builder->GetInsertBlock();
     builder->CreateBr(mergeBlock);
 
@@ -6648,18 +6859,23 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
   if (methodName == "copy") {
     auto* copiedBuffer = emitListDeepCopy(bufferType, bufferHandle);
     if (listClassType == nullptr) {
-      return std::make_unique<Value>("", bufferType, copiedBuffer);
+      auto out = std::make_unique<Value>("", bufferType, copiedBuffer);
+      out->setArcOwnedValue(true);
+      return out;
     }
     auto* classLlvmType = getOrCreateLlvmType(listClassType);
     auto* classSize = builder->getInt64(
         theModule->getDataLayout().getTypeAllocSize(classLlvmType).getFixedValue());
-    auto* classHandle = emitMalloc(classSize, "list.copy.obj");
+    auto* classHandle =
+        emitArcAlloc(classSize, getOrCreateArcDestroyFunction(listClassType), "list.copy.obj");
     emitInitClassVtablePointer(listClassType, classHandle);
     unsigned const copyBufIdx = TypeUtils::classDataFieldStructIndex(listClassType, 0U);
     auto* storagePtr = builder->CreateStructGEP(cast<llvm::StructType>(classLlvmType), classHandle,
                                                 copyBufIdx, "list.copy.storage.ptr");
     builder->CreateStore(copiedBuffer, storagePtr);
-    return std::make_unique<Value>("", listClassType, classHandle);
+    auto out = std::make_unique<Value>("", listClassType, classHandle);
+    out->setArcOwnedValue(true);
+    return out;
   }
   if (methodName == std::string{OperatorUtils::SUBSCRIPT_GET_NAME}) {
     if (args.size() != 1U) {
@@ -6677,8 +6893,17 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     }
     auto* elementPtr =
         emitListElementPointer(span, bufferType, bufferHandle, args[0]->getLlvmValue());
-    builder->CreateStore(getListStoredElementValue(span, args[1], bufferType->getElementType()),
-                         elementPtr);
+    if (TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
+      auto* oldElement = builder->CreateLoad(getListStoredElementType(bufferType), elementPtr);
+      emitReleaseLoadedValue(bufferType->getElementType(), oldElement, false);
+    }
+    auto* storedElement = getListStoredElementValue(span, args[1], bufferType->getElementType());
+    if (!args[1]->getArcOwnedValue() &&
+        TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
+      emitRetainLoadedValue(bufferType->getElementType(), storedElement,
+                           args[1]->getStoresFuncValuePair());
+    }
+    builder->CreateStore(storedElement, elementPtr);
     return std::make_unique<Value>(
         "", cacheType(std::make_unique<Type>(BaseType::TY_VOID, builder->getVoidTy())), nullptr);
   }

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1935,9 +1935,15 @@ auto Codegen::visit(const ForIn* node) -> void {
   llvm::BasicBlock* bInc = llvm::BasicBlock::Create(theModule->getContext(), "for.inc");
   llvm::BasicBlock* bEnd = llvm::BasicBlock::Create(theModule->getContext(), "for.end");
   std::unique_ptr<lesma::Value> iteratorValue;
+  llvm::AllocaInst* iteratorSlot = nullptr;
   llvm::AllocaInst* indexPtr = nullptr;
   if (!useArrayIndex) {
     iteratorValue = callMethodByName(node->getSpan(), iterable.get(), "iter");
+    if (iteratorValue != nullptr && TypeUtils::isArcReferenceType(iteratorValue->getType())) {
+      iteratorSlot = createAllocaInEntry(parentFct, builder->getPtrTy(), "for.iter.slot");
+      emitEntryNullInit(iteratorSlot, builder->getPtrTy());
+      builder->CreateStore(iteratorValue->getLlvmValue(), iteratorSlot);
+    }
   } else {
     getOrCreateLlvmType(listType);
     indexPtr = createAllocaInEntry(parentFct, builder->getInt64Ty(), "for.index");
@@ -2032,6 +2038,9 @@ auto Codegen::visit(const ForIn* node) -> void {
 
   bEnd->insertInto(parentFct);
   builder->SetInsertPoint(bEnd);
+  if (iteratorSlot != nullptr) {
+    emitArcReleaseNullable(builder->CreateLoad(builder->getPtrTy(), iteratorSlot, "for.iter"));
+  }
   breakBlocks.pop();
   continueBlocks.pop();
 

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1043,11 +1043,12 @@ auto Codegen::visit(const VarDecl* node) -> void {
           existing->setType(ptrType);
         }
       }
-      registerArcOwnedSlot(ptr, storedType, existing != nullptr && existing->getStoresFuncValuePair());
+      registerArcOwnedSlot(ptr, storedType,
+                           existing != nullptr && existing->getStoresFuncValuePair());
       auto unpacked = std::make_unique<Value>("", storedType, ev);
-      llvm::Instruction* st = emitSimpleClassPtrOrCastStore(
-          node->getSpan(), ptr, unpacked, storedType, false,
-          existing != nullptr && existing->getStoresFuncValuePair());
+      llvm::Instruction* st =
+          emitSimpleClassPtrOrCastStore(node->getSpan(), ptr, unpacked, storedType, false,
+                                        existing != nullptr && existing->getStoresFuncValuePair());
       emitAutoVarDebugDeclare(llvm::cast<llvm::AllocaInst>(ptr), elemName, node->getSpan(), st);
       if (existing != nullptr) {
         existing->setLlvmValue(ptr);
@@ -1144,9 +1145,8 @@ auto Codegen::visit(const VarDecl* node) -> void {
     existing->setMutable(node->getMutability());
     registerArcOwnedSlot(ptr, storedType, existing->getStoresFuncValuePair());
     if (valueResult != nullptr) {
-      llvm::Instruction* const st =
-          emitExistingVarSlotInitializerStore(node, ptr, valueResult, storedType, name,
-                                              existing->getStoresFuncValuePair());
+      llvm::Instruction* const st = emitExistingVarSlotInitializerStore(
+          node, ptr, valueResult, storedType, name, existing->getStoresFuncValuePair());
       emitAutoVarDebugDeclare(llvm::cast<llvm::AllocaInst>(ptr), name, node->getSpan(), st);
     } else {
       builder->CreateStore(llvm::Constant::getNullValue(storageLlvmTy), ptr);
@@ -1526,12 +1526,11 @@ auto Codegen::getOrCreateAnyTypeInfoGlobal(lesma::Type* type) -> llvm::GlobalVar
   }
   auto* typeInfoTy = llvm::StructType::getTypeByName(theModule->getContext(), "lesma.any.typeinfo");
   if (typeInfoTy == nullptr) {
-    typeInfoTy = llvm::StructType::create(theModule->getContext(),
-                                          {builder->getPtrTy(), builder->getPtrTy()},
-                                          "lesma.any.typeinfo");
+    typeInfoTy = llvm::StructType::create(
+        theModule->getContext(), {builder->getPtrTy(), builder->getPtrTy()}, "lesma.any.typeinfo");
   }
-  llvm::Constant* retainFn = llvm::ConstantExpr::getBitCast(getOrCreateArcStorageRetainFunction(type),
-                                                            builder->getPtrTy());
+  llvm::Constant* retainFn = llvm::ConstantExpr::getBitCast(
+      getOrCreateArcStorageRetainFunction(type), builder->getPtrTy());
   llvm::Constant* releaseFn = llvm::ConstantExpr::getBitCast(
       getOrCreateArcStorageReleaseFunction(type), builder->getPtrTy());
   auto* init = llvm::ConstantStruct::get(typeInfoTy, {retainFn, releaseFn});
@@ -1622,8 +1621,8 @@ auto Codegen::emitBoxToAny(llvm::SMRange span, lesma::Value* value, lesma::Type*
 
   auto* allocSize =
       builder->getInt64(theModule->getDataLayout().getTypeAllocSize(storageTy).getFixedValue());
-  llvm::Value* payloadPtr =
-      emitArcAlloc(allocSize, getOrCreateArcPayloadDestroyFunction(value->getType()), "any.payload");
+  llvm::Value* payloadPtr = emitArcAlloc(
+      allocSize, getOrCreateArcPayloadDestroyFunction(value->getType()), "any.payload");
   llvm::Value* typedPayloadPtr = builder->CreateBitCast(
       payloadPtr, llvm::PointerType::get(theModule->getContext(), 0U), "any.payload.typed");
   builder->CreateStore(storageValue, typedPayloadPtr);
@@ -1965,10 +1964,10 @@ auto Codegen::visit(const ForIn* node) -> void {
         llvm::Type* loopStorageTy = loopVar->getStoresFuncValuePair()
                                         ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
                                         : getStoredAggregateFieldLlvmType(loopVar->getType());
-        emitReleaseLoadedValue(loopVar->getType(),
-                               builder->CreateLoad(loopStorageTy, loopVar->getLlvmValue(),
-                                                   "for.loopvar.old"),
-                               loopVar->getStoresFuncValuePair());
+        emitReleaseLoadedValue(
+            loopVar->getType(),
+            builder->CreateLoad(loopStorageTy, loopVar->getLlvmValue(), "for.loopvar.old"),
+            loopVar->getStoresFuncValuePair());
         emitRetainLoadedValue(loopVar->getType(), elemVal, loopVar->getStoresFuncValuePair());
       }
       builder->CreateStore(elemVal, loopVar->getLlvmValue());
@@ -2019,24 +2018,11 @@ auto Codegen::visit(const ForIn* node) -> void {
     emitForInLoopIteration(parentFct, node, savedScope, forBodyScope, bLoop, bInc, [&] {
       auto unwrapped =
           materializeNarrowedUnionValue(nextValue.get(), payloadType, "for.next.unwrap");
-      if (unwrapped != nullptr && loopVar != nullptr && loopVar->getType() != nullptr &&
-          !unwrapped->getType()->isEqual(loopVar->getType())) {
-        unwrapped = cast(node->getSpan(), unwrapped.get(), loopVar->getType());
+      if (unwrapped == nullptr) {
+        throw CodegenError(node->getSpan(), "For-in iterator item could not be unwrapped");
       }
-      if (TypeUtils::containsArcManagedValue(loopVar->getType())) {
-        llvm::Type* loopStorageTy = loopVar->getStoresFuncValuePair()
-                                        ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
-                                        : getStoredAggregateFieldLlvmType(loopVar->getType());
-        emitReleaseLoadedValue(loopVar->getType(),
-                               builder->CreateLoad(loopStorageTy, loopVar->getLlvmValue(),
-                                                   "for.loopvar.old"),
-                               loopVar->getStoresFuncValuePair());
-        if (!unwrapped->getArcOwnedValue()) {
-          emitRetainLoadedValue(loopVar->getType(), unwrapped->getLlvmValue(),
-                               loopVar->getStoresFuncValuePair());
-        }
-      }
-      builder->CreateStore(unwrapped->getLlvmValue(), loopVar->getLlvmValue());
+      emitSimpleClassPtrOrCastStore(node->getSpan(), loopVar->getLlvmValue(), unwrapped,
+                                    loopVar->getType(), true, loopVar->getStoresFuncValuePair());
     });
 
     bInc->insertInto(parentFct);
@@ -3017,8 +3003,8 @@ auto Codegen::visit(const Assignment* node) -> void {
     if (!result->getArcOwnedValue()) {
       emitRetainLoadedValue(lhs->getType(), rhsAgg, true);
     }
-    emitReleaseLoadedValue(lhs->getType(), builder->CreateLoad(pt, lhs->getLlvmValue(), "fnval.old"),
-                           true);
+    emitReleaseLoadedValue(lhs->getType(),
+                           builder->CreateLoad(pt, lhs->getLlvmValue(), "fnval.old"), true);
     builder->CreateStore(rhsAgg, lhs->getLlvmValue());
     lhs->setClosureCalleeUsesEnvParameter(result->getClosureCalleeUsesEnvParameter());
     return;
@@ -3037,9 +3023,9 @@ auto Codegen::visit(const Assignment* node) -> void {
       llvm::Type* oldStorageTy = lhs->getStoresFuncValuePair()
                                      ? static_cast<llvm::Type*>(getFuncValuePairLlvmType())
                                      : getStoredAggregateFieldLlvmType(storeType);
-      emitReleaseLoadedValue(
-          storeType, builder->CreateLoad(oldStorageTy, lhs->getLlvmValue(), "assign.old"),
-          lhs->getStoresFuncValuePair());
+      emitReleaseLoadedValue(storeType,
+                             builder->CreateLoad(oldStorageTy, lhs->getLlvmValue(), "assign.old"),
+                             lhs->getStoresFuncValuePair());
     }
     builder->CreateStore(value->getLlvmValue(), lhs->getLlvmValue());
     break;
@@ -5057,7 +5043,7 @@ auto Codegen::visit(const ListLiteral* node) -> void {
         if (!result->getArcOwnedValue() &&
             TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
           emitRetainLoadedValue(bufferType->getElementType(), storedElement,
-                               result->getStoresFuncValuePair());
+                                result->getStoresFuncValuePair());
         }
         builder->CreateStore(storedElement, elementPtr);
       }
@@ -5083,7 +5069,8 @@ auto Codegen::visit(const ListLiteral* node) -> void {
   std::vector<Expression*> elements = node->getElements();
   auto* headerSize =
       builder->getInt64(theModule->getDataLayout().getTypeAllocSize(listStructTy).getFixedValue());
-  auto* listHandle = emitArcAlloc(headerSize, getOrCreateArcDestroyFunction(listType), "list.header");
+  auto* listHandle =
+      emitArcAlloc(headerSize, getOrCreateArcDestroyFunction(listType), "list.header");
 
   llvm::Value* dataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
   if (!elements.empty()) {
@@ -5152,14 +5139,14 @@ auto Codegen::visit(const DictLiteral* node) -> void {
 
   auto* keysListStructTy = getOrCreateListStructType(keysBufferType);
   auto* valsListStructTy = getOrCreateListStructType(valsBufferType);
-  auto* keysHeader =
-      emitArcAlloc(builder->getInt64(
-                       theModule->getDataLayout().getTypeAllocSize(keysListStructTy).getFixedValue()),
-                   getOrCreateArcDestroyFunction(keysBufferType), "dict.keys.header");
-  auto* valsHeader =
-      emitArcAlloc(builder->getInt64(
-                       theModule->getDataLayout().getTypeAllocSize(valsListStructTy).getFixedValue()),
-                   getOrCreateArcDestroyFunction(valsBufferType), "dict.vals.header");
+  auto* keysHeader = emitArcAlloc(
+      builder->getInt64(
+          theModule->getDataLayout().getTypeAllocSize(keysListStructTy).getFixedValue()),
+      getOrCreateArcDestroyFunction(keysBufferType), "dict.keys.header");
+  auto* valsHeader = emitArcAlloc(
+      builder->getInt64(
+          theModule->getDataLayout().getTypeAllocSize(valsListStructTy).getFixedValue()),
+      getOrCreateArcDestroyFunction(valsBufferType), "dict.vals.header");
 
   llvm::Value* keysDataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
   llvm::Value* valsDataPtr = llvm::ConstantPointerNull::get(builder->getPtrTy());
@@ -5259,8 +5246,8 @@ auto Codegen::visit(const Literal* node) -> void {
   } else if (node->getType() == TokenType::STRING) {
     lesma::Type* strClass = node->getResolvedStrClassType();
     if (strClass != nullptr && strClass->is(BaseType::TY_CLASS)) {
-      result = emitBoxedStrWithCstrField(node->getSpan(), builder->CreateGlobalString(node->getValue()),
-                                         strClass);
+      result = emitBoxedStrWithCstrField(node->getSpan(),
+                                         builder->CreateGlobalString(node->getValue()), strClass);
     } else {
       auto* type = cacheType(std::make_unique<Type>(BaseType::TY_STRING, builder->getPtrTy()));
       result = std::make_unique<Value>("", type, builder->CreateGlobalString(node->getValue()));
@@ -6736,8 +6723,8 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
           llvm::BasicBlock::Create(theModule->getContext(), "list.clear.body", parentFunction);
       auto* loopInc =
           llvm::BasicBlock::Create(theModule->getContext(), "list.clear.inc", parentFunction);
-      auto* releaseDone =
-          llvm::BasicBlock::Create(theModule->getContext(), "list.clear.release.done", parentFunction);
+      auto* releaseDone = llvm::BasicBlock::Create(theModule->getContext(),
+                                                   "list.clear.release.done", parentFunction);
       auto* indexPtr = createAllocaInEntry(parentFunction, builder->getInt64Ty(), "list.clear.idx");
       builder->CreateStore(builder->getInt64(0), indexPtr);
       builder->CreateBr(loopCond);
@@ -6791,7 +6778,7 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     if (!args[0]->getArcOwnedValue() &&
         TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
       emitRetainLoadedValue(bufferType->getElementType(), storedElement,
-                           args[0]->getStoresFuncValuePair());
+                            args[0]->getStoresFuncValuePair());
     }
     builder->CreateStore(storedElement, elementPtr);
     emitStoreListLength(bufferType, bufferHandle, nextLength);
@@ -6844,7 +6831,8 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     emitStoreListLength(bufferType, bufferHandle, newLength);
     Value popped("", bufferType->getElementType(), poppedValue);
     auto poppedWrapped = cast(span, &popped, popType);
-    if (TypeUtils::containsArcManagedValue(bufferType->getElementType()) && poppedWrapped != nullptr) {
+    if (TypeUtils::containsArcManagedValue(bufferType->getElementType()) &&
+        poppedWrapped != nullptr) {
       poppedWrapped->setArcOwnedValue(true);
     }
     llvm::BasicBlock* valueIncoming = builder->GetInsertBlock();
@@ -6901,7 +6889,7 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     if (!args[1]->getArcOwnedValue() &&
         TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
       emitRetainLoadedValue(bufferType->getElementType(), storedElement,
-                           args[1]->getStoresFuncValuePair());
+                            args[1]->getStoresFuncValuePair());
     }
     builder->CreateStore(storedElement, elementPtr);
     return std::make_unique<Value>(

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -194,8 +194,10 @@ Codegen::Codegen(
         preSpecializedClassTypeEnvs,
     std::unordered_map<lesma::Type*, lesma::Type*> preSpecializedClassTemplateOf,
     std::unordered_map<std::string, lesma::Type*> preSpecializedClassTypesByKey, bool emitDebug,
+    bool emitArcDebugArg, bool emitArcTraceArg,
     llvm::OptimizationLevel optimizationLevelForDebugArg,
-    std::shared_ptr<std::vector<std::string>> sharedPendingJitModuleInits) {
+    std::shared_ptr<std::vector<std::string>> sharedPendingJitModuleInits,
+    std::shared_ptr<std::vector<std::string>> sharedPendingJitModuleFinis) {
   InitializeNativeTarget();
   InitializeNativeTargetAsmPrinter();
   InitializeNativeTargetAsmParser();
@@ -234,6 +236,11 @@ Codegen::Codegen(
   } else if (jit) {
     pendingJitModuleInits = std::make_shared<std::vector<std::string>>();
   }
+  if (sharedPendingJitModuleFinis != nullptr) {
+    pendingJitModuleFinis = std::move(sharedPendingJitModuleFinis);
+  } else if (jit) {
+    pendingJitModuleFinis = std::make_shared<std::vector<std::string>>();
+  }
 
   if (sharedModules && sharedScopes) {
     importedModules = std::move(sharedModules);
@@ -248,6 +255,8 @@ Codegen::Codegen(
     importedSpecializationStates = std::make_shared<std::vector<ImportedSpecializationState>>();
   }
   emitDebugInfo = emitDebug;
+  emitArcDebug = emitArcDebugArg || emitArcTraceArg;
+  emitArcTrace = emitArcTraceArg;
   optimizationLevelForDebug = optimizationLevelForDebugArg;
   initializeDebugMetadata();
   topLevelFunc = initializeTopLevel();
@@ -720,6 +729,7 @@ auto Codegen::emitSimpleClassPtrOrCastStore(llvm::SMRange span, llvm::Value* des
       unwrappedFnPair = std::make_unique<Value>("", valueResult->getType(), payload);
       unwrappedFnPair->setStoresFuncValuePair(false);
       unwrappedFnPair->setCategory(valueResult->getCategory());
+      unwrappedFnPair->setArcOwnedValue(valueResult->getArcOwnedValue());
       valueForStore = unwrappedFnPair.get();
     }
   }
@@ -1131,6 +1141,7 @@ auto Codegen::visit(const VarDecl* node) -> void {
       existing->setMangledName(mangled);
       existing->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
       existing->setMutable(node->getMutability());
+      registerModuleArcRoot(gv, storedType, filename + "::" + name, existing->getStoresFuncValuePair());
       if (valueResult != nullptr) {
         emitSimpleClassPtrOrCastStore(node->getSpan(), gv, valueResult, storedType, false,
                                       existing->getStoresFuncValuePair());
@@ -3369,6 +3380,7 @@ auto Codegen::emitClassStaticFieldGlobals(lesma::Type* classTy, const Class* ast
                                         llvm::GlobalValue::PrivateLinkage, init, gvName);
     sym->setLlvmValue(gv);
     sym->setCategory(ValueCategory::ADDRESSABLE_STORAGE);
+    registerModuleArcRoot(gv, fieldTy, gvName, sym->getStoresFuncValuePair());
     if (vd->getValue() != nullptr) {
       vd->getValue()->accept(*this);
       auto* valueResult = result.get();
@@ -3743,6 +3755,10 @@ auto Codegen::visit(const BinaryOp* node) -> void {
     phi->addIncoming(leftValue, leftIncoming);
     phi->addIncoming(rightValue, rightIncoming);
     result = std::make_unique<Value>("", payloadType, phi);
+    if (TypeUtils::containsArcManagedValue(payloadType) && leftPayload->getArcOwnedValue() &&
+        (right != nullptr && right->getArcOwnedValue())) {
+      result->setArcOwnedValue(true);
+    }
     if (payloadType->is(BaseType::TY_FUNCTION)) {
       result->setStoresFuncValuePair(true);
       result->setCategory(ValueCategory::DIRECT_VALUE);
@@ -4523,6 +4539,9 @@ void Codegen::lowerDotOpSuperMethodCall(const DotOp* node) {
     llvm::Value* callResult = builder->CreateCall(calleeFn, finalParams);
     currentGenericTypes = std::move(savedGenerics);
     result = std::make_unique<Value>("", returnTy, callResult);
+    if (returnTy != nullptr && TypeUtils::containsArcManagedValue(returnTy)) {
+      result->setArcOwnedValue(true);
+    }
     if (returnTy != nullptr && returnTy->is(BaseType::TY_FUNCTION)) {
       result->setStoresFuncValuePair(true);
       result->setCategory(ValueCategory::DIRECT_VALUE);
@@ -5576,6 +5595,22 @@ auto Codegen::cast(llvm::SMRange span, lesma::Value* val, lesma::Type* type)
   if (type != nullptr && type->is(BaseType::TY_ANY) && val != nullptr &&
       val->getType() != nullptr) {
     return emitBoxToAny(span, val, type);
+  }
+  if (type != nullptr && type->is(BaseType::TY_TRAIT_EXISTENTIAL) && val != nullptr &&
+      val->getType() != nullptr) {
+    lesma::Type* actualType = val->getType();
+    llvm::Value* actualValue = val->getLlvmValue();
+    if (actualType->is(BaseType::TY_CLASS)) {
+      actualType =
+          cacheType(std::make_unique<Type>(BaseType::TY_PTR, builder->getPtrTy(), actualType));
+    }
+    if (actualType->is(BaseType::TY_PTR) && actualType->getElementType() != nullptr &&
+        actualType->getElementType()->is(BaseType::TY_CLASS)) {
+      auto out = std::make_unique<lesma::Value>(
+          "", type, emitBoxClassToExistential(type, actualType, actualValue));
+      out->setArcOwnedValue(val->getArcOwnedValue());
+      return out;
+    }
   }
   if (type != nullptr && type->is(BaseType::TY_UNION) && val != nullptr &&
       val->getType() != nullptr) {
@@ -7016,7 +7051,11 @@ auto Codegen::emitUnionClassMethodDispatch(llvm::SMRange span, lesma::Value* uni
   for (unsigned j = 0; j < phiVals.size(); ++j) {
     phi->addIncoming(phiVals[j], phiBBs[j]);
   }
-  return std::make_unique<lesma::Value>("", commonRetTy, phi);
+  auto out = std::make_unique<lesma::Value>("", commonRetTy, phi);
+  if (commonRetTy != nullptr && TypeUtils::containsArcManagedValue(commonRetTy)) {
+    out->setArcOwnedValue(true);
+  }
+  return out;
 }
 
 auto Codegen::callMethodByName(llvm::SMRange span, lesma::Value* receiver,

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -558,7 +558,6 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
 
   deferStack.pop();
   deferBaselineStack.pop();
-  popArcOwnedSlotFrame(false);
 
   for (BasicBlock& bb : *f) {
     if (bb.getTerminator() != nullptr) {
@@ -572,6 +571,8 @@ auto Codegen::defineLambdaFunction(lesma::Value* value, const LambdaExpr* node) 
       throw CodegenError(node->getSpan(), "Lambda does not always return a result");
     }
   }
+
+  popArcOwnedSlotFrame(false);
 
   isReturn = false;
   std::string verifyOutput;
@@ -2372,7 +2373,6 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
 
   deferStack.pop();
   deferBaselineStack.pop();
-  popArcOwnedSlotFrame(false);
 
   for (BasicBlock& bb : *f) {
     Instruction* terminator = bb.getTerminator();
@@ -2383,6 +2383,8 @@ auto Codegen::defineSynthesizedClassConstructor(lesma::Value* ctorSym, const Cla
     emitReleaseCurrentArcOwnedSlots();
     builder->CreateRetVoid();
   }
+
+  popArcOwnedSlotFrame(false);
 
   isReturn = false;
   std::string verifyOutput;
@@ -6851,7 +6853,11 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     auto* phi = builder->CreatePHI(popType->getLlvmType(), 2, "list.pop.result");
     phi->addIncoming(nullWrapped->getLlvmValue(), emptyBlock);
     phi->addIncoming(poppedWrapped->getLlvmValue(), valueIncoming);
-    return std::make_unique<Value>("", popType, phi);
+    auto out = std::make_unique<Value>("", popType, phi);
+    if (TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
+      out->setArcOwnedValue(true);
+    }
+    return out;
   }
   if (methodName == "copy") {
     auto* copiedBuffer = emitListDeepCopy(bufferType, bufferHandle);
@@ -6890,15 +6896,15 @@ auto Codegen::callListMethodByName(llvm::SMRange span, lesma::Value* receiver,
     }
     auto* elementPtr =
         emitListElementPointer(span, bufferType, bufferHandle, args[0]->getLlvmValue());
-    if (TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
-      auto* oldElement = builder->CreateLoad(getListStoredElementType(bufferType), elementPtr);
-      emitReleaseLoadedValue(bufferType->getElementType(), oldElement, false);
-    }
     auto* storedElement = getListStoredElementValue(span, args[1], bufferType->getElementType());
     if (!args[1]->getArcOwnedValue() &&
         TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
       emitRetainLoadedValue(bufferType->getElementType(), storedElement,
                             args[1]->getStoresFuncValuePair());
+    }
+    if (TypeUtils::containsArcManagedValue(bufferType->getElementType())) {
+      auto* oldElement = builder->CreateLoad(getListStoredElementType(bufferType), elementPtr);
+      emitReleaseLoadedValue(bufferType->getElementType(), oldElement, false);
     }
     builder->CreateStore(storedElement, elementPtr);
     return std::make_unique<Value>(

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -1944,6 +1944,7 @@ auto Codegen::visit(const ForIn* node) -> void {
       iteratorSlot = createAllocaInEntry(parentFct, builder->getPtrTy(), "for.iter.slot");
       emitEntryNullInit(iteratorSlot, builder->getPtrTy());
       builder->CreateStore(iteratorValue->getLlvmValue(), iteratorSlot);
+      registerArcOwnedSlot(iteratorSlot, iteratorValue->getType(), false);
     }
   } else {
     getOrCreateLlvmType(listType);
@@ -2041,6 +2042,7 @@ auto Codegen::visit(const ForIn* node) -> void {
   builder->SetInsertPoint(bEnd);
   if (iteratorSlot != nullptr) {
     emitArcReleaseNullable(builder->CreateLoad(builder->getPtrTy(), iteratorSlot, "for.iter"));
+    builder->CreateStore(llvm::ConstantPointerNull::get(builder->getPtrTy()), iteratorSlot);
   }
   breakBlocks.pop();
   continueBlocks.pop();

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -5333,7 +5333,7 @@ namespace {
   if (t->is(BaseType::TY_PTR) && t->getElementType() != nullptr) {
     b = t->getElementType();
   }
-  return b->is(BaseType::TY_CLASS) && b->getDisplayName() == "str";
+  return b->isBuiltinStringClass();
 }
 
 /// Pointers we may free after copying in \c emitCstrConcatValues: results of \c emitMalloc (format

--- a/src/liblesma/Backend/CodegenVisit.cpp
+++ b/src/liblesma/Backend/CodegenVisit.cpp
@@ -734,6 +734,7 @@ auto Codegen::emitSimpleClassPtrOrCastStore(llvm::SMRange span, llvm::Value* des
     }
   }
   llvm::Value* storedValue = nullptr;
+  bool storedOwnsArcValue = valueForStore->getArcOwnedValue();
   const bool ptrToClass = isLesmaPtrToClass(storedType);
   if (ptrToClass && valueForStore->getType() != nullptr &&
       valueForStore->getType()->is(BaseType::TY_PTR)) {
@@ -742,8 +743,9 @@ auto Codegen::emitSimpleClassPtrOrCastStore(llvm::SMRange span, llvm::Value* des
     lesma::Type* castTarget = ptrToClass ? storedType->getElementType() : storedType;
     auto castVal = cast(span, valueForStore, castTarget);
     storedValue = castVal->getLlvmValue();
+    storedOwnsArcValue = castVal->getArcOwnedValue();
   }
-  if (!valueForStore->getArcOwnedValue() && TypeUtils::containsArcManagedValue(storedType)) {
+  if (!storedOwnsArcValue && TypeUtils::containsArcManagedValue(storedType)) {
     emitRetainLoadedValue(storedType, storedValue, destStoresFuncValuePair);
   }
   if (releasePrevious && TypeUtils::containsArcManagedValue(storedType)) {
@@ -764,6 +766,7 @@ auto Codegen::emitExistingVarSlotInitializerStore(const VarDecl* node, llvm::Val
     -> llvm::Instruction* {
   const bool ptrToClass = isLesmaPtrToClass(storedType);
   llvm::Value* storedValue = nullptr;
+  bool storedOwnsArcValue = valueResult->getArcOwnedValue();
   if (valueResult->getLlvmValue() == nullptr && storedType->is(BaseType::TY_FUNCTION) &&
       !storedType->getGenericParams().empty()) {
     storedValue = llvm::ConstantAggregateZero::get(getFuncValuePairLlvmType());
@@ -780,8 +783,9 @@ auto Codegen::emitExistingVarSlotInitializerStore(const VarDecl* node, llvm::Val
     lesma::Type* castTarget = ptrToClass ? storedType->getElementType() : storedType;
     auto castVal = cast(node->getSpan(), valueResult.get(), castTarget);
     storedValue = castVal->getLlvmValue();
+    storedOwnsArcValue = castVal->getArcOwnedValue();
   }
-  if (!valueResult->getArcOwnedValue() && TypeUtils::containsArcManagedValue(storedType)) {
+  if (!storedOwnsArcValue && TypeUtils::containsArcManagedValue(storedType)) {
     emitRetainLoadedValue(storedType, storedValue, destStoresFuncValuePair);
   }
   return builder->CreateStore(storedValue, destPtr);
@@ -1554,7 +1558,8 @@ auto Codegen::getOrCreateAnyTypeInfoGlobal(lesma::Type* type) -> llvm::GlobalVar
 }
 
 auto Codegen::emitAnyTypeInfoPtr(lesma::Type* type) -> llvm::Value* {
-  return builder->CreateBitCast(getOrCreateAnyTypeInfoGlobal(type), builder->getPtrTy(),
+  lesma::Type* canonicalType = isLesmaPtrToClass(type) ? type->getElementType() : type;
+  return builder->CreateBitCast(getOrCreateAnyTypeInfoGlobal(canonicalType), builder->getPtrTy(),
                                 "any.typeinfo");
 }
 
@@ -2997,7 +3002,7 @@ auto Codegen::visit(const Assignment* node) -> void {
     builder->SetInsertPoint(assignBlock);
     node->getRightHandSide()->accept(*this);
     auto storedValue = cast(node->getSpan(), result.get(), targetType);
-    if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(targetType)) {
+    if (!storedValue->getArcOwnedValue() && TypeUtils::containsArcManagedValue(targetType)) {
       emitRetainLoadedValue(targetType, storedValue->getLlvmValue(), lhs->getStoresFuncValuePair());
     }
     if (TypeUtils::containsArcManagedValue(targetType)) {
@@ -3040,7 +3045,7 @@ auto Codegen::visit(const Assignment* node) -> void {
     auto value = cast(node->getSpan(), result.get(),
                       isPtr ? lhs->getType()->getElementType() : lhs->getType());
     lesma::Type* storeType = isPtr ? lhs->getType()->getElementType() : lhs->getType();
-    if (!result->getArcOwnedValue() && TypeUtils::containsArcManagedValue(storeType)) {
+    if (!value->getArcOwnedValue() && TypeUtils::containsArcManagedValue(storeType)) {
       emitRetainLoadedValue(storeType, value->getLlvmValue(), lhs->getStoresFuncValuePair());
     }
     if (TypeUtils::containsArcManagedValue(storeType)) {
@@ -5252,8 +5257,16 @@ auto Codegen::visit(const TupleLiteral* node) -> void {
     elements[i]->accept(*this);
     setDebugLoc(node->getSpan());
     llvm::Value* ev = result->getLlvmValue();
+    bool const elementOwned = result != nullptr && result->getArcOwnedValue();
+    bool const elementNeedsArc =
+        fields[i]->type != nullptr && TypeUtils::containsArcManagedValue(fields[i]->type);
+    if (elementNeedsArc) {
+      if (!elementOwned) {
+        emitRetainLoadedValue(fields[i]->type, ev, false);
+      }
+      tupleOwnsArcValue = true;
+    }
     agg = builder->CreateInsertValue(agg, ev, static_cast<unsigned>(i), "tuple");
-    tupleOwnsArcValue = tupleOwnsArcValue || (result != nullptr && result->getArcOwnedValue());
   }
   result = std::make_unique<Value>("", tupleType, agg);
   result->setArcOwnedValue(tupleOwnsArcValue);

--- a/src/liblesma/Backend/MangleUtils.cpp
+++ b/src/liblesma/Backend/MangleUtils.cpp
@@ -145,4 +145,12 @@ auto getImportedModuleInitSymbolName(const std::string& modulePathNormalized) ->
   unsigned long long const h = stableHash64(norm);
   return fmt::format("__lesma_mod_init_{:x}", static_cast<unsigned long long>(h));
 }
+
+auto getImportedModuleFiniSymbolName(const std::string& modulePathNormalized) -> std::string {
+  std::string const norm = modulePathNormalized.empty()
+                               ? std::string("<stdin>")
+                               : normalizeResolvedFilesystemPath(modulePathNormalized);
+  unsigned long long const h = stableHash64(norm);
+  return fmt::format("__lesma_mod_fini_{:x}", static_cast<unsigned long long>(h));
+}
 } // namespace lesma::MangleUtils

--- a/src/liblesma/Backend/MangleUtils.h
+++ b/src/liblesma/Backend/MangleUtils.h
@@ -15,5 +15,7 @@ auto getGlobalVariableSymbolName(const std::string& modulePathNormalized,
                                  const std::string& variableName) -> std::string;
 /** Unique per-module top-level init symbol for JIT (replaces internal `main`). */
 auto getImportedModuleInitSymbolName(const std::string& modulePathNormalized) -> std::string;
+/** Unique per-module ARC cleanup symbol for JIT shutdown ordering. */
+auto getImportedModuleFiniSymbolName(const std::string& modulePathNormalized) -> std::string;
 } // namespace MangleUtils
 } // namespace lesma

--- a/src/liblesma/Common/Utils.h
+++ b/src/liblesma/Common/Utils.h
@@ -38,6 +38,10 @@ struct CLIOptions {
   bool emitDebugInfo = false;
   /** When true, do not print compiler warnings to stderr. */
   bool suppressWarnings = false;
+  /** Emit debug-only ARC live-object diagnostics in generated code. */
+  bool arcDebug = false;
+  /** Emit verbose ARC retain/release/alloc/free trace lines in generated code. */
+  bool arcTrace = false;
 };
 
 template <typename S, typename... Args>

--- a/src/liblesma/Driver/Driver.cpp
+++ b/src/liblesma/Driver/Driver.cpp
@@ -138,7 +138,7 @@ auto lesma::analyze(std::unique_ptr<Options> options, Timer* phaseTimer) -> Anal
   try {
     maybeTimed(phaseTimer, "Parsing", [&]() -> void {
       parser = std::make_unique<Parser>(lexer->getTokens(), &result.diagnostics, srcMgr,
-                                       mainBufferId, result.mainFilePath);
+                                        mainBufferId, result.mainFilePath);
       parser->parse();
       if ((options->debug & Debug::AST) != Debug::NONE) {
         Compound* ast = parser->getAst();
@@ -217,6 +217,8 @@ auto Driver::baseCompile(std::unique_ptr<lesma::Options> options, bool jit) -> i
   Debug debugFlags = options->debug;
   llvm::OptimizationLevel const optLevel = options->optimizationLevel;
   bool const emitDebugInfo = options->emitDebugInfo;
+  bool const emitArcDebug = options->arcDebug || options->arcTrace;
+  bool const emitArcTrace = options->arcTrace;
   bool const timerEnabled = options->timer;
 
   auto result = analyze(std::move(options), timerEnabled ? &timer : nullptr);
@@ -242,11 +244,10 @@ auto Driver::baseCompile(std::unique_ptr<lesma::Options> options, bool jit) -> i
         auto cg = std::make_unique<Codegen>(
             std::move(result.parser), result.sourceMgr,
             result.mainFilePath.empty() ? "" : result.mainFilePath, modules, jit, true, "", nullptr,
-            nullptr, nullptr,             nullptr, std::move(result.rootScope),
-            std::move(result.typeCache),
+            nullptr, nullptr, nullptr, std::move(result.rootScope), std::move(result.typeCache),
             std::move(result.specializedTypeEnv), std::move(result.specializedTypeToTemplate),
-            std::move(result.specializedClassTypes),
-            emitDebugInfo, optLevel);
+            std::move(result.specializedClassTypes), emitDebugInfo, emitArcDebug, emitArcTrace,
+            optLevel);
         cg->run();
         return cg;
       });

--- a/src/liblesma/Driver/Driver.h
+++ b/src/liblesma/Driver/Driver.h
@@ -48,6 +48,10 @@ struct Options {
   bool emitDebugInfo = false;
   /** When true, Driver does not print warnings to stderr (diagnostics still collected). */
   bool suppressWarnings = false;
+  /** Emit debug-only ARC live-object diagnostics in generated code. */
+  bool arcDebug = false;
+  /** Emit verbose ARC retain/release/alloc/free trace lines in generated code. */
+  bool arcTrace = false;
 };
 
 class Driver {

--- a/src/liblesma/Symbol/Type.h
+++ b/src/liblesma/Symbol/Type.h
@@ -85,6 +85,8 @@ class Type {
   /** True once another class declares this type as its base (needs vtable dispatch via base ptr).
    */
   bool classHasDerivedClass = false;
+  /** Marks the stdlib `str` class type so callers do not rely on display-name string checks. */
+  bool builtinStringClass = false;
   std::string genericName;
   std::string displayName;
   /** Declared generic parameter names in order (for TY_CLASS and TY_FUNCTION). */
@@ -220,6 +222,8 @@ public:
   auto setClassSuperclass(Type* super) -> void { classSuperclass = super; }
   [[nodiscard]] auto getClassHasDerivedClass() const -> bool { return classHasDerivedClass; }
   auto setClassHasDerivedClass(bool value) -> void { classHasDerivedClass = value; }
+  [[nodiscard]] auto isBuiltinStringClass() const -> bool { return builtinStringClass; }
+  auto setBuiltinStringClass(bool value) -> void { builtinStringClass = value; }
   [[nodiscard]] auto getClassVtableMethodOrder() const -> const std::vector<std::string>& {
     return classVtableMethodOrder;
   }

--- a/src/liblesma/Symbol/TypeUtils.cpp
+++ b/src/liblesma/Symbol/TypeUtils.cpp
@@ -69,6 +69,40 @@ auto passesByPointerInAbi(Type const* t) -> bool {
   return t->is(BaseType::TY_CLASS) || t->is(BaseType::TY_TRAIT_EXISTENTIAL);
 }
 
+auto isArcReferenceType(Type const* t) -> bool {
+  if (t == nullptr) {
+    return false;
+  }
+  if (t->is(BaseType::TY_CLASS) || t->is(BaseType::TY_ARRAY)) {
+    return true;
+  }
+  return t->is(BaseType::TY_PTR) && t->getElementType() != nullptr &&
+         t->getElementType()->is(BaseType::TY_CLASS);
+}
+
+auto containsArcManagedValue(Type const* t) -> bool {
+  if (t == nullptr) {
+    return false;
+  }
+  if (isArcReferenceType(t)) {
+    return true;
+  }
+  switch (t->getBaseType()) {
+  case BaseType::TY_FUNCTION:
+  case BaseType::TY_ANY:
+  case BaseType::TY_TRAIT_EXISTENTIAL:
+    return true;
+  case BaseType::TY_TUPLE:
+    return std::ranges::any_of(
+        t->getFields(), [](Field const* field) { return containsArcManagedValue(field->type); });
+  case BaseType::TY_UNION:
+    return std::ranges::any_of(t->getUnionMembers(),
+                               [](Type const* member) { return containsArcManagedValue(member); });
+  default:
+    return false;
+  }
+}
+
 auto makeSpecializedClassKey(Type* classTemplate, const std::vector<std::string>& genericParamNames,
                              const std::unordered_map<std::string, Type*>& env) -> std::string {
   std::ostringstream key;

--- a/src/liblesma/Symbol/TypeUtils.h
+++ b/src/liblesma/Symbol/TypeUtils.h
@@ -29,6 +29,10 @@ auto findStaticFieldInClass(Type* classType, const std::string& field) -> Field*
 /** Return value is passed as a pointer (class instance, trait existential, or already a pointer).
  */
 [[nodiscard]] auto passesByPointerInAbi(Type const* t) -> bool;
+/** Shared ARC-managed heap handle (`class`, `__buffer`, or pointer-to-class). */
+[[nodiscard]] auto isArcReferenceType(Type const* t) -> bool;
+/** Type storage may contain ARC-managed references transitively. */
+[[nodiscard]] auto containsArcManagedValue(Type const* t) -> bool;
 /** Stable specialization registry key shared by typecheck and codegen. */
 auto makeSpecializedClassKey(Type* classTemplate, const std::vector<std::string>& genericParamNames,
                              const std::unordered_map<std::string, Type*>& env) -> std::string;

--- a/src/liblesma/Symbol/Value.h
+++ b/src/liblesma/Symbol/Value.h
@@ -89,7 +89,7 @@ public:
         privateMember(other.privateMember), memberDeclaredInClass(other.memberDeclaredInClass),
         closureCaptureOuters(other.closureCaptureOuters),
         closureSlotOuter(other.closureSlotOuter), storesFuncValuePair(other.storesFuncValuePair),
-        originLambdaExpr(other.originLambdaExpr),
+        originLambdaExpr(other.originLambdaExpr), arcOwnedValue(other.arcOwnedValue),
         closureCalleeUsesEnvParameter(other.closureCalleeUsesEnvParameter),
         staticMethod(other.staticMethod) {}
 
@@ -119,6 +119,7 @@ public:
       closureSlotOuter = other.closureSlotOuter;
       storesFuncValuePair = other.storesFuncValuePair;
       originLambdaExpr = other.originLambdaExpr;
+      arcOwnedValue = other.arcOwnedValue;
       closureCalleeUsesEnvParameter = other.closureCalleeUsesEnvParameter;
       staticMethod = other.staticMethod;
     }
@@ -203,6 +204,9 @@ public:
   /** Variable initialized from a lambda AST; used to specialize generic lambdas at call sites. */
   [[nodiscard]] auto getOriginLambdaExpr() const -> const LambdaExpr* { return originLambdaExpr; }
   auto setOriginLambdaExpr(const LambdaExpr* expr) -> void { originLambdaExpr = expr; }
+  /** True when this SSA value currently owns a +1 ARC reference and may be moved into storage. */
+  [[nodiscard]] auto getArcOwnedValue() const -> bool { return arcOwnedValue; }
+  auto setArcOwnedValue(bool v) -> void { arcOwnedValue = v; }
 
   /** Indirect call must pass closure env as first argument (lambda with captures). */
   [[nodiscard]] auto getClosureCalleeUsesEnvParameter() const -> bool {
@@ -259,6 +263,7 @@ private:
   Value* closureSlotOuter = nullptr;
   bool storesFuncValuePair = false;
   const LambdaExpr* originLambdaExpr = nullptr;
+  bool arcOwnedValue = false;
   bool closureCalleeUsesEnvParameter = false;
   bool staticMethod = false;
 };

--- a/src/liblesma/Typecheck/Typechecker.cpp
+++ b/src/liblesma/Typecheck/Typechecker.cpp
@@ -1575,6 +1575,7 @@ auto Typechecker::materializeImportedType(Type* type) -> Type* {
     Type* copy = cacheType(std::move(placeholder));
     importedTypeCopies[type] = copy;
     copy->setDisplayName(type->getDisplayName());
+    copy->setBuiltinStringClass(type->isBuiltinStringClass());
     copy->setGenericParams(type->getGenericParams());
     copy->setImplTraitNames(std::vector<std::string>(type->getImplTraitNames()));
     copy->setDeclarationSpan(type->getDeclarationSpan());
@@ -4464,6 +4465,14 @@ auto Typechecker::visit(const Class* node) -> void {
                          makeGenericDisplaySuffix(node->getGenericParams()));
     stub->setDeclarationSpan(node->getNameSpan());
     stub->setDeclarationFilePath(mainFilePath);
+    const auto stdBasePath =
+        std::filesystem::absolute(std::filesystem::path(getStdDir()) / "base.les")
+            .lexically_normal();
+    const auto declPath =
+        std::filesystem::absolute(std::filesystem::path(mainFilePath)).lexically_normal();
+    std::error_code builtinStrEc;
+    stub->setBuiltinStringClass(node->getIdentifier() == "str" &&
+                                std::filesystem::equivalent(declPath, stdBasePath, builtinStrEc));
     stub->setGenericParams(node->getGenericParams());
     stub->setImplTraitNames(node->getImplTraitNames());
     classTypePtr = stub.get();
@@ -6439,7 +6448,7 @@ auto Typechecker::isStdStrClassType(Type* type) const -> bool {
   if (auto it = specializedTypeToTemplate.find(baseType); it != specializedTypeToTemplate.end()) {
     baseType = it->second;
   }
-  return baseType->getDisplayName() == "str";
+  return baseType->isBuiltinStringClass();
 }
 
 auto Typechecker::getStdStrType(llvm::SMRange span) -> Type* {

--- a/tests/lesma/success/arc_any_assignment_from_loaded_var.les
+++ b/tests/lesma/success/arc_any_assignment_from_loaded_var.les
@@ -1,0 +1,24 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+let current: Box = Box(7)
+var erased: any = 0
+erased = current
+
+if erased is not Box {
+  exit(1)
+}
+
+let out = erased as Box
+if out.get() != 7 {
+  exit(2)
+}

--- a/tests/lesma/success/arc_any_roundtrip_heap_values.les
+++ b/tests/lesma/success/arc_any_roundtrip_heap_values.les
@@ -1,0 +1,62 @@
+enum Kind {
+  START
+  STOP
+}
+
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+func make_reader(value: int) -> func() -> int {
+  return func() -> int => value + 1
+}
+
+var value: any = str("alpha")
+if value is not str {
+  exit(1)
+} else {
+  let alphaStr = value as str
+  if alphaStr.len() != 5 {
+    exit(1)
+  }
+}
+
+value = Box(7)
+if value is not Box {
+  exit(2)
+} else {
+  let box = value as Box
+  if box.get() != 7 {
+    exit(2)
+  }
+}
+
+value = Kind.STOP
+if value is not Kind {
+  exit(3)
+} else if value as Kind != Kind.STOP {
+  exit(3)
+}
+
+let erasedReader: any = make_reader(9)
+let reader = erasedReader as func() -> int
+if reader() != 10 {
+  exit(5)
+}
+if reader() != 10 {
+  exit(5)
+}
+
+value = erasedReader
+let storedReader = value as func() -> int
+if storedReader() != 10 {
+  exit(4)
+}

--- a/tests/lesma/success/arc_class_reassignment_loop.les
+++ b/tests/lesma/success/arc_class_reassignment_loop.les
@@ -1,0 +1,27 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+var current: Box? = Box(0)
+var i: int = 1
+
+while i <= 8 {
+  current = Box(i)
+  i += 1
+}
+
+if current is null {
+  exit(1)
+} else {
+  if current.get() != 8 {
+    exit(1)
+  }
+}

--- a/tests/lesma/success/arc_closure_outer_heap_rebinding.les
+++ b/tests/lesma/success/arc_closure_outer_heap_rebinding.les
@@ -1,0 +1,43 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+func read_box(current: Box?) -> int {
+  if current is null {
+    return 0
+  } else {
+    return current.get()
+  }
+}
+
+func make_first_reader(seed: int) -> func() -> int {
+  var current: Box? = Box(seed)
+  let first = func() -> int => read_box(current)
+  current = Box(seed + 5)
+  return first
+}
+
+func make_second_reader(seed: int) -> func() -> int {
+  var current: Box? = Box(seed)
+  let first = func() -> int => read_box(current)
+  current = Box(seed + 5)
+  return func() -> int => read_box(current)
+}
+
+let readerA = make_first_reader(2)
+if readerA() != 2 {
+  exit(1)
+}
+
+let readerB = make_second_reader(2)
+if readerB() != 7 {
+  exit(2)
+}

--- a/tests/lesma/success/arc_dict_class_replace.les
+++ b/tests/lesma/success/arc_dict_class_replace.les
@@ -1,0 +1,26 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+var d: dict<str, Box> = {"k": Box(1)}
+
+if d["k"].get() != 1 {
+  exit(1)
+}
+
+d.set("k", Box(9))
+
+if d.len() != 1 {
+  exit(1)
+}
+if d["k"].get() != 9 {
+  exit(1)
+}

--- a/tests/lesma/success/arc_export_global_heap.les
+++ b/tests/lesma/success/arc_export_global_heap.les
@@ -1,0 +1,9 @@
+import "arc_export_global_heap_module.les"
+let first = arc_export_global_heap_module.current
+if first is null {
+  exit(1)
+} else {
+  if first.get() != 7 {
+    exit(1)
+  }
+}

--- a/tests/lesma/success/arc_export_global_heap_module.les
+++ b/tests/lesma/success/arc_export_global_heap_module.les
@@ -1,0 +1,13 @@
+export class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+export var current: Box? = Box(7)

--- a/tests/lesma/success/arc_export_global_heap_rich.les
+++ b/tests/lesma/success/arc_export_global_heap_rich.les
@@ -1,0 +1,18 @@
+import "arc_export_global_heap_rich_module.les"
+let first = arc_export_global_heap_rich_module.first
+if first is null {
+  exit(1)
+} else {
+  if first.get() != 4 {
+    exit(2)
+  }
+}
+
+let second = arc_export_global_heap_rich_module.second
+if second is null {
+  exit(3)
+} else {
+  if second.get() != 9 {
+    exit(4)
+  }
+}

--- a/tests/lesma/success/arc_export_global_heap_rich_module.les
+++ b/tests/lesma/success/arc_export_global_heap_rich_module.les
@@ -1,0 +1,14 @@
+export class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+export var first: Box? = Box(4)
+export var second: Box? = Box(9)

--- a/tests/lesma/success/arc_for_in_heap_payloads.les
+++ b/tests/lesma/success/arc_for_in_heap_payloads.les
@@ -1,0 +1,91 @@
+enum Kind {
+  START
+  STOP
+}
+
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+var textTotal = 0
+var texts: list<str> = [str("a"), str("bb"), str("ccc")]
+for text in texts {
+  textTotal = textTotal + text.len()
+}
+if textTotal != 6 {
+  exit(1)
+}
+
+var boxTotal = 0
+var boxes: list<Box> = [Box(2), Box(5), Box(8)]
+for box in boxes {
+  boxTotal = boxTotal + box.get()
+}
+if boxTotal != 15 {
+  exit(2)
+}
+
+var mixedTotal = 0
+var mixed: list<str | Box | Kind> = [str("xy"), Box(7), Kind.START, str("z")]
+for item in mixed {
+  if item is str {
+    mixedTotal = mixedTotal + item.len()
+  } else if item is Box {
+    mixedTotal = mixedTotal + item.get()
+  } else if item is Kind {
+    if item == Kind.START {
+      mixedTotal = mixedTotal + 10
+    } else {
+      mixedTotal = mixedTotal + 20
+    }
+  }
+}
+if mixedTotal != 20 {
+  exit(3)
+}
+
+class OnceIter<T> impl Iterator<T> {
+  var one: T
+  var done: bool = false
+
+  func new(v: T) {
+    self.one = v
+    self.done = false
+  }
+
+  func next() -> T? {
+    if self.done {
+      return null
+    }
+    self.done = true
+    return self.one
+  }
+}
+
+class Once<T> impl Iterable<T> {
+  var one: T
+
+  func new(v: T) {
+    self.one = v
+  }
+
+  func iter() -> OnceIter<T> {
+    return OnceIter<T>(self.one)
+  }
+}
+
+var only = 0
+for word in Once<Box>(Box(11)) {
+  only = word.get()
+}
+if only != 11 {
+  exit(4)
+}

--- a/tests/lesma/success/arc_for_in_iterator_break_continue_heap.les
+++ b/tests/lesma/success/arc_for_in_iterator_break_continue_heap.les
@@ -1,0 +1,59 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+class BoxIter impl Iterator<Box> {
+  var current: int
+  var stop: int
+
+  func new(start: int, stop: int) {
+    self.current = start
+    self.stop = stop
+  }
+
+  func next() -> Box? {
+    if self.current > self.stop {
+      return null
+    }
+    let out = Box(self.current)
+    self.current += 1
+    return out
+  }
+}
+
+class BoxRange impl Iterable<Box> {
+  var start: int
+  var stop: int
+
+  func new(start: int, stop: int) {
+    self.start = start
+    self.stop = stop
+  }
+
+  func iter() -> BoxIter {
+    return BoxIter(self.start, self.stop)
+  }
+}
+
+var total: int = 0
+for item in BoxRange(1, 4) {
+  if item.get() == 2 {
+    continue
+  }
+  if item.get() == 4 {
+    break
+  }
+  total += item.get()
+}
+
+if total != 4 {
+  exit(1)
+}

--- a/tests/lesma/success/arc_for_in_named_iterable_heap.les
+++ b/tests/lesma/success/arc_for_in_named_iterable_heap.les
@@ -1,0 +1,50 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+class OnceIter<T> impl Iterator<T> {
+  var one: T
+  var done: bool = false
+
+  func new(v: T) {
+    self.one = v
+    self.done = false
+  }
+
+  func next() -> T? {
+    if self.done {
+      return null
+    }
+    self.done = true
+    return self.one
+  }
+}
+
+class Once<T> impl Iterable<T> {
+  var one: T
+
+  func new(v: T) {
+    self.one = v
+  }
+
+  func iter() -> OnceIter<T> {
+    return OnceIter<T>(self.one)
+  }
+}
+
+var total = 0
+let once = Once<Box>(Box(14))
+for word in once {
+  total = total + word.get()
+}
+if total != 14 {
+  exit(1)
+}

--- a/tests/lesma/success/arc_generic_class_heap_param.les
+++ b/tests/lesma/success/arc_generic_class_heap_param.les
@@ -1,0 +1,28 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+class Holder<T> {
+  var current: T
+
+  func new(current: T) {
+    self.current = current
+  }
+
+  func get() -> T {
+    return self.current
+  }
+}
+
+var holder = Holder<Box>(Box(11))
+if holder.get().get() != 11 {
+  exit(1)
+}

--- a/tests/lesma/success/arc_generic_class_optional_heap_return.les
+++ b/tests/lesma/success/arc_generic_class_optional_heap_return.les
@@ -1,0 +1,32 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+class Holder<T> {
+  var current: T
+
+  func new(current: T) {
+    self.current = current
+  }
+
+  func next() -> T? {
+    return self.current
+  }
+}
+
+let item = Holder<Box>(Box(12)).next()
+if item is null {
+  exit(1)
+} else {
+  if item.get() != 12 {
+    exit(1)
+  }
+}

--- a/tests/lesma/success/arc_generic_iterator_heap_direct.les
+++ b/tests/lesma/success/arc_generic_iterator_heap_direct.les
@@ -1,0 +1,51 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+class OnceIter<T> impl Iterator<T> {
+  var one: T
+  var done: bool = false
+
+  func new(v: T) {
+    self.one = v
+    self.done = false
+  }
+
+  func next() -> T? {
+    if self.done {
+      return null
+    }
+    self.done = true
+    return self.one
+  }
+}
+
+class Once<T> impl Iterable<T> {
+  var one: T
+
+  func new(v: T) {
+    self.one = v
+  }
+
+  func iter() -> OnceIter<T> {
+    return OnceIter<T>(self.one)
+  }
+}
+
+let iterator = Once<Box>(Box(13)).iter()
+let item = iterator.next()
+if item is null {
+  exit(1)
+} else {
+  if item.get() != 13 {
+    exit(1)
+  }
+}

--- a/tests/lesma/success/arc_lambda_any_union_capture_matrix.les
+++ b/tests/lesma/success/arc_lambda_any_union_capture_matrix.les
@@ -1,0 +1,94 @@
+enum Kind {
+  START
+  STOP
+}
+
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+func make_union_reader(payload: str | list<int> | Box | Kind) -> func() -> int {
+  return func() -> int {
+    if payload is str {
+      return payload.len()
+    }
+    if payload is list<int> {
+      return payload[0] + payload[1]
+    }
+    if payload is Box {
+      return payload.get()
+    }
+    if payload is Kind {
+      if payload == Kind.START {
+        return 1
+      }
+      return 2
+    }
+    return 0
+  }
+}
+
+let firstPair: list<int> = [2, 3]
+var reader0: func() -> int = make_union_reader(str("abc"))
+var reader1: func() -> int = make_union_reader(firstPair)
+var reader2: func() -> int = make_union_reader(Box(7))
+var reader3: func() -> int = make_union_reader(Kind.STOP)
+
+if reader0() != 3 {
+  exit(1)
+}
+if reader1() != 5 {
+  exit(2)
+}
+if reader2() != 7 {
+  exit(3)
+}
+if reader3() != 2 {
+  exit(4)
+}
+
+let secondTriplet: list<int> = [1, 4, 9]
+reader0 = make_union_reader(secondTriplet)
+reader1 = make_union_reader(Box(11))
+reader2 = make_union_reader(Kind.START)
+reader3 = make_union_reader(str("zz"))
+
+if reader0() != 5 {
+  exit(5)
+}
+if reader1() != 11 {
+  exit(6)
+}
+if reader2() != 1 {
+  exit(7)
+}
+if reader3() != 2 {
+  exit(8)
+}
+
+let erased: any = make_union_reader(Box(30))
+let restored = erased as func() -> int
+if restored() != 30 {
+  exit(9)
+}
+
+let erasedStart: any = make_union_reader(Kind.START)
+let restoredStart = erasedStart as func() -> int
+if restoredStart() != 1 {
+  exit(10)
+}
+
+let thirdTriplet: list<int> = [3, 4, 5]
+let erasedListReader: any = make_union_reader(thirdTriplet)
+let restoredListReader = erasedListReader as func() -> int
+if restoredListReader() != 7 {
+  exit(11)
+}

--- a/tests/lesma/success/arc_list_closure_replacement.les
+++ b/tests/lesma/success/arc_list_closure_replacement.les
@@ -1,0 +1,28 @@
+func make_adder(base: int) -> func(int) -> int {
+  return func(x: int) -> int => x + base
+}
+
+var f = make_adder(1)
+if f(9) != 10 {
+  exit(1)
+}
+
+f = make_adder(10)
+if f(5) != 15 {
+  exit(1)
+}
+
+var g = make_adder(2)
+if g(5) != 7 {
+  exit(1)
+}
+
+g = make_adder(7)
+if g(1) != 8 {
+  exit(1)
+}
+
+g = make_adder(20)
+if g(1) != 21 {
+  exit(1)
+}

--- a/tests/lesma/success/arc_nested_dict_list_replace.les
+++ b/tests/lesma/success/arc_nested_dict_list_replace.les
@@ -1,0 +1,52 @@
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+let leftInitial: list<Box> = [Box(1), Box(2)]
+let rightInitial: list<Box> = [Box(3)]
+var groups: dict<str, list<Box>> = {"left": leftInitial, "right": rightInitial}
+
+if groups["left"][1].get() != 2 {
+  exit(1)
+}
+if groups["right"][0].get() != 3 {
+  exit(1)
+}
+
+let leftReplacement: list<Box> = [Box(4), Box(5), Box(6)]
+groups.set("left", leftReplacement)
+if groups["left"].len() != 3 {
+  exit(2)
+}
+if groups["left"][0].get() != 4 or groups["left"][2].get() != 6 {
+  exit(2)
+}
+
+groups["right"] = [Box(7), Box(8)]
+if groups["right"].len() != 2 {
+  exit(3)
+}
+if groups["right"][0].get() != 7 or groups["right"][1].get() != 8 {
+  exit(3)
+}
+
+var outer: list<dict<str, list<Box>>> = [groups]
+outer[0].set("left", [Box(9)])
+if outer[0]["left"].len() != 1 {
+  exit(4)
+}
+if outer[0]["left"][0].get() != 9 {
+  exit(4)
+}
+
+if groups.get("missing") is not null {
+  exit(5)
+}

--- a/tests/lesma/success/arc_nested_tuple_heap_payload_churn.les
+++ b/tests/lesma/success/arc_nested_tuple_heap_payload_churn.les
@@ -1,0 +1,49 @@
+enum Kind {
+  START
+  STOP
+}
+
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+func make_bundle(seed: int) -> ((str, Box), list<Box>, (Box, Kind)) {
+  return ((str("seed"), Box(seed)), [Box(seed + 1), Box(seed + 2)], (Box(seed + 3), Kind.STOP))
+}
+
+let pair,
+boxes,
+tail = make_bundle(1)
+
+if pair[0] != "seed" or pair[1].get() != 1 {
+  exit(1)
+}
+if boxes.len() != 2 or boxes[0].get() != 2 or boxes[1].get() != 3 {
+  exit(2)
+}
+if tail[0].get() != 4 or tail[1] != Kind.STOP {
+  exit(3)
+}
+
+let nested: (
+  (str, Box),
+  list<Box>,
+  (Box, Kind),
+) = ((str("swap"), Box(8)), [Box(9)], (Box(10), Kind.START))
+if nested[0][0] != "swap" or nested[0][1].get() != 8 {
+  exit(4)
+}
+if nested[1][0].get() != 9 {
+  exit(5)
+}
+if nested[2][0].get() != 10 or nested[2][1] != Kind.START {
+  exit(6)
+}

--- a/tests/lesma/success/arc_trait_existential_heap_replacement.les
+++ b/tests/lesma/success/arc_trait_existential_heap_replacement.les
@@ -1,0 +1,51 @@
+trait Speaker {
+  func id() -> int
+}
+
+func read_id(value: Speaker) -> int {
+  return value.id()
+}
+
+class BoxA impl Speaker {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func id() -> int {
+    return self.value
+  }
+}
+
+class BoxB impl Speaker {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func id() -> int {
+    return self.value + 10
+  }
+}
+
+func run() -> int {
+  var current: Speaker = BoxA(1)
+  if read_id(current) != 1 {
+    return 1
+  }
+
+  current = BoxB(2)
+  if read_id(current) != 12 {
+    return 2
+  }
+
+  current = BoxA(3)
+  if read_id(current) != 3 {
+    return 3
+  }
+  return 0
+}
+
+exit(run())

--- a/tests/lesma/success/arc_tuple_heap_payload_churn.les
+++ b/tests/lesma/success/arc_tuple_heap_payload_churn.les
@@ -1,0 +1,65 @@
+enum Kind {
+  START
+  STOP
+}
+
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+func make_bundle(seed: int) -> (str, list<Box>, Box, Kind) {
+  return (str("seed"), [Box(seed), Box(seed + 1)], Box(seed + 2), Kind.START)
+}
+
+let text,
+boxes,
+last,
+tag = make_bundle(3)
+if text != "seed" {
+  exit(1)
+}
+if boxes.len() != 2 or boxes[0].get() != 3 or boxes[1].get() != 4 {
+  exit(2)
+}
+if last.get() != 5 {
+  exit(3)
+}
+if tag != Kind.START {
+  exit(4)
+}
+
+let packed: (str, list<Box>, Box, Kind) = (str("swap"), [Box(8)], Box(9), Kind.STOP)
+if packed[0] != "swap" {
+  exit(5)
+}
+if packed[1].len() != 1 or packed[1][0].get() != 8 {
+  exit(6)
+}
+if packed[2].get() != 9 {
+  exit(7)
+}
+if packed[3] != Kind.STOP {
+  exit(8)
+}
+
+let againText,
+againBoxes,
+againLast,
+againTag = make_bundle(10)
+if againText != "seed" {
+  exit(9)
+}
+if againBoxes[0].get() != 10 or againBoxes[1].get() != 11 {
+  exit(10)
+}
+if againLast.get() != 12 or againTag != Kind.START {
+  exit(11)
+}

--- a/tests/lesma/success/arc_union_str_list_class_enum_reassignment.les
+++ b/tests/lesma/success/arc_union_str_list_class_enum_reassignment.les
@@ -1,0 +1,152 @@
+enum Kind {
+  START
+  STOP
+}
+
+class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+var value: str | list<int> | Box | Kind = str("seed")
+if value is not str {
+  exit(1)
+} else {
+  if value != "seed" {
+    exit(1)
+  }
+}
+
+let initialList: list<int> = [1, 2, 3]
+value = initialList
+if value is not list<int> {
+  exit(2)
+} else {
+  if value.len() != 3 or value[1] != 2 {
+    exit(2)
+  }
+}
+
+value = Box(9)
+if value is not Box {
+  exit(3)
+} else {
+  if value.get() != 9 {
+    exit(3)
+  }
+}
+
+value = Kind.STOP
+if value is not Kind {
+  exit(4)
+} else {
+  if value != Kind.STOP {
+    exit(4)
+  }
+}
+
+let pair: list<int> = [4, 5]
+var xs: list<str | list<int> | Box | Kind> = [str("a"), pair, Box(6), Kind.START]
+xs[0] = Box(1)
+xs[1] = str("swap")
+xs[2] = Kind.STOP
+let tail: list<int> = [7, 8, 9]
+xs[3] = tail
+
+let first = xs[0]
+if first is not Box {
+  exit(5)
+} else {
+  if first.get() != 1 {
+    exit(5)
+  }
+}
+let second = xs[1]
+if second is not str {
+  exit(6)
+} else {
+  if second != "swap" {
+    exit(6)
+  }
+}
+let third = xs[2]
+if third is not Kind {
+  exit(7)
+} else {
+  if third != Kind.STOP {
+    exit(7)
+  }
+}
+let fourth = xs[3]
+if fourth is not list<int> {
+  exit(8)
+} else {
+  if fourth.len() != 3 or fourth[2] != 9 {
+    exit(8)
+  }
+}
+
+let popped = xs.pop()
+if popped is null {
+  exit(9)
+} else {
+  if popped is not list<int> {
+    exit(9)
+  } else {
+    if popped[0] != 7 or popped[2] != 9 {
+      exit(9)
+    }
+  }
+}
+
+var d: dict<
+  str,
+  str | list<int> | Box | Kind,
+> = {"text": str("hello"), "box": Box(3), "state": Kind.START}
+d.set("text", [10, 11])
+d.set("box", Kind.STOP)
+d.set("state", Box(12))
+d.set("extra", str("tail"))
+
+let textValue = d["text"]
+if textValue is not list<int> {
+  exit(10)
+} else {
+  if textValue[0] != 10 or textValue[1] != 11 {
+    exit(10)
+  }
+}
+
+let boxValue = d["box"]
+if boxValue is not Kind {
+  exit(11)
+} else {
+  if boxValue != Kind.STOP {
+    exit(11)
+  }
+}
+
+let stateValue = d["state"]
+if stateValue is not Box {
+  exit(12)
+} else {
+  if stateValue.get() != 12 {
+    exit(12)
+  }
+}
+
+let extra = d["extra"]
+if extra is not str {
+  exit(13)
+} else {
+  if extra != "tail" {
+    exit(13)
+  }
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -582,6 +582,36 @@ if current is null {
   EXPECT_NE(output.find("[arc] live objects: 0"), std::string::npos);
 }
 
+TEST(ArcDebugRuntimeTests, MixedTupleBorrowedAndOwnedArcElementsReportZero) {
+  std::filesystem::path const scratchDir = recreateScratchDir("lesma_arc_runtime_tuple_mixed_zero");
+  std::filesystem::path const mainPath = scratchDir / "main.les";
+  writeScratchFile(mainPath, R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+let a = Box(1)
+let pair: (Box, Box) = (a, Box(2))
+if pair[0].get() != 1 {
+  exit(1)
+}
+if pair[1].get() != 2 {
+  exit(2)
+}
+)");
+
+  auto const [exitCode, output] = runFileWithArcDebug(mainPath);
+  EXPECT_EQ(exitCode, 0);
+  EXPECT_NE(output.find("[arc] live objects: 0"), std::string::npos);
+}
+
 TEST(ArcDebugRuntimeTests, ImportedModuleGlobalsReportZeroAfterCleanup) {
   std::filesystem::path const repoRoot =
       std::filesystem::path(__FILE__).parent_path().parent_path();

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -45,19 +45,19 @@ auto initializeLexer(const std::shared_ptr<SourceMgr>& sourceMgr) -> std::unique
   return curLexer;
 }
 
-auto initializeParser(std::unique_ptr<Lexer> lexer, const std::shared_ptr<SourceMgr>& srcMgr = nullptr)
+auto initializeParser(std::unique_ptr<Lexer> lexer,
+                      const std::shared_ptr<SourceMgr>& srcMgr = nullptr)
     -> std::unique_ptr<Parser> {
-  auto curParser =
-      srcMgr != nullptr ? std::make_unique<Parser>(lexer->getTokens(), nullptr, srcMgr,
-                                                   srcMgr->getNumBuffers(), "test.les")
-                        : std::make_unique<Parser>(lexer->getTokens());
+  auto curParser = srcMgr != nullptr ? std::make_unique<Parser>(lexer->getTokens(), nullptr, srcMgr,
+                                                                srcMgr->getNumBuffers(), "test.les")
+                                     : std::make_unique<Parser>(lexer->getTokens());
   curParser->parse();
 
   return curParser;
 }
 
-auto initializeCodegen(std::unique_ptr<Parser> parser, const std::shared_ptr<SourceMgr>& srcMgr)
-    -> std::unique_ptr<Codegen> {
+auto initializeCodegen(std::unique_ptr<Parser> parser, const std::shared_ptr<SourceMgr>& srcMgr,
+                       bool arcDebug = false, bool arcTrace = false) -> std::unique_ptr<Codegen> {
   Typechecker typechecker;
   typechecker.run(parser->getAst());
   auto takenTypeCache = typechecker.takeTypeCache();
@@ -66,10 +66,19 @@ auto initializeCodegen(std::unique_ptr<Parser> parser, const std::shared_ptr<Sou
       std::move(parser), srcMgr, __FILE__, std::vector<std::string>{}, true, true, "", nullptr,
       nullptr, nullptr, nullptr, std::move(takenRootScope), std::move(takenTypeCache),
       typechecker.takeSpecializedTypeEnv(), typechecker.takeSpecializedTypeToTemplate(),
-      typechecker.takeSpecializedClassTypes());
+      typechecker.takeSpecializedClassTypes(), false, arcDebug, arcTrace);
   codegen->run();
 
   return codegen;
+}
+
+auto buildModuleText(const std::string& src, bool arcDebug = false, bool arcTrace = false)
+    -> std::string {
+  auto srcMgr = initializeSrcMgr(src);
+  auto lexer = initializeLexer(srcMgr);
+  auto parser = initializeParser(std::move(lexer), srcMgr);
+  auto codegen = initializeCodegen(std::move(parser), srcMgr, arcDebug, arcTrace);
+  return codegen->moduleToString();
 }
 
 auto analyzeSource(const std::string& src) -> AnalysisResult {
@@ -79,6 +88,51 @@ auto analyzeSource(const std::string& src) -> AnalysisResult {
   options->implicitFilePath = "analysis_index_test.les";
   options->suppressWarnings = true;
   return analyze(std::move(options));
+}
+
+auto analyzeFile(const std::filesystem::path& path) -> AnalysisResult;
+
+auto initializeCodegenFromAnalysis(AnalysisResult result, bool arcDebug = false, bool arcTrace = false)
+    -> std::unique_ptr<Codegen> {
+  auto codegen = std::make_unique<Codegen>(
+      std::move(result.parser), result.sourceMgr,
+      result.mainFilePath.empty() ? "" : result.mainFilePath, std::vector<std::string>{}, true, true,
+      "", nullptr, nullptr, nullptr, nullptr, std::move(result.rootScope),
+      std::move(result.typeCache), std::move(result.specializedTypeEnv),
+      std::move(result.specializedTypeToTemplate), std::move(result.specializedClassTypes), false,
+      arcDebug, arcTrace);
+  codegen->run();
+  return codegen;
+}
+
+auto buildFileModuleText(const std::filesystem::path& path, bool arcDebug = false,
+                         bool arcTrace = false) -> std::string {
+  AnalysisResult result = analyzeFile(path);
+  auto codegen = initializeCodegenFromAnalysis(std::move(result), arcDebug, arcTrace);
+  return codegen->moduleToString();
+}
+
+auto runFileWithArcDebug(const std::filesystem::path& path, bool arcTrace = false)
+    -> std::pair<int, std::string> {
+  AnalysisResult result = analyzeFile(path);
+  auto codegen = initializeCodegenFromAnalysis(std::move(result), true, arcTrace);
+  testing::internal::CaptureStdout();
+  codegen->prepareJit();
+  int const exitCode = codegen->executeJit();
+  return {exitCode, testing::internal::GetCapturedStdout()};
+}
+
+auto writeScratchFile(const std::filesystem::path& path, const std::string& contents) -> void {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << contents;
+}
+
+auto recreateScratchDir(const std::string& name) -> std::filesystem::path {
+  std::filesystem::path const dir = std::filesystem::temp_directory_path() / name;
+  std::filesystem::remove_all(dir);
+  std::filesystem::create_directories(dir);
+  return dir;
 }
 
 auto analyzeFile(const std::filesystem::path& path) -> AnalysisResult {
@@ -203,6 +257,360 @@ TEST_F(CodegenTest, Run) {
   int exitCode = codegen->executeJit();
 
   EXPECT_TRUE(exitCode == 0);
+}
+
+TEST(CodegenIRTests, BorrowedArcReturnEmitsRetain) {
+  std::string const moduleText = buildModuleText(R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+}
+
+func echo(box: Box) -> Box {
+  return box
+}
+
+let out = echo(Box(1))
+exit(out.value)
+)");
+
+  EXPECT_NE(moduleText.find("arc.retain.count"), std::string::npos);
+  EXPECT_NE(moduleText.find("ret ptr"), std::string::npos);
+}
+
+TEST(CodegenIRTests, ForInIteratorCleanupReleasesIteratorSlot) {
+  std::string const moduleText = buildModuleText(R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+}
+
+class OnceIter impl Iterator<Box> {
+  var current: Box?
+
+  func new(value: Box?) {
+    self.current = value
+  }
+
+  func next() -> Box? {
+    let out = self.current
+    self.current = null
+    return out
+  }
+}
+
+class Once impl Iterable<Box> {
+  var current: Box?
+
+  func new(value: Box?) {
+    self.current = value
+  }
+
+  func iter() -> OnceIter {
+    return OnceIter(self.current)
+  }
+}
+
+for item in Once(Box(3)) {
+  exit(item.value)
+}
+)");
+
+  EXPECT_NE(moduleText.find("for.iter.slot"), std::string::npos);
+  EXPECT_NE(moduleText.find("for.iter"), std::string::npos);
+  EXPECT_NE(moduleText.find("arc.release.next"), std::string::npos);
+}
+
+TEST(CodegenIRTests, ListOverwriteAndPopEmitStableOwnershipBlocks) {
+  std::string const moduleText = buildModuleText(R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+}
+
+var items: list<Box> = []
+items.push(Box(1))
+items[0] = Box(2)
+let tail = items.pop()
+if tail is not null {
+  exit(tail.value)
+}
+)");
+
+  EXPECT_NE(moduleText.find("list.pop.result"), std::string::npos);
+  EXPECT_NE(moduleText.find("list.pop.ptr"), std::string::npos);
+  EXPECT_NE(moduleText.find("arc.release.next"), std::string::npos);
+}
+
+TEST(CodegenIRTests, ClosureCaptureMaterializationBuildsArcEnvironment) {
+  std::string const moduleText = buildModuleText(R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+}
+
+func make_reader(box: Box) -> func() -> int {
+  return func() -> int {
+    return box.value
+  }
+}
+
+let reader = make_reader(Box(7))
+exit(reader())
+)");
+
+  EXPECT_NE(moduleText.find(".env.arc.payload"), std::string::npos);
+  EXPECT_NE(moduleText.find("__lesma_arc_destroy_env___lambda_0"), std::string::npos);
+  EXPECT_NE(moduleText.find("cap.slot"), std::string::npos);
+  EXPECT_NE(moduleText.find("arc.env.slot"), std::string::npos);
+}
+
+TEST(CodegenIRTests, OptionalReplacementEmitsReleaseOfPreviousValue) {
+  std::string const moduleText = buildModuleText(R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+var current: Box? = Box(1)
+current = Box(2)
+if current is null {
+  exit(1)
+} else {
+  exit(current.get())
+}
+)");
+
+  EXPECT_NE(moduleText.find("arc.release.next"), std::string::npos);
+  EXPECT_NE(moduleText.find("arc.release.destroyfn"), std::string::npos);
+}
+
+TEST(CodegenIRTests, NullCoalesceManagedPayloadBuildsMergePhi) {
+  std::string const moduleText = buildModuleText(R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+func choose(left: Box?, fallback: Box) -> Box {
+  return left ?? fallback
+}
+
+let chosen = choose(Box(1), Box(2))
+exit(chosen.get())
+)");
+
+  EXPECT_NE(moduleText.find("coalesce.result"), std::string::npos);
+  EXPECT_NE(moduleText.find("coalesce.left.payload.tmp"), std::string::npos);
+}
+
+TEST(CodegenIRTests, UnionMethodDispatchManagedReturnBuildsPhi) {
+  std::string const moduleText = buildModuleText(R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+class BoxA {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func make() -> Box {
+    return Box(self.value)
+  }
+}
+
+class BoxB {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func make() -> Box {
+    return Box(self.value + 10)
+  }
+}
+
+func read(value: BoxA | BoxB) -> int {
+  let made = value.make()
+  return made.get()
+}
+
+exit(read(BoxA(4)))
+)");
+
+  EXPECT_NE(moduleText.find("union.m.phi"), std::string::npos);
+  EXPECT_NE(moduleText.find("union.m.case"), std::string::npos);
+}
+
+TEST(CodegenIRTests, MainModuleCleanupRunsBeforeArcReport) {
+  std::string const moduleText = buildModuleText(R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+export var current: Box? = Box(4)
+
+let first = current
+if first is null {
+  exit(1)
+} else {
+  if first.get() != 4 {
+    exit(2)
+  }
+}
+)",
+                                           true);
+
+  size_t const cleanupCallPos = moduleText.rfind("call void @__lesma_mod_fini_");
+  size_t const reportCallPos = moduleText.rfind("call void @__lesma_arc_debug_report()");
+  ASSERT_NE(cleanupCallPos, std::string::npos);
+  ASSERT_NE(reportCallPos, std::string::npos);
+  EXPECT_LT(cleanupCallPos, reportCallPos);
+}
+
+TEST(CodegenIRTests, ImportedModuleFinisRunBeforeMainCleanupAndReport) {
+  std::filesystem::path const scratchDir =
+      recreateScratchDir("lesma_arc_ir_imported_module_cleanup");
+  std::filesystem::path const modulePath = scratchDir / "arc_mod.les";
+  std::filesystem::path const mainPath = scratchDir / "main.les";
+  writeScratchFile(modulePath, R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+export var current: Box? = Box(7)
+)");
+  writeScratchFile(mainPath, R"(import "arc_mod.les"
+
+export var local: arc_mod.Box? = arc_mod.Box(2)
+
+let first = arc_mod.current
+if first is null {
+  exit(1)
+} else {
+  if first.get() != 7 {
+    exit(2)
+  }
+}
+)");
+
+  std::string const moduleText = buildFileModuleText(mainPath, true);
+  size_t const importedFiniCallPos = moduleText.find("call void @__lesma_mod_fini_");
+  size_t const mainFiniCallPos =
+      moduleText.find("call void @__lesma_mod_fini_", importedFiniCallPos + 1U);
+  size_t const reportCallPos = moduleText.rfind("call void @__lesma_arc_debug_report()");
+  ASSERT_NE(importedFiniCallPos, std::string::npos);
+  ASSERT_NE(mainFiniCallPos, std::string::npos);
+  ASSERT_NE(reportCallPos, std::string::npos);
+  EXPECT_LT(importedFiniCallPos, mainFiniCallPos);
+  EXPECT_LT(mainFiniCallPos, reportCallPos);
+}
+
+TEST(ArcDebugRuntimeTests, LocalTopLevelArcChurnReportsZero) {
+  std::filesystem::path const scratchDir = recreateScratchDir("lesma_arc_runtime_local_zero");
+  std::filesystem::path const mainPath = scratchDir / "main.les";
+  writeScratchFile(mainPath, R"(class Box {
+  var value: int
+
+  func new(value: int) {
+    self.value = value
+  }
+
+  func get() -> int {
+    return self.value
+  }
+}
+
+var current: Box? = Box(1)
+current = Box(2)
+if current is null {
+  exit(1)
+} else {
+  if current.get() != 2 {
+    exit(2)
+  }
+}
+)");
+
+  auto const [exitCode, output] = runFileWithArcDebug(mainPath);
+  EXPECT_EQ(exitCode, 0);
+  EXPECT_NE(output.find("[arc] live objects: 0"), std::string::npos);
+}
+
+TEST(ArcDebugRuntimeTests, ImportedModuleGlobalsReportZeroAfterCleanup) {
+  std::filesystem::path const repoRoot =
+      std::filesystem::path(__FILE__).parent_path().parent_path();
+  auto const [exitCode, output] =
+      runFileWithArcDebug(repoRoot / "tests/lesma/success/arc_export_global_heap.les");
+  EXPECT_EQ(exitCode, 0);
+  EXPECT_NE(output.find("[arc] live objects: 0"), std::string::npos);
+  EXPECT_NE(output.find("roots tracked:"), std::string::npos);
+  EXPECT_NE(output.find("roots remaining: 0"), std::string::npos);
+}
+
+TEST(ArcDebugRuntimeTests, StaticArcRootsReportZeroAfterCleanup) {
+  std::filesystem::path const repoRoot =
+      std::filesystem::path(__FILE__).parent_path().parent_path();
+  auto const [exitCode, output] =
+      runFileWithArcDebug(repoRoot / "tests/lesma/success/static_field_callable_closure.les");
+  EXPECT_EQ(exitCode, 0);
+  EXPECT_NE(output.find("[arc] live objects: 0"), std::string::npos);
+  EXPECT_NE(output.find("roots tracked:"), std::string::npos);
+  EXPECT_NE(output.find("roots remaining: 0"), std::string::npos);
+}
+
+TEST(ArcDebugRuntimeTests, ArcTracePrintsModuleRootNamesDuringCleanup) {
+  std::filesystem::path const repoRoot =
+      std::filesystem::path(__FILE__).parent_path().parent_path();
+  auto const [exitCode, output] =
+      runFileWithArcDebug(repoRoot / "tests/lesma/success/static_field_callable_closure.les", true);
+  EXPECT_EQ(exitCode, 0);
+  EXPECT_NE(output.find("[arc] cleanup root lesma.sfs."), std::string::npos);
 }
 
 // ============================================================================
@@ -403,8 +811,7 @@ TEST(FormatterTests, DriverFormatsDirectoriesBestEffortWhenSomeFilesDoNotParse) 
 }
 
 TEST(FormatterTests, ParserAttachesStatementTriviaAndNormalizedBlankLines) {
-  auto srcMgr =
-      initializeSrcMgr("// file comment\nlet x = 1 // trailing\n\n// step\nlet y = 2\n");
+  auto srcMgr = initializeSrcMgr("// file comment\nlet x = 1 // trailing\n\n// step\nlet y = 2\n");
   auto lexer = initializeLexer(srcMgr);
   auto parser = initializeParser(std::move(lexer), srcMgr);
 
@@ -422,8 +829,9 @@ TEST(FormatterTests, ParserAttachesStatementTriviaAndNormalizedBlankLines) {
 }
 
 TEST(FormatterTests, FormatSourceNormalizesOptionalBlankLines) {
-  auto formatted = formatSource("func work() -> void {\nlet a = 1\n\n\nlet b = 2\n\n// step\nlet c = 3\n}\n",
-                                "blank_lines_test.les", 100);
+  auto formatted =
+      formatSource("func work() -> void {\nlet a = 1\n\n\nlet b = 2\n\n// step\nlet c = 3\n}\n",
+                   "blank_lines_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "func work() {\n"
                         "  let a = 1\n"
@@ -436,9 +844,8 @@ TEST(FormatterTests, FormatSourceNormalizesOptionalBlankLines) {
 }
 
 TEST(FormatterTests, FormatSourcePreservesEnumValueComments) {
-  auto formatted =
-      formatSource("enum Status {\nREADY\n\n// transitional\nWAITING // trailing\n}\n",
-                   "enum_comments_test.les", 100);
+  auto formatted = formatSource("enum Status {\nREADY\n\n// transitional\nWAITING // trailing\n}\n",
+                                "enum_comments_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "enum Status {\n"
                         "  READY\n"
@@ -449,9 +856,8 @@ TEST(FormatterTests, FormatSourcePreservesEnumValueComments) {
 }
 
 TEST(FormatterTests, FormatSourcePreservesBlockComments) {
-  auto formatted = formatSource(
-      "func work() -> void {\n/* setup\n * step\n */\nlet x = 1\n}\n",
-      "block_comment_test.les", 100);
+  auto formatted = formatSource("func work() -> void {\n/* setup\n * step\n */\nlet x = 1\n}\n",
+                                "block_comment_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "func work() {\n"
                         "  /* setup\n"
@@ -462,9 +868,8 @@ TEST(FormatterTests, FormatSourcePreservesBlockComments) {
 }
 
 TEST(FormatterTests, FormatSourceNormalizesDocComments) {
-  auto formatted = formatSource(
-      "/**\n* summary\n*details\n*/\nfunc work() -> int { return 1 }\n",
-      "doc_comment_test.les", 100);
+  auto formatted = formatSource("/**\n* summary\n*details\n*/\nfunc work() -> int { return 1 }\n",
+                                "doc_comment_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "/**\n"
                         " * summary\n"
@@ -489,8 +894,7 @@ TEST(FormatterTests, FormatSourceIsParseStable) {
 }
 
 TEST(FormatterTests, FormatSourceCanonicalizesOptionalTypeSyntax) {
-  auto formatted =
-      formatSource("let value: int | null = null\n", "optional_type_test.les", 100);
+  auto formatted = formatSource("let value: int | null = null\n", "optional_type_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "let value: int? = null\n");
 }
@@ -502,10 +906,12 @@ TEST(FormatterTests, FormatSourcePreservesNilCoalescingPrecedence) {
 }
 
 TEST(FormatterTests, FormatSourcePreservesNullCoalescingAssignment) {
-  auto formatted = formatSource("var maybe: int? = null\nmaybe ?" "?= 1\n",
+  auto formatted = formatSource("var maybe: int? = null\nmaybe ?"
+                                "?= 1\n",
                                 "coalesce_assign_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
-  EXPECT_EQ(*formatted, "var maybe: int? = null\nmaybe ?" "?= 1\n");
+  EXPECT_EQ(*formatted, "var maybe: int? = null\nmaybe ?"
+                        "?= 1\n");
 }
 
 TEST(FormatterTests, FormatSourcePreservesAddressOfUnaryOperator) {
@@ -516,9 +922,8 @@ TEST(FormatterTests, FormatSourcePreservesAddressOfUnaryOperator) {
 }
 
 TEST(FormatterTests, FormatSourcePreservesBitwisePipeOperator) {
-  auto formatted =
-      formatSource("func combine(lhs: int, rhs: int) -> int {\nreturn lhs | rhs\n}\n",
-                   "bitwise_pipe_test.les", 100);
+  auto formatted = formatSource("func combine(lhs: int, rhs: int) -> int {\nreturn lhs | rhs\n}\n",
+                                "bitwise_pipe_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_NE(formatted->find("lhs | rhs"), std::string::npos);
   EXPECT_EQ(formatted->find("lhs ? rhs"), std::string::npos);
@@ -532,24 +937,22 @@ TEST(FormatterTests, FormatSourcePreservesInferredExpressionLambdaReturnType) {
 }
 
 TEST(FormatterTests, FormatSourceOmitsExplicitVoidReturnTypesEverywhere) {
-  auto formatted = formatSource(
-      "func work() -> void {\n"
-      "  pass\n"
-      "}\n"
-      "func takes(callback: func(int) -> void) -> void {\n"
-      "  callback(1)\n"
-      "}\n"
-      "let handler: func(int) -> void = func(value: int) -> void {\n"
-      "  pass\n"
-      "}\n",
-      "void_return_style_test.les", 100);
+  auto formatted = formatSource("func work() -> void {\n"
+                                "  pass\n"
+                                "}\n"
+                                "func takes(callback: func(int) -> void) -> void {\n"
+                                "  callback(1)\n"
+                                "}\n"
+                                "let handler: func(int) -> void = func(value: int) -> void {\n"
+                                "  pass\n"
+                                "}\n",
+                                "void_return_style_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(formatted->find("-> void"), std::string::npos);
 }
 
 TEST(FormatterTests, NarrowWidthBreaksLongCalls) {
-  auto formatted =
-      formatSource("combine(alpha, beta, gamma, delta)\n", "width_test.les", 20);
+  auto formatted = formatSource("combine(alpha, beta, gamma, delta)\n", "width_test.les", 20);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "combine(\n"
                         "  alpha,\n"
@@ -560,9 +963,9 @@ TEST(FormatterTests, NarrowWidthBreaksLongCalls) {
 }
 
 TEST(FormatterTests, NarrowWidthBreaksChainedCallsOneSegmentPerLine) {
-  auto formatted = formatSource(
-      "let total = xs.map(func(x: int) => x + 1).filter(func(x: int) => x > 5).reduce(func(acc: int, x: int) => acc + x, 0)\n",
-      "chain_width_test.les", 32);
+  auto formatted = formatSource("let total = xs.map(func(x: int) => x + 1).filter(func(x: int) => "
+                                "x > 5).reduce(func(acc: int, x: int) => acc + x, 0)\n",
+                                "chain_width_test.les", 32);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "let total = xs\n"
                         "  .map(func(x: int) => x + 1)\n"
@@ -601,9 +1004,8 @@ TEST(FormatterTests, NarrowWidthBreaksLongReturnExpressionAndReparses) {
 }
 
 TEST(FormatterTests, NarrowWidthWrapsRepeatedBinaryOperatorsConsistently) {
-  auto formatted = formatSource(
-      "func calc() -> int {\nreturn alpha + beta + gamma + delta\n}\n",
-      "operator_chain_width_test.les", 22);
+  auto formatted = formatSource("func calc() -> int {\nreturn alpha + beta + gamma + delta\n}\n",
+                                "operator_chain_width_test.les", 22);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "func calc() -> int {\n"
                         "  return alpha\n"
@@ -614,9 +1016,9 @@ TEST(FormatterTests, NarrowWidthWrapsRepeatedBinaryOperatorsConsistently) {
 }
 
 TEST(FormatterTests, NarrowWidthBreaksLongIfConditionAndReparses) {
-  auto formatted = formatSource(
-      "func check(flag: bool, other: bool, extra: bool) -> bool {\nif flag and other or extra { return true }\nreturn false\n}\n",
-      "if_condition_width_test.les", 24);
+  auto formatted = formatSource("func check(flag: bool, other: bool, extra: bool) -> bool {\nif "
+                                "flag and other or extra { return true }\nreturn false\n}\n",
+                                "if_condition_width_test.les", 24);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_TRUE(formatted->find("flag and other or extra") == std::string::npos);
 
@@ -625,9 +1027,8 @@ TEST(FormatterTests, NarrowWidthBreaksLongIfConditionAndReparses) {
 }
 
 TEST(FormatterTests, NarrowWidthBreaksLongAssignmentAndReparses) {
-  auto formatted = formatSource(
-      "func work() -> void {\nvalue = alpha + beta + gamma + delta\n}\n",
-      "assignment_width_test.les", 20);
+  auto formatted = formatSource("func work() -> void {\nvalue = alpha + beta + gamma + delta\n}\n",
+                                "assignment_width_test.les", 20);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_TRUE(formatted->find("value = alpha + beta + gamma + delta") == std::string::npos);
 
@@ -636,9 +1037,9 @@ TEST(FormatterTests, NarrowWidthBreaksLongAssignmentAndReparses) {
 }
 
 TEST(FormatterTests, NarrowWidthBreaksLongWhileConditionAndReparses) {
-  auto formatted = formatSource(
-      "func work() -> void {\nwhile alpha and beta or gamma { break }\n}\n",
-      "while_condition_width_test.les", 20);
+  auto formatted =
+      formatSource("func work() -> void {\nwhile alpha and beta or gamma { break }\n}\n",
+                   "while_condition_width_test.les", 20);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_TRUE(formatted->find("while alpha and beta or gamma") == std::string::npos);
 
@@ -658,13 +1059,13 @@ TEST(FormatterTests, NarrowWidthBreaksLongLambdaExpressionBodyAndReparses) {
 }
 
 TEST(FormatterTests, FormatSourceParsesIndentedContinuationInput) {
-  auto formatted = formatSource(
-      "func check(b: uint8) -> bool {\n"
-      "  return\n"
-      "    b == 9 as uint8 or b == 10 as uint8 or b == 11 as uint8 or b == 12 as uint8 or b == 13 as uint8\n"
-      "      or b == 32 as uint8\n"
-      "}\n",
-      "wrapped_return_input_test.les", 100);
+  auto formatted = formatSource("func check(b: uint8) -> bool {\n"
+                                "  return\n"
+                                "    b == 9 as uint8 or b == 10 as uint8 or b == 11 as uint8 or b "
+                                "== 12 as uint8 or b == 13 as uint8\n"
+                                "      or b == 32 as uint8\n"
+                                "}\n",
+                                "wrapped_return_input_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
 
   auto reparsed = parseSourceForFormatting(*formatted, "wrapped_return_input_test.les");
@@ -672,16 +1073,15 @@ TEST(FormatterTests, FormatSourceParsesIndentedContinuationInput) {
 }
 
 TEST(FormatterTests, FormatSourcePreservesLogicalSectionsInsideBlocks) {
-  auto formatted = formatSource(
-      "func work() -> void {\n"
-      "let a = 1\n"
-      "\n"
-      "// phase two\n"
-      "let b = 2\n"
-      "\n"
-      "let c = 3\n"
-      "}\n",
-      "block_grouping_test.les", 100);
+  auto formatted = formatSource("func work() -> void {\n"
+                                "let a = 1\n"
+                                "\n"
+                                "// phase two\n"
+                                "let b = 2\n"
+                                "\n"
+                                "let c = 3\n"
+                                "}\n",
+                                "block_grouping_test.les", 100);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "func work() {\n"
                         "  let a = 1\n"
@@ -694,12 +1094,11 @@ TEST(FormatterTests, FormatSourcePreservesLogicalSectionsInsideBlocks) {
 }
 
 TEST(FormatterTests, FormatSourceWrapsClassHeadsAndSeparatesFieldsFromMethods) {
-  auto formatted = formatSource(
-      "class Widget : Base impl FirstTrait, SecondTrait, ThirdTrait {\n"
-      "var value: int\n"
-      "func read() -> int { return self.value }\n"
-      "}\n",
-      "class_layout_test.les", 36);
+  auto formatted = formatSource("class Widget : Base impl FirstTrait, SecondTrait, ThirdTrait {\n"
+                                "var value: int\n"
+                                "func read() -> int { return self.value }\n"
+                                "}\n",
+                                "class_layout_test.les", 36);
   ASSERT_TRUE(formatted.has_value()) << formatted.error().message;
   EXPECT_EQ(*formatted, "class Widget : Base\n"
                         "  impl FirstTrait,\n"
@@ -714,149 +1113,138 @@ TEST(FormatterTests, FormatSourceWrapsClassHeadsAndSeparatesFieldsFromMethods) {
 }
 
 TEST(ParserTests, ReturnExpressionAllowsIndentedContinuation) {
-  AnalysisResult const result = analyzeSource(
-      "func check(b: uint8) -> bool {\n"
-      "  return\n"
-      "    b == 9 as uint8 or b == 10 as uint8 or b == 11 as uint8 or b == 12 as uint8 or b == 13 as uint8\n"
-      "      or b == 32 as uint8\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func check(b: uint8) -> bool {\n"
+                                              "  return\n"
+                                              "    b == 9 as uint8 or b == 10 as uint8 or b == 11 "
+                                              "as uint8 or b == 12 as uint8 or b == 13 as uint8\n"
+                                              "      or b == 32 as uint8\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, LogicalExpressionAllowsIndentedContinuationInInitializer) {
-  AnalysisResult const result = analyzeSource(
-      "func check() -> bool {\n"
-      "  let result = true and\n"
-      "    false or\n"
-      "    true\n"
-      "  return result\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func check() -> bool {\n"
+                                              "  let result = true and\n"
+                                              "    false or\n"
+                                              "    true\n"
+                                              "  return result\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, ArithmeticExpressionAllowsIndentedContinuation) {
-  AnalysisResult const result = analyzeSource(
-      "func calc() -> int {\n"
-      "  return 1 +\n"
-      "    2 * 3 -\n"
-      "    4\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func calc() -> int {\n"
+                                              "  return 1 +\n"
+                                              "    2 * 3 -\n"
+                                              "    4\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, ComparisonOperatorsAllowIndentedContinuationBeforeOperator) {
-  AnalysisResult const result = analyzeSource(
-      "func check(b: uint8) -> bool {\n"
-      "  return b\n"
-      "    == 9 as uint8\n"
-      "    or b\n"
-      "      == 32 as uint8\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func check(b: uint8) -> bool {\n"
+                                              "  return b\n"
+                                              "    == 9 as uint8\n"
+                                              "    or b\n"
+                                              "      == 32 as uint8\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, ContinuationExpressionDoesNotConsumeFollowingStatement) {
-  AnalysisResult const result = analyzeSource(
-      "func calc() -> int {\n"
-      "  let total = 1 +\n"
-      "    2\n"
-      "  let extra = 3\n"
-      "  return total + extra\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func calc() -> int {\n"
+                                              "  let total = 1 +\n"
+                                              "    2\n"
+                                              "  let extra = 3\n"
+                                              "  return total + extra\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, InitializerAllowsIndentedContinuationAfterEquals) {
-  AnalysisResult const result = analyzeSource(
-      "func calc() -> int {\n"
-      "  let total =\n"
-      "    1 + 2\n"
-      "  return total\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func calc() -> int {\n"
+                                              "  let total =\n"
+                                              "    1 + 2\n"
+                                              "  return total\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, UnaryOperatorAllowsIndentedContinuationAfterOperator) {
-  AnalysisResult const result = analyzeSource(
-      "func check(flag: bool) -> bool {\n"
-      "  return not\n"
-      "    flag\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func check(flag: bool) -> bool {\n"
+                                              "  return not\n"
+                                              "    flag\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, IfConditionAllowsIndentedContinuationAfterKeyword) {
-  AnalysisResult const result = analyzeSource(
-      "func check(a: bool, b: bool) -> bool {\n"
-      "  if\n"
-      "    a or b {\n"
-      "    return true\n"
-      "  }\n"
-      "  return false\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func check(a: bool, b: bool) -> bool {\n"
+                                              "  if\n"
+                                              "    a or b {\n"
+                                              "    return true\n"
+                                              "  }\n"
+                                              "  return false\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, WhileConditionAllowsIndentedContinuationAfterKeyword) {
-  AnalysisResult const result = analyzeSource(
-      "func spin(a: bool, b: bool) -> void {\n"
-      "  while\n"
-      "    a and b {\n"
-      "    break\n"
-      "  }\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func spin(a: bool, b: bool) -> void {\n"
+                                              "  while\n"
+                                              "    a and b {\n"
+                                              "    break\n"
+                                              "  }\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, ForIterableAllowsIndentedContinuationAfterIn) {
-  AnalysisResult const result = analyzeSource(
-      "func walk() -> void {\n"
-      "  for item in\n"
-      "    range(3) {\n"
-      "    print(item)\n"
-      "  }\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func walk() -> void {\n"
+                                              "  for item in\n"
+                                              "    range(3) {\n"
+                                              "    print(item)\n"
+                                              "  }\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, ParameterDefaultAllowsIndentedContinuationAfterEquals) {
-  AnalysisResult const result = analyzeSource(
-      "func check(flag: bool =\n"
-      "  true or false) -> bool {\n"
-      "  return flag\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func check(flag: bool =\n"
+                                              "  true or false) -> bool {\n"
+                                              "  return flag\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);
 }
 
 TEST(ParserTests, LambdaExpressionBodyAllowsIndentedContinuationAfterFatArrow) {
-  AnalysisResult const result = analyzeSource(
-      "func check() -> int {\n"
-      "  let f = func(x: int) -> int =>\n"
-      "    x + 1\n"
-      "  return f(1)\n"
-      "}\n");
+  AnalysisResult const result = analyzeSource("func check() -> int {\n"
+                                              "  let f = func(x: int) -> int =>\n"
+                                              "    x + 1\n"
+                                              "  return f(1)\n"
+                                              "}\n");
   ASSERT_FALSE(result.hasErrors())
       << (result.diagnostics.empty() ? std::string("unknown analysis error")
                                      : result.diagnostics.front().message);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end ARC support: allocation, retain/release, tracked slot frames, module root cleanup, and CLI flags to enable ARC debug/trace.
* **Bug Fixes**
  * Corrected ownership propagation across returns, stores, casts, iterators, list/tuple/union operations, and module/JIT cleanup to reduce leaks.
* **Tests**
  * Many new ARC-focused tests covering closures, collections, generics, tuples, unions, optionals and cross-module globals.
* **Chores**
  * CI workflows updated to run ARC/ASAN test jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements end-to-end Automatic Reference Counting (ARC) for the Lesma compiler. The implementation adds an ARC header (refcount + destroy-function pointer) prepended to every heap allocation, retain/release primitives, tracked slot frames to release locals on every exit path, module-level root cleanup, JIT finalization ordering, and debug/trace instrumentation behind `--arc-debug`/`--arc-trace` flags (debug builds only). All previous heap allocations — class instances, list/buffer/dict objects, closure environments, and `any`-boxed values — are migrated from plain `malloc` to `emitArcAlloc`. Ownership propagation is threaded through returns, stores, casts, iterators, list/tuple/union operations, and cross-module globals, with 22 new focused ARC integration tests.

Key design decisions verified:
- ARC header layout: `{i64 refcount, ptr destroyfn}` immediately preceding the payload pointer returned by `emitArcAlloc`.
- Slot-frame stack (`arcOwnedSlotFrames`) tracks alloca slots per function scope; `emitReleaseCurrentArcOwnedSlots()` is inserted before every `ret` instruction to release locals.
- Module-root registry (`moduleArcTrackedRoots`) collects global slots for cleanup; JIT calls fini functions in reverse import order.
- `arcOwnedValue` flag propagates \"caller already owns this +1\" through the codegen pipeline to avoid double-retains at store sites.
- The three previously-flagged issues (null destroy-function, iterator slot leak, tuple ownership per-element retain, pre-cast `arcOwnedValue`) are all addressed in this revision.

<h3>Confidence Score: 4/5</h3>

PR is on the happy path to merge; all three previously-flagged critical bugs are resolved and the new ARC machinery is structurally sound.

The core ARC primitives (retain/release, slot frames, module cleanup, JIT fini ordering) are correctly implemented and verified by a comprehensive test suite. The three previous review concerns — null destroy-function pointer, iterator slot leak, tuple ownership, and pre-cast arcOwnedValue — are all addressed. The only remaining concrete finding (push/set retaining without checking arcOwnedValue for owned temporaries) is a systemic design limitation of the current ARC model rather than a targeted regression, and does not affect the current test patterns.

src/liblesma/Backend/CodegenBuiltinIntrinsics.cpp — push() and set() retain logic; src/liblesma/Backend/CodegenBufferHelpers.cpp — retain/release non-atomicity comment.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The ARC implementation carefully guards null pointers in retain/release paths. The `emitArcAlloc` function now throws a compile-time `CodegenError` when called with a null destroy function, preventing silent null-function-pointer calls at runtime. Refcount underflow is caught in debug mode via `emitArcDebugValidateRefcount`. The module cleanup function uses an idempotent done-flag global to prevent double-free on re-entry.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/liblesma/Backend/CodegenBufferHelpers.cpp | Adds ~580 lines of ARC primitives: emitArcAlloc/Retain/Release/ReleaseNullable, slot-frame tracking, module-root registry, typed retain/release helpers for all ARC-managed types (class, array, function, tuple, union, any), and destroy-function generators. The ARC destroy path for arrays correctly frees the backing data pointer before freeing the header payload. One concern: push()/set() list intrinsics always retain the argument without checking arcOwnedValue, which can cause a refcount imbalance if freshly-owned temporaries are passed directly as arguments. |
| src/liblesma/Backend/CodegenVisit.cpp | Extensive ARC ownership wiring: slot-frame push/pop around every function/lambda entry-exit, retain-before-store and release-of-previous in Assignment, Return now retains before releasing the slot frame to avoid use-after-free, constructor properly retains field values, iterator slot registered for early-return cleanup, tuple construction emits per-element retains for non-owned fields, arcOwnedValue propagated through cast/union-wrap/lambda results. The ordering (retain-new, release-old) is consistently correct throughout. |
| src/liblesma/Backend/Codegen.h | Adds ArcTrackedSlot/ModuleArcTrackedRoot structs, ARC state fields (arcOwnedSlotFrames, moduleArcTrackedRoots, arcHeaderLlvmType, ARC debug/cleanup function caches), ARC flags (emitArcDebug, emitArcTrace), pendingJitModuleFinis, and declarations for all new ARC helper methods. Constructor signature updated with new optional parameters. |
| src/liblesma/Backend/CodegenPipeline.cpp | Adds emitEntryNullInit, adds ARC slot-frame push/pop at top-level run(), wires finalBlock to collect unterminated blocks before emitting slot cleanup and module cleanup call. For JIT, emitCallPendingJitModuleFinis is called in reverse import order before the main module's own cleanup. getOrCreateModuleCleanupFunction creates an idempotent cleanup function guarded by a done-flag global. |
| src/liblesma/Backend/CodegenBuiltinIntrinsics.cpp | Migrates BufferNew/BufferCopy to emitArcAlloc, adds per-element retain/release to BufferClear, emits retain-on-push and retain-new/release-old on BufferSet, marks pop result as owned. Both push and set always retain the argument without checking arcOwnedValue, which is a potential ownership imbalance for transient owned values passed directly as arguments. |
| src/liblesma/Symbol/TypeUtils.cpp | Adds isArcReferenceType (class, array, ptr-to-class) and containsArcManagedValue (transitive ARC check for tuples/unions/functions/any). Correct and complete. |
| src/liblesma/Backend/CodegenImport.cpp | Propagates emitArcDebug/emitArcTrace to imported module codegens, wires pendingJitModuleFinis shared pointer, promotes imported module's fini function to external linkage for JIT. |
| tests/test.cpp | Adds 730 lines of ARC tests covering IR-level checks (retain/release intrinsic presence, destroy-function naming) and runtime tests with arc-debug mode verifying zero live-object count at program exit for closures, collections, generics, tuples, unions, optionals, and cross-module globals. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/liblesma/Backend/CodegenVisit.cpp`, line 1939-1945 ([link](https://github.com/alinalihassan/lesma/blob/358f16afac4e8e377a96fec601ca30a076a82339/src/liblesma/Backend/CodegenVisit.cpp#L1939-L1945)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Iterator object from `iter()` is never ARC-released after the loop**

   When the iterable is a class-based `Iterable<T>`, `iter()` is called here and the result is stored in `iteratorValue`. Because `iter()` returns a class instance, the caller receives a `+1` ARC reference (the returned object is arc-owned). After `bEnd` is reached — whether by normal exhaustion or `break` — there is no `emitArcReleaseNullable` or `registerArcOwnedSlot` call for `iteratorValue->getLlvmValue()`.

   This leaks the entire iterator allocation for every `for-in` loop over a class-based `Iterable`. The tests `arc_for_in_named_iterable_heap.les` and `arc_for_in_heap_payloads.les` exercise exactly this path and would expose the leak under LeakSanitizer.

   A straightforward fix is to allocate a tracked slot for the iterator so it is automatically released when the function scope ends:

   ```
   // After iteratorValue = callMethodByName(...):
   if (iteratorValue != nullptr &&
       TypeUtils::isArcReferenceType(iteratorValue->getType())) {
     llvm::AllocaInst* iterSlot =
         createAllocaInEntry(parentFct, builder->getPtrTy(), "for.iter.slot");
     emitEntryNullInit(iterSlot, builder->getPtrTy());
     builder->CreateStore(iteratorValue->getLlvmValue(), iterSlot);
     registerArcOwnedSlot(iterSlot, iteratorValue->getType(), false);
   }
   ```

   Alternatively, emit an explicit `emitArcReleaseNullable` in `bEnd` before popping the defer stack.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/liblesma/Backend/CodegenVisit.cpp
   Line: 1939-1945

   Comment:
   **Iterator object from `iter()` is never ARC-released after the loop**

   When the iterable is a class-based `Iterable<T>`, `iter()` is called here and the result is stored in `iteratorValue`. Because `iter()` returns a class instance, the caller receives a `+1` ARC reference (the returned object is arc-owned). After `bEnd` is reached — whether by normal exhaustion or `break` — there is no `emitArcReleaseNullable` or `registerArcOwnedSlot` call for `iteratorValue->getLlvmValue()`.

   This leaks the entire iterator allocation for every `for-in` loop over a class-based `Iterable`. The tests `arc_for_in_named_iterable_heap.les` and `arc_for_in_heap_payloads.les` exercise exactly this path and would expose the leak under LeakSanitizer.

   A straightforward fix is to allocate a tracked slot for the iterator so it is automatically released when the function scope ends:

   ```
   // After iteratorValue = callMethodByName(...):
   if (iteratorValue != nullptr &&
       TypeUtils::isArcReferenceType(iteratorValue->getType())) {
     llvm::AllocaInst* iterSlot =
         createAllocaInEntry(parentFct, builder->getPtrTy(), "for.iter.slot");
     emitEntryNullInit(iterSlot, builder->getPtrTy());
     builder->CreateStore(iteratorValue->getLlvmValue(), iterSlot);
     registerArcOwnedSlot(iterSlot, iteratorValue->getType(), false);
   }
   ```

   Alternatively, emit an explicit `emitArcReleaseNullable` in `bEnd` before popping the defer stack.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/liblesma/Backend/CodegenBuiltinIntrinsics.cpp
Line: 339-343

Comment:
**`push()` always retains without checking `arcOwnedValue`**

The push intrinsic retains `storedElement` unconditionally. This is correct for the common case where the argument was loaded from a caller slot (the slot release at scope-end cancels out). However, if a freshly-allocated value with `arcOwnedValue = true` is passed directly as an argument (e.g., `list.push(Box(1))`) without first being stored in a variable, the initial `+1` reference from the allocation has no corresponding slot in the caller's frame to release it:

1. `Box(1)` allocates: `refcount = 1`, `arcOwnedValue = true`, no slot registered.
2. `push()` retains: `refcount = 2`.
3. Caller scope ends: no slot to release → `refcount` stays at 2, but only the list holds 1 reference → **leak**.

The same issue exists in the `BufferSet` path (line ~361).

The real fix needs to happen in the caller: emit a release of the owned temporary **after** the intrinsic call returns, similar to how `Return` retains before releasing the slot frame. Alternatively, consider registering owned intermediate expression results in a temporary slot so the frame cleanup handles them automatically.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/liblesma/Backend/CodegenBufferHelpers.cpp
Line: 192-200

Comment:
**Non-atomic retain/release — documentation note**

`emitArcRetain` and `emitArcRelease` use plain `load`/`add`/`store` sequences without atomic memory ordering. For the current single-threaded Lesma runtime this is correct and intentional. If Lesma ever gains concurrent execution (threads, async tasks), the refcount operations would need to become `atomicrmw add`/`atomicrmw sub` with at least `monotonic` ordering (and `acquire`/`release` on the destroy path) to avoid data races.

A short comment near the refcount load/store would help future readers understand this is a deliberate trade-off:

```cpp
// Non-atomic: Lesma is single-threaded; upgrade to atomicrmw if concurrency is added.
auto* refCount = builder->CreateLoad(builder->getInt64Ty(), refSlot, "arc.retain.count");
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (7): Last reviewed commit: ["Fix"](https://github.com/alinalihassan/lesma/commit/00c895aad61063c12cd29fb4afdd294c3821d9ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27581383)</sub>

<!-- /greptile_comment -->